### PR TITLE
network: fix accepted work confirmation.

### DIFF
--- a/network/acceptedwork.go
+++ b/network/acceptedwork.go
@@ -5,11 +5,11 @@
 package network
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/decred/dcrpool/database"
@@ -35,6 +35,7 @@ type AcceptedWork struct {
 	Height    uint32 `json:"height"`
 	MinedBy   string `json:"minedby"`
 	Miner     string `json:"miner"`
+	CreatedOn int64  `json:"createdon"`
 
 	// An accepted work becomes mined work once it is confirmed by an incoming
 	// work as the parent block it was built on.
@@ -58,6 +59,7 @@ func NewAcceptedWork(blockHash string, prevHash string, height uint32, minedBy s
 		Height:    height,
 		MinedBy:   minedBy,
 		Miner:     miner,
+		CreatedOn: time.Now().Unix(),
 	}
 }
 
@@ -222,68 +224,6 @@ func ListMinedWorkByAccount(db *bolt.DB, accountID string) ([]*AcceptedWork, err
 	}
 
 	return minedWork, nil
-}
-
-// FilterParentAcceptedWork locates the accepted work associated with the
-// previous block hash of the provided accepted work. It also removes all
-// invalidated accepted work at the same height.
-func (work *AcceptedWork) FilterParentAcceptedWork(db *bolt.DB) (*AcceptedWork, error) {
-	var prevWork AcceptedWork
-	err := db.Update(func(tx *bolt.Tx) error {
-		pbkt := tx.Bucket(database.PoolBkt)
-		if pbkt == nil {
-			return database.ErrBucketNotFound(database.PoolBkt)
-		}
-		bkt := pbkt.Bucket(database.WorkBkt)
-		if bkt == nil {
-			return database.ErrBucketNotFound(database.WorkBkt)
-		}
-
-		heightB := util.HeightToBigEndianBytes(work.Height - 1)
-		prefix := make([]byte, hex.EncodedLen(len(heightB)))
-		hex.Encode(prefix, heightB)
-
-		toDelete := [][]byte{}
-		match := false
-		prevHashB := []byte(work.PrevHash)
-		cursor := bkt.Cursor()
-		for k, v := cursor.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = cursor.Next() {
-			parentWork := k[len(prefix):]
-			if !match {
-				if bytes.Equal(parentWork, prevHashB) {
-					err := json.Unmarshal(v, &prevWork)
-					if err != nil {
-						return err
-					}
-					match = true
-					continue
-				}
-			}
-
-			if match {
-				toDelete = append(toDelete, k)
-			}
-		}
-
-		for _, entry := range toDelete {
-			err := bkt.Delete(entry)
-			if err != nil {
-				return err
-			}
-		}
-
-		if !match {
-			return fmt.Errorf("no accepted work found for: %v", work.PrevHash)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &prevWork, nil
 }
 
 // PruneAcceptedWork removes all accepted work not confirmed as mined work with

--- a/network/hub.go
+++ b/network/hub.go
@@ -654,7 +654,7 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 			var header wire.BlockHeader
 			err := header.FromBytes(headerB)
 			if err != nil {
-				log.Errorf("Failed to create header from bytes: %v", err)
+				log.Errorf("unable to create header from bytes: %v", err)
 				h.cancel()
 				continue
 			}
@@ -664,7 +664,7 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 				pruneLimit := header.Height - MaxReorgLimit
 				err := PruneJobs(h.db, pruneLimit)
 				if err != nil {
-					log.Errorf("Failed to prune jobs to height %d: %v",
+					log.Errorf("unable to prune jobs to height %d: %v",
 						pruneLimit, err)
 					h.cancel()
 					continue
@@ -673,17 +673,34 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 				log.Tracef("Pruned jobs below height: %v", pruneLimit)
 			}
 
-			blockHash := header.BlockHash()
-			id := AcceptedWorkID(blockHash.String(), header.Height)
-			work, err := FetchAcceptedWork(h.db, id)
+			// If the parent of the connected block is an accepted work of the
+			// pool, confirmed it as mined. The parent of a connected block
+			// at this point is guaranteed to have its corresponding accepted
+			// work persisted if it was mined by the pool.
+			parentID := AcceptedWorkID(header.PrevBlock.String(),
+				header.Height-1)
+			work, err := FetchAcceptedWork(h.db, parentID)
 			if err != nil {
-				log.Errorf("Failed to fetch accepted work: %v", err)
+				log.Errorf(
+					"unable to fetch accepted work for block #%v's parent"+
+						" (%v) : %v", header.Height,
+					header.PrevBlock.String(), err)
 				continue
 			}
 
-			prevWork, err := work.FilterParentAcceptedWork(h.db)
+			if work == nil {
+				log.Tracef("No mined work found for block #%v's parent (%v)",
+					header.Height, header.PrevBlock.String())
+				continue
+			}
+
+			// Update accepted work as confirmed mined.
+			work.Confirmed = true
+			err = work.Update(h.db)
 			if err != nil {
-				log.Errorf("Failed to filter parent accepted work: %v", err)
+				log.Errorf("unable to confirm accepted work for block"+
+					"(%v): %v", header.PrevBlock.String(), err)
+				h.cancel()
 				continue
 			}
 
@@ -692,8 +709,8 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 				pruneLimit := header.Height - MaxReorgLimit
 				err = PruneAcceptedWork(h.db, pruneLimit)
 				if err != nil {
-					log.Errorf("Failed to prune accepted work below height (%v)"+
-						": %v", pruneLimit, err)
+					log.Errorf("unable to prune accepted work below"+
+						" height (%v): %v", pruneLimit, err)
 					h.cancel()
 					continue
 				}
@@ -701,31 +718,19 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 				log.Tracef("Pruned accepted work below height: %v", pruneLimit)
 			}
 
-			if prevWork == nil {
-				log.Tracef("No mined work found")
-				continue
-			}
+			log.Tracef("Found mined parent (%v) for connected block (%v)",
+				header.PrevBlock.String(), header.BlockHash().String())
 
-			log.Tracef("Found mined parent %v for work %v",
-				prevWork.BlockHash, header.BlockHash().String())
-
-			// Update accepted work as confirmed mined.
-			prevWork.Confirmed = true
-			err = prevWork.Update(h.db)
-			if err != nil {
-				log.Errorf("Failed to confirm accepted work: %v", err)
-				h.cancel()
-				continue
-			}
-
-			// Only process shares and payments when not mining in solo
-			// pool mode.
+			// Fetch the coinbase of the the confirmed accepted work
+			// (the parent of the connected block) and process payments
+			//  when not mining in solo pool mode.
 			if !h.cfg.SoloPool {
 				h.rpccMtx.Lock()
-				block, err := h.rpcc.GetBlock(&blockHash)
+				block, err := h.rpcc.GetBlock(&header.PrevBlock)
 				h.rpccMtx.Unlock()
 				if err != nil {
-					log.Errorf("Failed to fetch block: %v", err)
+					log.Errorf("unable to fetch block (%v): %v",
+						header.PrevBlock.String(), err)
 					h.cancel()
 					continue
 				}
@@ -734,7 +739,8 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 					dcrutil.Amount(block.Transactions[0].TxOut[2].Value)
 
 				log.Tracef("Accepted work (%v) at height %v has coinbase"+
-					" of %v", header.BlockHash(), header.Height, coinbase)
+					" of %v", header.PrevBlock.String(), header.Height-1,
+					coinbase)
 
 				// Pay dividends per the configured payment scheme and process
 				// mature payments.
@@ -743,7 +749,7 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 					err := dividend.PayPerShare(h.db, coinbase, h.cfg.PoolFee,
 						header.Height, h.cfg.ActiveNet.CoinbaseMaturity)
 					if err != nil {
-						log.Error("Failed to process generate PPS shares: %v", err)
+						log.Error("unable to process generate PPS shares: %v", err)
 						h.cancel()
 						continue
 					}
@@ -753,7 +759,7 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 						h.cfg.PoolFee, header.Height,
 						h.cfg.ActiveNet.CoinbaseMaturity, h.cfg.LastNPeriod)
 					if err != nil {
-						log.Errorf("Failed to generate PPLNS shares: %v", err)
+						log.Errorf("unable to generate PPLNS shares: %v", err)
 						h.cancel()
 						continue
 					}
@@ -762,7 +768,7 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 				// Process mature payments.
 				err = h.ProcessPayments(header.Height)
 				if err != nil {
-					log.Errorf("Failed to process payments: %v", err)
+					log.Errorf("unable to process payments: %v", err)
 				}
 			}
 
@@ -770,23 +776,25 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 			var header wire.BlockHeader
 			err := header.FromBytes(headerB)
 			if err != nil {
-				log.Errorf("Failed to create header from bytes: %v", err)
+				log.Errorf("unable to create header from bytes: %v", err)
 				h.cancel()
 				continue
 			}
 			log.Tracef("Block disconnected at height %v", header.Height)
 
-			// Delete mined work if it is disconnected from the chain.
+			// Delete mined work if it is disconnected from the chain. At this
+			// point a mined confirmed block will have its corresponding
+			// accepted block record persisted.
 			id := AcceptedWorkID(header.BlockHash().String(), header.Height)
 			work, err := FetchAcceptedWork(h.db, id)
 			if err != nil {
-				log.Errorf("Failed to fetch mined work: %v", err)
+				log.Errorf("unable to fetch mined work: %v", err)
 				continue
 			}
 
 			err = work.Delete(h.db)
 			if err != nil {
-				log.Errorf("Failed to delete mined work: %v", err)
+				log.Errorf("unable to delete mined work: %v", err)
 				h.cancel()
 				continue
 			}
@@ -807,7 +815,7 @@ func (h *Hub) handleChainUpdates(ctx context.Context) {
 				for _, pmt := range payments {
 					err = pmt.Delete(h.db)
 					if err != nil {
-						log.Errorf("Failed to delete payment", err)
+						log.Errorf("unable to delete pending payment", err)
 						h.cancel()
 						break
 					}


### PR DESCRIPTION
This fixes the accepted work confirmation bug by fetching the parent accepted work of the connected
block instead of fetching the accepted work of the connected block first. This is being done because
it is possible for the accepted work of the connected block to be unavailable at the time its
corresponding block connected notification is received. It's also more efficient to directly fetch
the parent accepted work since that's ultimately the accepted work being confirmed.

Fixes #74.