### PR TITLE
multi: check work against pool target.

### DIFF
--- a/network/message.go
+++ b/network/message.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 )
@@ -147,19 +148,29 @@ func WorkNotification(header string, target string) *Request {
 
 // ParseWorkNotification parses a work notification message.
 func ParseWorkNotification(req *Request) ([]byte, []byte, error) {
-	header, ok := req.Params["header"].(string)
+	headerEncoded, ok := req.Params["header"].(string)
 	if !ok {
 		return nil, nil, errors.New("Invalid work notification, 'params' data " +
 			"should have 'header' field")
 	}
 
-	target, ok := req.Params["target"].(string)
+	targetEncoded, ok := req.Params["target"].(string)
 	if !ok {
 		return nil, nil, errors.New("Invalid work notification, 'params' data " +
 			"should have 'target' field")
 	}
 
-	return []byte(header), []byte(target), nil
+	header, err := hex.DecodeString(headerEncoded)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	target, err := hex.DecodeString(targetEncoded)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return header, target, nil
 }
 
 // WorkSubmissionRequest is a convenience function for creating a work

--- a/poolclient/client.go
+++ b/poolclient/client.go
@@ -145,7 +145,6 @@ out:
 			req := msg.(*network.Request)
 			switch req.Method {
 			case network.Ping:
-				log.Debugf("ping received, responding")
 				pc.connMtx.Lock()
 				pc.Conn.WriteJSON(network.PongResponse(req.ID))
 				pc.connMtx.Unlock()

--- a/poolclient/cpuminer.go
+++ b/poolclient/cpuminer.go
@@ -153,21 +153,16 @@ out:
 		}
 
 		var sizedTarget [32]byte
-		decoded, err := network.DecodeHeader(m.c.work.header)
-		if err != nil {
-			log.Error(err)
-			m.c.workMtx.RUnlock()
-			return
-		}
-
+		header := make([]byte, len(m.c.work.header))
+		copy(header, m.c.work.header)
 		copy(sizedTarget[:], m.c.work.target)
 		target := network.LEUint256ToBig(sizedTarget)
 		m.c.workMtx.RUnlock()
 
-		if m.solveBlock(ctx, decoded, target, ticker) {
+		if m.solveBlock(ctx, header, target, ticker) {
 			id := m.c.nextID()
 			submission := network.WorkSubmissionRequest(id,
-				hex.EncodeToString(decoded))
+				hex.EncodeToString(header))
 
 			// Record the request.
 			m.c.recordRequest(*id, network.SubmitWork)


### PR DESCRIPTION
This ensures submitted work are truly less than than the pool target set for the client. It also fixes a target conversion bug by updating work notification parsing to decode the header and target.