### PR TITLE
network: set extraNonce1 for non-complaint miners.

### DIFF
--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -99,8 +99,7 @@ func (e *Endpoint) connect(ctx context.Context) {
 			e.clients[client.generateID()] = client
 			e.clientsMtx.Unlock()
 
-			updated := atomic.AddUint32(&e.hub.clients, 1)
-			atomic.StoreUint32(&e.hub.clients, updated)
+			atomic.AddInt32(&e.hub.clients, 1)
 
 			go client.run(client.ctx)
 		}
@@ -113,6 +112,7 @@ func (e *Endpoint) RemoveClient(c *Client) {
 	e.clientsMtx.Lock()
 	id := c.generateID()
 	delete(e.clients, id)
+	atomic.AddInt32(&e.hub.clients, -1)
 	log.Tracef("Client (%s) removed.", id)
 	e.clientsMtx.Unlock()
 }

--- a/network/hub.go
+++ b/network/hub.go
@@ -91,7 +91,7 @@ type DifficultyData struct {
 type Hub struct {
 	lastWorkHeight    uint32 // update atomically
 	lastPaymentHeight uint32 // update atomically
-	clients           uint32 // update atomically
+	clients           int32  // update atomically
 
 	db           *bolt.DB
 	httpc        *http.Client
@@ -168,7 +168,7 @@ func (h *Hub) processWork(headerE string, target string) {
 
 	log.Tracef("New work at height (%v) received (%v)", height, headerE)
 
-	// Do not process work data id there are no connected  pool clients.
+	// Do not process work data id there are no connected pool clients.
 	if !h.HasClients() {
 		return
 	}
@@ -407,7 +407,7 @@ func NewHub(ctx context.Context, cancel context.CancelFunc, db *bolt.DB, httpc *
 
 // HasClients asserts the mining pool has clients.
 func (h *Hub) HasClients() bool {
-	return atomic.LoadUint32(&h.clients) > 0
+	return atomic.LoadInt32(&h.clients) > 0
 }
 
 // SubmitWork sends solved block data to the consensus daemon for evaluation.

--- a/network/message.go
+++ b/network/message.go
@@ -250,7 +250,7 @@ func ParseSubscribeRequest(req *Request) (string, string, error) {
 }
 
 // SubscribeResponse creates a mining.subscribe response.
-func SubscribeResponse(id uint64, notifyID string, extraNonce1 string, err *StratumError) *Response {
+func SubscribeResponse(id uint64, notifyID string, extraNonce1 string, extraNonce2Size int, err *StratumError) *Response {
 	if err != nil {
 		return &Response{
 			ID:     id,
@@ -264,7 +264,7 @@ func SubscribeResponse(id uint64, notifyID string, extraNonce1 string, err *Stra
 		Error: nil,
 		Result: []interface{}{[][]string{
 			{"mining.set_difficulty", notifyID}, {"mining.notify", notifyID}},
-			extraNonce1, ExtraNonce2Size},
+			extraNonce1, extraNonce2Size},
 	}
 }
 
@@ -456,10 +456,11 @@ func GenerateSolvedBlockHeader(headerE string, extraNonce1E string, extraNonce2E
 		copy(headerEB[288:296], []byte(extraNonce1E))
 		copy(headerEB[296:304], []byte(extraNonce2E))
 
-	// The Antiminer DR3 and DR5 return a 12-byte entraNonce regardless of the
-	// extraNonce2Size specified in the mining.subscribe message. The nTime and
-	// nonce values submitted are big endian, they have to be reversed before
-	// block header reconstruction.
+	// The Antiminer DR3 and DR5 return a 12-byte entraNonce comprised of the
+	// the extraNonce1 and extraNonce2 regardless of the extraNonce2Size
+	// specified in the mining.subscribe message. The nTime and nonce values
+	// submitted are big endian, they have to be reversed before block header
+	// reconstruction.
 	case dividend.AntminerDR3, dividend.AntminerDR5:
 		nTimeERev, err := util.HexReversed(nTimeE)
 		if err != nil {


### PR DESCRIPTION
This updates miner implementations to set the `extraNonce1` values for miners that do not fully comply to the stratum spec.

This also fixes client read/write related bugs as well as a connection counter decrement bug.

Fixes #81.