### PR TITLE
gui: show connected miners

### DIFF
--- a/dividend/payment.go
+++ b/dividend/payment.go
@@ -555,10 +555,10 @@ func GeneratePaymentDetails(db *bolt.DB, poolFeeAddrs []dcrutil.Address, eligibl
 	return pmts, &targetAmt, nil
 }
 
-// FetchArchivedPaymentsForAccount fetches archived payments for the provided
-// account.
+// FetchArchivedPaymentsForAccount fetches the N most recent archived payments
+// for the provided account.
 // List is ordered, most recent comes first.
-func FetchArchivedPaymentsForAccount(db *bolt.DB, account string) ([]*Payment, error) {
+func FetchArchivedPaymentsForAccount(db *bolt.DB, account string, n int) ([]*Payment, error) {
 	pmts := make([]*Payment, 0)
 	err := db.View(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(database.PoolBkt)
@@ -585,14 +585,15 @@ func FetchArchivedPaymentsForAccount(db *bolt.DB, account string) ([]*Payment, e
 				}
 
 				pmts = append(pmts, &payment)
+
+				if len(pmts) == n {
+					return nil
+				}
 			}
 		}
 
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return pmts, nil
+	return pmts, err
 }

--- a/dividend/payment.go
+++ b/dividend/payment.go
@@ -557,6 +557,7 @@ func GeneratePaymentDetails(db *bolt.DB, poolFeeAddrs []dcrutil.Address, eligibl
 
 // FetchArchivedPaymentsForAccount fetches archived payments for the provided
 // account.
+// List is ordered, most recent comes first.
 func FetchArchivedPaymentsForAccount(db *bolt.DB, account string) ([]*Payment, error) {
 	pmts := make([]*Payment, 0)
 	err := db.View(func(tx *bolt.Tx) error {
@@ -571,7 +572,7 @@ func FetchArchivedPaymentsForAccount(db *bolt.DB, account string) ([]*Payment, e
 
 		c := abkt.Cursor()
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
+		for k, v := c.Last(); k != nil; k, v = c.Prev() {
 			accountE := k[16:]
 			minNanoE := k[:16]
 			minNanoB := make([]byte, hex.DecodedLen(len(minNanoE)))

--- a/dividend/payment.go
+++ b/dividend/payment.go
@@ -556,8 +556,8 @@ func GeneratePaymentDetails(db *bolt.DB, poolFeeAddrs []dcrutil.Address, eligibl
 }
 
 // FetchArchivedPaymentsForAccount fetches archived payments for the provided
-// account that were created before the provided timestamp.
-func FetchArchivedPaymentsForAccount(db *bolt.DB, account []byte, minNano []byte) ([]*Payment, error) {
+// account.
+func FetchArchivedPaymentsForAccount(db *bolt.DB, account string) ([]*Payment, error) {
 	pmts := make([]*Payment, 0)
 	err := db.View(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(database.PoolBkt)
@@ -576,8 +576,7 @@ func FetchArchivedPaymentsForAccount(db *bolt.DB, account []byte, minNano []byte
 			minNanoE := k[:16]
 			minNanoB := make([]byte, hex.DecodedLen(len(minNanoE)))
 			hex.Decode(minNanoB, minNanoE)
-			if bytes.Equal(accountE, account) &&
-				bytes.Compare(minNanoB, minNano) > 0 {
+			if bytes.Equal(accountE, []byte(account)) {
 				var payment Payment
 				err := json.Unmarshal(v, &payment)
 				if err != nil {

--- a/dividend/payment.go
+++ b/dividend/payment.go
@@ -558,8 +558,12 @@ func GeneratePaymentDetails(db *bolt.DB, poolFeeAddrs []dcrutil.Address, eligibl
 // FetchArchivedPaymentsForAccount fetches the N most recent archived payments
 // for the provided account.
 // List is ordered, most recent comes first.
-func FetchArchivedPaymentsForAccount(db *bolt.DB, account string, n int) ([]*Payment, error) {
+func FetchArchivedPaymentsForAccount(db *bolt.DB, account string, n uint) ([]*Payment, error) {
 	pmts := make([]*Payment, 0)
+	if n == 0 {
+		return pmts, nil
+	}
+
 	err := db.View(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(database.PoolBkt)
 		if pbkt == nil {
@@ -586,7 +590,7 @@ func FetchArchivedPaymentsForAccount(db *bolt.DB, account string, n int) ([]*Pay
 
 				pmts = append(pmts, &payment)
 
-				if len(pmts) == n {
+				if len(pmts) == int(n) {
 					return nil
 				}
 			}

--- a/dividend/payment.go
+++ b/dividend/payment.go
@@ -599,5 +599,9 @@ func FetchArchivedPaymentsForAccount(db *bolt.DB, account string, n uint) ([]*Pa
 		return nil
 	})
 
-	return pmts, err
+	if err != nil {
+		return nil, err
+	}
+
+	return pmts, nil
 }

--- a/dividend/payment_test.go
+++ b/dividend/payment_test.go
@@ -525,10 +525,6 @@ func TestArchivedPaymentsFiltering(t *testing.T) {
 	bx.UpdateAsPaid(db, 10)
 	bx.ArchivePayments(db)
 
-	now := time.Now()
-	minNano := now.Add(time.Second * 3).UnixNano()
-	minBytes := util.NanoToBigEndianBytes(minNano)
-
 	time.Sleep(time.Second * 10)
 
 	bx = CreatePaymentBundle(yID, count, amt)
@@ -536,7 +532,7 @@ func TestArchivedPaymentsFiltering(t *testing.T) {
 	bx.ArchivePayments(db)
 
 	// Fetch archived payments for account x.
-	pmts, err := FetchArchivedPaymentsForAccount(db, []byte(xID), minBytes)
+	pmts, err := FetchArchivedPaymentsForAccount(db, xID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -548,7 +544,7 @@ func TestArchivedPaymentsFiltering(t *testing.T) {
 	}
 
 	// Fetch archived payments for account y.
-	pmts, err = FetchArchivedPaymentsForAccount(db, []byte(yID), minBytes)
+	pmts, err = FetchArchivedPaymentsForAccount(db, yID)
 	if err != nil {
 		t.Error(err)
 	}

--- a/dividend/payment_test.go
+++ b/dividend/payment_test.go
@@ -532,7 +532,7 @@ func TestArchivedPaymentsFiltering(t *testing.T) {
 	bx.ArchivePayments(db)
 
 	// Fetch archived payments for account x.
-	pmts, err := FetchArchivedPaymentsForAccount(db, xID)
+	pmts, err := FetchArchivedPaymentsForAccount(db, xID, 10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -544,7 +544,7 @@ func TestArchivedPaymentsFiltering(t *testing.T) {
 	}
 
 	// Fetch archived payments for account y.
-	pmts, err = FetchArchivedPaymentsForAccount(db, yID)
+	pmts, err = FetchArchivedPaymentsForAccount(db, yID, 10)
 	if err != nil {
 		t.Error(err)
 	}

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -11,7 +11,7 @@ import (
 )
 
 type adminPageData struct {
-	Connections []network.Connection
+	Connections map[string][]*network.ClientInfo
 	WorkQuotas  *network.WorkQuotas
 	Admin       bool
 	CSRF        template.HTML
@@ -35,7 +35,7 @@ func (ui *GUI) GetAdmin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ui.renderTemplate(w, r, "admin", adminPageData{
-		Connections: ui.hub.FetchConnections(),
+		Connections: ui.hub.FetchClientInfo(),
 		WorkQuotas:  workQuotas,
 		Admin:       true,
 		CSRF:        csrf.TemplateField(r),

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
+	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrpool/database"
 	"github.com/decred/dcrpool/network"
 	"github.com/decred/dcrpool/util"
@@ -32,6 +33,7 @@ type Config struct {
 	GUIPort     uint32
 	TLSCertFile string
 	TLSKeyFile  string
+	ActiveNet   *chaincfg.Params
 }
 
 // GUI represents the the mining pool user interface.

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/decred/dcrpool/database"
 	"github.com/decred/dcrpool/network"
+	"github.com/decred/dcrpool/util"
 )
 
 // Config represents configuration details for the pool user interface.
@@ -154,10 +155,14 @@ func (ui *GUI) loadTemplates() error {
 		return err
 	}
 
+	httpTemplates := template.New("template").Funcs(template.FuncMap{
+		"hashString": util.HashString,
+	})
+
 	// Since template.Must panics with non-nil error, it is much more
 	// informative to pass the error to the caller to log it and exit
 	// gracefully.
-	httpTemplates, err := template.ParseFiles(templates...)
+	httpTemplates, err = httpTemplates.ParseFiles(templates...)
 	if err != nil {
 		return err
 	}

--- a/gui/index.go
+++ b/gui/index.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"reflect"
 
 	"github.com/decred/dcrpool/dividend"
 	"github.com/decred/dcrpool/network"
@@ -92,10 +91,6 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// // Reverse for display purposes. We want the most recent block/payments to be first.
-	reverseSlice(work)
-	reverseSlice(payments)
-
 	data.AccountStats = &AccountStats{
 		MinedWork: work,
 		Payments:  payments,
@@ -103,12 +98,4 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ui.renderTemplate(w, r, "index", data)
-}
-
-func reverseSlice(s interface{}) {
-	size := reflect.ValueOf(s).Len()
-	swap := reflect.Swapper(s)
-	for i, j := 0, size-1; i < j; i, j = i+1, j-1 {
-		swap(i, j)
-	}
 }

--- a/gui/templates/admin.html
+++ b/gui/templates/admin.html
@@ -9,6 +9,7 @@
             <form action="/backup" method="post">
                 <h4>Database Backup</h4>
                 {{.CSRF}}
+                <p>Click this button to download a snapshot of the dcrpool database.</p>
                 <button type="submit" class="btn btn-primary">Download Backup</button>
             </form>
         </div>  
@@ -17,7 +18,7 @@
     <div class="row">
 
         <div class="m-3 p-3 overflow-hidden">
-            <h4>Work Quotas ({{.WorkQuotas.Type}})</h4>
+            <h4>Work Quotas ({{.WorkQuotas.PaymentScheme}})</h4>
             <div style="overflow: auto; max-height: 250px;">
                 <table class="table table-striped">
                     <tr>
@@ -26,7 +27,7 @@
                     </tr>
                     {{ range .WorkQuotas.Quotas }}
                         <tr>
-                            <td>{{.User}}</td>
+                            <td>{{.AccountID}}</td>
                             <td>{{.Percentage}}</td>
                         </tr>
                     {{else}}
@@ -43,16 +44,20 @@
             <div style="overflow: auto; max-height: 250px;">
                 <table class="table table-striped">
                     <tr>
+                        <th>Account</th>
                         <th>IP</th>
-                        <th>Port</th>
                         <th>Miner</th>
+                        <th>Hash Rate</th>
                     </tr>
-                    {{ range .Connections }}
-                        <tr>
-                            <td>{{.IP}}</td>
-                            <td>{{.Port}}</td>
-                            <td>{{.Miner}}</td>
-                        </tr>
+                    {{range $accountID, $clients := .Connections}}
+                        {{range $client := $clients}}
+                            <tr>
+                                <td>{{$accountID}}</td>
+                                <td>{{$client.IP}}</td>	                                
+                                <td>{{$client.Miner}}</td>
+                                <td>{{hashString $client.HashRate}}</td>
+                            </tr>
+                        {{end}}
                     {{else}}
                         <tr>
                             <td colspan="100%">No Connections</td>

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -43,7 +43,7 @@
             {{end}}
         </div>
 
-        <h3>Blocks Mined by this Pool ({{len .PoolStats.MinedWork}} total)</h3>
+        <h3>Blocks Mined by this Pool</h3>
         <div style="overflow: auto; max-height: 400px;">
             <table class="table table-striped">
                 <tr>
@@ -94,7 +94,7 @@
                 </div>
 
             <div class="p-3">
-                <h3>Blocks Mined by this Account ({{len .AccountStats.MinedWork}} total)</h3>
+                <h3>Blocks Mined by this Account</h3>
                 <div style="overflow: auto; max-height: 250px;">
                     <table class="table table-striped">
                         <tr>
@@ -118,7 +118,7 @@
             </div>
 
             <div class="p-3">
-                <h3>Payments made to this Account ({{len .AccountStats.Payments}} total)</h3>
+                <h3>Payments made to this Account</h3>
                 <div style="overflow: auto; max-height: 250px;">
                     <table class="table table-striped">
                         <tr>

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -14,7 +14,8 @@
             <p>Enter your address to see your mining stats.</p>
             <div class="form-group">
                 <label>Address:</label>
-                <input type="text" name="address" class="form-control" placeholder="Enter address">
+                <input type="text" name="address" class="form-control" placeholder="Enter address"
+                    value="{{if .Address}}{{if not .AccountStats}}{{.Address}}{{end}}{{end}}">
             </div>
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -48,7 +48,7 @@
                     <th>Miner</th>
                     <th>MinedBy</th>
                 </tr>
-                {{ range .MinedWork }}
+                {{ range .PoolStats.MinedWork }}
                 <tr>
                     <td>{{.Height}}</td>
                     <td>{{.Confirmed}}</td>
@@ -97,7 +97,6 @@
                 <div style="overflow: auto; max-height: 250px;">
                     <table class="table table-striped">
                         <tr>
-                            <th>Account</th>
                             <th>EstimatedMaturity</th>
                             <th>Height</th>
                             <th>Amount</th>
@@ -106,7 +105,6 @@
                         </tr>
                         {{ range .AccountStats.Payments }}
                         <tr>
-                            <td>{{.Account}}</td>
                             <td>{{.EstimatedMaturity}}</td>
                             <td>{{.Height}}</td>
                             <td>{{.Amount}}</td>

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -3,13 +3,13 @@
 
 <div class="row justify-content-center">
 
+    <div class="col p-3 col-s-12 col-md-4">
         {{ with .Error }}
             <div style="background-color:black;color:red;font-weight:bold;">
                 {{.}}
             </div>
         {{end}}
 
-        <div class="col p-3 col-s-12 col-md-4">
         <form style="min-width:300px;" action="" method="get">
             <p>Enter your address to see your mining stats.</p>
             <div class="form-group">

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -1,11 +1,15 @@
 {{define "index"}}
 {{template "header" .}}
 
-
-
 <div class="row justify-content-center">
 
-    <div class="col p-3 col-s-12 col-md-4">
+        {{ with .Error }}
+            <div style="background-color:black;color:red;font-weight:bold;">
+                {{.}}
+            </div>
+        {{end}}
+
+        <div class="col p-3 col-s-12 col-md-4">
         <form style="min-width:300px;" action="" method="get">
             <p>Enter your address to see your mining stats.</p>
             <div class="form-group">
@@ -21,7 +25,7 @@
         {{ if not .AccountStats }}
         <div class="row justify-content-center">
             <div class="row px-2 m-2 overflow-hidden">
-                <p><span class="font-weight-bold">Pool Hash Rate:&nbsp;</span>{{.HashRate}}</p>
+                <p><span class="font-weight-bold">Pool Hash Rate:&nbsp;</span>{{hashString .PoolHashRate}}</p>
                 <p></p>
             </div>
 
@@ -39,7 +43,7 @@
             {{end}}
         </div>
 
-        <p class="font-weight-bold">Blocks Mined by this Pool</p>
+        <h3>Blocks Mined by this Pool ({{len .PoolStats.MinedWork}} total)</h3>
         <div style="overflow: auto; max-height: 400px;">
             <table class="table table-striped">
                 <tr>
@@ -66,10 +70,31 @@
 
         <div class="col">
             <p><span class="font-weight-bold">Address:&nbsp;</span>{{.Address}}</p>
-            <p><span class="font-weight-bold">Account ID:&nbsp;</span>{{.AccountStats.AccountID}}</p>
 
             <div class="p-3">
-                <p class="font-weight-bold">Blocks Mined by this Account</p>
+                    <h3>Connected Clients</h3>
+                    <div style="overflow: auto; max-height: 250px;">
+                        <table class="table table-striped">
+                            <tr>
+                                <th>Miner</th>
+                                <th>Hash Rate</th>
+                            </tr>
+                            {{ range .AccountStats.Clients }}
+                                <tr>
+                                    <td>{{.Miner}}</td>
+                                    <td>{{hashString .HashRate}}</td>
+                                </tr>
+                            {{else}}
+                                <tr>
+                                    <td colspan="100%">No connected clients</td>
+                                </tr>
+                            {{end}}
+                        </table>
+                    </div>
+                </div>
+
+            <div class="p-3">
+                <h3>Blocks Mined by this Account ({{len .AccountStats.MinedWork}} total)</h3>
                 <div style="overflow: auto; max-height: 250px;">
                     <table class="table table-striped">
                         <tr>
@@ -93,7 +118,7 @@
             </div>
 
             <div class="p-3">
-                <p class="font-weight-bold">Payments made to this Account</p>
+                <h3>Payments made to this Account ({{len .AccountStats.Payments}} total)</h3>
                 <div style="overflow: auto; max-height: 250px;">
                     <table class="table table-striped">
                         <tr>

--- a/network/acceptedwork.go
+++ b/network/acceptedwork.go
@@ -155,8 +155,12 @@ func (work *AcceptedWork) Delete(db *bolt.DB) error {
 // ListMinedWork returns the N most recent work data associated
 // with blocks mined by the pool.
 // List is ordered, most recent comes first.
-func ListMinedWork(db *bolt.DB, n int) ([]*AcceptedWork, error) {
+func ListMinedWork(db *bolt.DB, n uint) ([]*AcceptedWork, error) {
 	minedWork := make([]*AcceptedWork, 0)
+	if n == 0 {
+		return minedWork, nil
+	}
+
 	err := db.Update(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(database.PoolBkt)
 		if pbkt == nil {
@@ -178,7 +182,7 @@ func ListMinedWork(db *bolt.DB, n int) ([]*AcceptedWork, error) {
 
 			if work.Confirmed {
 				minedWork = append(minedWork, &work)
-				if len(minedWork) == n {
+				if len(minedWork) == int(n) {
 					return nil
 				}
 			}
@@ -193,8 +197,12 @@ func ListMinedWork(db *bolt.DB, n int) ([]*AcceptedWork, error) {
 // ListMinedWorkByAccount returns the N most recent mined work data on
 // blocks mined by the provided pool account id.
 // List is ordered, most recent comes first.
-func ListMinedWorkByAccount(db *bolt.DB, accountID string, n int) ([]*AcceptedWork, error) {
+func ListMinedWorkByAccount(db *bolt.DB, accountID string, n uint) ([]*AcceptedWork, error) {
 	minedWork := make([]*AcceptedWork, 0)
+	if n == 0 {
+		return minedWork, nil
+	}
+
 	err := db.Update(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(database.PoolBkt)
 		if pbkt == nil {
@@ -216,7 +224,7 @@ func ListMinedWorkByAccount(db *bolt.DB, accountID string, n int) ([]*AcceptedWo
 
 			if strings.Compare(work.MinedBy, accountID) == 0 {
 				minedWork = append(minedWork, &work)
-				if len(minedWork) == n {
+				if len(minedWork) == int(n) {
 					return nil
 				}
 			}

--- a/network/acceptedwork.go
+++ b/network/acceptedwork.go
@@ -188,6 +188,7 @@ func ListMinedWork(db *bolt.DB) ([]*AcceptedWork, error) {
 
 // ListMinedWorkByAccount returns all mined work data on blocks mined by the
 // provided pool account id.
+// List is ordered, most recent comes first.
 func ListMinedWorkByAccount(db *bolt.DB, accountID string) ([]*AcceptedWork, error) {
 	minedWork := make([]*AcceptedWork, 0)
 	err := db.Update(func(tx *bolt.Tx) error {
@@ -202,7 +203,7 @@ func ListMinedWorkByAccount(db *bolt.DB, accountID string) ([]*AcceptedWork, err
 		}
 
 		cursor := bkt.Cursor()
-		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+		for k, v := cursor.Last(); k != nil; k, v = cursor.Prev() {
 			var work AcceptedWork
 			err := json.Unmarshal(v, &work)
 			if err != nil {

--- a/network/acceptedwork.go
+++ b/network/acceptedwork.go
@@ -191,7 +191,11 @@ func ListMinedWork(db *bolt.DB, n uint) ([]*AcceptedWork, error) {
 		return nil
 	})
 
-	return minedWork, err
+	if err != nil {
+		return nil, err
+	}
+
+	return minedWork, nil
 }
 
 // ListMinedWorkByAccount returns the N most recent mined work data on
@@ -233,7 +237,11 @@ func ListMinedWorkByAccount(db *bolt.DB, accountID string, n uint) ([]*AcceptedW
 		return nil
 	})
 
-	return minedWork, err
+	if err != nil {
+		return nil, err
+	}
+
+	return minedWork, nil
 }
 
 // PruneAcceptedWork removes all accepted work not confirmed as mined work with

--- a/network/acceptedwork.go
+++ b/network/acceptedwork.go
@@ -154,9 +154,8 @@ func (work *AcceptedWork) Delete(db *bolt.DB) error {
 
 // ListMinedWork returns work data associated with blocks mined by
 // the pool.
-func ListMinedWork(db *bolt.DB, truncate bool) ([]*AcceptedWork, error) {
+func ListMinedWork(db *bolt.DB) ([]*AcceptedWork, error) {
 	minedWork := make([]*AcceptedWork, 0)
-	truncatedSize := 5
 	err := db.Update(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(database.PoolBkt)
 		if pbkt == nil {
@@ -178,20 +177,13 @@ func ListMinedWork(db *bolt.DB, truncate bool) ([]*AcceptedWork, error) {
 
 			if work.Confirmed {
 				minedWork = append(minedWork, &work)
-
-				if truncate && len(minedWork) == truncatedSize {
-					return nil
-				}
 			}
 		}
 
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return minedWork, nil
+	return minedWork, err
 }
 
 // ListMinedWorkByAccount returns all mined work data on blocks mined by the

--- a/network/hub.go
+++ b/network/hub.go
@@ -980,7 +980,7 @@ func (h *Hub) FetchPoolStats() (*PoolStats, error) {
 		poolStats.LastPaymentHeight = atomic.LoadUint32(&h.lastPaymentHeight)
 	}
 
-	work, err := ListMinedWork(h.db)
+	work, err := ListMinedWork(h.db, 10)
 	poolStats.MinedWork = work
 
 	return poolStats, err
@@ -993,7 +993,7 @@ type Quota struct {
 	Percentage *big.Rat
 }
 
-// WorkQuota details the how mining rewards are to be distributed to
+// WorkQuotas details the how mining rewards are to be distributed to
 // participating accounts when a block is found, per the payment scheme.
 type WorkQuotas struct {
 	PaymentScheme string
@@ -1044,13 +1044,13 @@ func (h *Hub) FetchWorkQuotas() (*WorkQuotas, error) {
 // FetchMinedWorkByAddress returns a list of mined work by the provided address.
 // List is ordered, most recent comes first.
 func (h *Hub) FetchMinedWorkByAddress(id string) ([]*AcceptedWork, error) {
-	work, err := ListMinedWorkByAccount(h.db, id)
+	work, err := ListMinedWorkByAccount(h.db, id, 10)
 	return work, err
 }
 
 // FetchPaymentsForAddress returns a list or payments made to the provided address.
 // List is ordered, most recent comes first.
 func (h *Hub) FetchPaymentsForAddress(id string) ([]*dividend.Payment, error) {
-	payments, err := dividend.FetchArchivedPaymentsForAccount(h.db, id)
+	payments, err := dividend.FetchArchivedPaymentsForAccount(h.db, id, 10)
 	return payments, err
 }

--- a/network/hub.go
+++ b/network/hub.go
@@ -944,7 +944,7 @@ type ClientInfo struct {
 
 // FetchClientInfo returns information about all connected clients
 func (h *Hub) FetchClientInfo() map[string][]*ClientInfo {
-	clientInfo := make(map[string][]*ClientInfo, 0)
+	clientInfo := make(map[string][]*ClientInfo)
 
 	// Iterate through all connected miners
 	for _, endpoint := range h.endpoints {

--- a/network/hub.go
+++ b/network/hub.go
@@ -1042,12 +1042,14 @@ func (h *Hub) FetchWorkQuotas() (*WorkQuotas, error) {
 }
 
 // FetchMinedWorkByAddress returns a list of mined work by the provided address.
+// List is ordered, most recent comes first.
 func (h *Hub) FetchMinedWorkByAddress(id string) ([]*AcceptedWork, error) {
 	work, err := ListMinedWorkByAccount(h.db, id)
 	return work, err
 }
 
 // FetchPaymentsForAddress returns a list or payments made to the provided address.
+// List is ordered, most recent comes first.
 func (h *Hub) FetchPaymentsForAddress(id string) ([]*dividend.Payment, error) {
 	payments, err := dividend.FetchArchivedPaymentsForAccount(h.db, id)
 	return payments, err

--- a/pool.go
+++ b/pool.go
@@ -160,6 +160,7 @@ func NewPool(cfg *config) (*Pool, error) {
 		GUIPort:     cfg.GUIPort,
 		TLSCertFile: defaultTLSCertFile,
 		TLSKeyFile:  defaultTLSKeyFile,
+		ActiveNet:   cfg.net,
 	}
 
 	p.gui, err = gui.NewGUI(gcfg, p.hub, p.db)


### PR DESCRIPTION
### gui: Fix and simplify code.
This fixes some issues with the gui which were introduced
in the previous commit. Also:

- Combine methods in hub.go so pool stats can be fetched in one call.
- Remove truncate param from method to fetch mined work
- Remove minNano param from method to fetch payments
- Reverse slices in index.go so payments and mined blocks
are displayed in reverse order. (This is temporary)


### gui: show connected miners.
- index: show connected miners belonging to account
- move usage of util.HashString into the templates
- admin: show all connected miners
- Move AccountStats struct to gui package
- Add server side input validation to the Address form
- Combine functions FetchHash and FetchConnections so we only need to iterate
over connections once.