### PR TITLE
multi: better account creation.

### DIFF
--- a/dividend/account.go
+++ b/dividend/account.go
@@ -7,7 +7,6 @@ package dividend
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
@@ -18,26 +17,23 @@ import (
 // Account represents an anonymous mining pool account.
 type Account struct {
 	UUID      string `json:"uuid"`
-	Name      string `json:"name"`
 	Address   string `json:"address"`
 	CreatedOn uint64 `json:"createdon"`
 }
 
-// AccountID forms a unique id for an account using the provided name
-// and address.
-func AccountID(name, address string) *string {
+// AccountID geenrates an id using provided address of the account.
+func AccountID(address string) *string {
 	hasher := blake256.New()
-	hasher.Write([]byte(fmt.Sprintf("%s.%s", address, name)))
+	hasher.Write([]byte(address))
 	id := hex.EncodeToString(hasher.Sum(nil))
 	return &id
 }
 
 // NewAccount generates a new account.
-func NewAccount(name string, address string) (*Account, error) {
-	id := AccountID(name, address)
+func NewAccount(address string) (*Account, error) {
+	id := AccountID(address)
 	account := &Account{
 		UUID:      *id,
-		Name:      name,
 		Address:   address,
 		CreatedOn: uint64(time.Now().Unix()),
 	}

--- a/dividend/payment.go
+++ b/dividend/payment.go
@@ -575,7 +575,7 @@ func FetchArchivedPaymentsForAccount(db *bolt.DB, account []byte, minNano []byte
 			accountE := k[16:]
 			minNanoE := k[:16]
 			minNanoB := make([]byte, hex.DecodedLen(len(minNanoE)))
-			hex.Decode(minNano, minNanoE)
+			hex.Decode(minNanoB, minNanoE)
 			if bytes.Equal(accountE, account) &&
 				bytes.Compare(minNanoB, minNano) > 0 {
 				var payment Payment

--- a/dividend/payment_test.go
+++ b/dividend/payment_test.go
@@ -19,8 +19,8 @@ import (
 
 // createPersistedAccount creates a pool account with the provided parameters
 // and persists it to the database.
-func createPersistedAccount(db *bolt.DB, name string, address string) error {
-	account, err := NewAccount(name, address)
+func createPersistedAccount(db *bolt.DB, address string) error {
+	account, err := NewAccount(address)
 	if err != nil {
 		return err
 	}

--- a/dividend/share_test.go
+++ b/dividend/share_test.go
@@ -20,18 +20,14 @@ import (
 var (
 	// TestDB represents the testing database.
 	testDB = "testdb"
-	// Account X.
-	accX = "x"
 	// Account X address.
 	xAddr = "SsWKp7wtdTZYabYFYSc9cnxhwFEjA5g4pFc"
 	// Account X id.
-	xID = *AccountID(accX, xAddr)
-	// Account Y.
-	accY = "y"
+	xID = *AccountID(xAddr)
 	// Account Y address.
 	yAddr = "Ssp7J7TUmi5iPhoQnWYNGQbeGhu6V3otJcS"
 	// Account Y id.
-	yID = *AccountID(accY, yAddr)
+	yID = *AccountID(yAddr)
 	// Pool fee address.
 	poolFeeAddrs, _ = dcrutil.DecodeAddress("SsnbEmxCVXskgTHXvf3rEa17NA39qQuGHwQ")
 )
@@ -55,12 +51,12 @@ func setupDB() (*bolt.DB, error) {
 		return nil, err
 	}
 
-	err = createPersistedAccount(db, accX, xAddr)
+	err = createPersistedAccount(db, xAddr)
 	if err != nil {
 		return nil, err
 	}
 
-	err = createPersistedAccount(db, accY, yAddr)
+	err = createPersistedAccount(db, yAddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This update account creation to use only the address to send mining rewards to for the
account.  This is more efficient compared to creating an account using the address and miner id.

This also betters hash rate formatting and fixes a bug with `FetchArchivedPaymentsForAccount`.