### PR TITLE
multi: letsencrypt support.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
 	go.etcd.io/bbolt v1.3.2 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/grpc v1.20.1
 )

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
 	"html/template"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/acme/autocert"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/gorilla/csrf"
@@ -34,6 +38,8 @@ type Config struct {
 	GUIPort          uint32
 	TLSCertFile      string
 	TLSKeyFile       string
+	UseLEHTTPS       bool
+	Domain           string
 	ActiveNet        *chaincfg.Params
 	BlockExplorerURL string
 }
@@ -47,6 +53,7 @@ type GUI struct {
 	cookieStore *sessions.CookieStore
 	router      *mux.Router
 	server      *http.Server
+	certMgr     *autocert.Manager
 }
 
 // GenerateSecret generates the CSRF secret.
@@ -98,6 +105,13 @@ func NewGUI(cfg *Config, hub *network.Hub, db *bolt.DB) (*GUI, error) {
 		db:  db,
 	}
 
+	switch cfg.ActiveNet.Name {
+	case chaincfg.TestNet3Params.Name:
+		ui.cfg.BlockExplorerURL = "https://testnet.dcrdata.org"
+	default:
+		ui.cfg.BlockExplorerURL = "https://explorer.dcrdata.org"
+	}
+
 	// Fetch or generate the CSRF secret.
 	err := db.Update(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(database.PoolBkt)
@@ -127,14 +141,6 @@ func NewGUI(cfg *Config, hub *network.Hub, db *bolt.DB) (*GUI, error) {
 	ui.cookieStore = sessions.NewCookieStore(cfg.CSRFSecret)
 	ui.loadTemplates()
 	ui.route()
-
-	ui.server = &http.Server{
-		Addr:         fmt.Sprintf("0.0.0.0:%v", cfg.GUIPort),
-		WriteTimeout: time.Second * 30,
-		ReadTimeout:  time.Second * 5,
-		IdleTimeout:  time.Second * 30,
-		Handler:      ui.router,
-	}
 
 	return ui, nil
 }
@@ -179,22 +185,73 @@ func (ui *GUI) loadTemplates() error {
 
 // Run starts the user interface.
 func (ui *GUI) Run() {
-	log.Infof("GUI served on port %v.", ui.cfg.GUIPort)
-
 	go func() {
-		if err := ui.server.ListenAndServeTLS(ui.cfg.TLSCertFile,
-			ui.cfg.TLSKeyFile); err != nil &&
-			err != http.ErrServerClosed {
-			log.Error(err)
+		if !ui.cfg.UseLEHTTPS {
+			ui.server = &http.Server{
+				WriteTimeout: time.Second * 30,
+				ReadTimeout:  time.Second * 30,
+				IdleTimeout:  time.Second * 30,
+				Addr:         fmt.Sprintf("0.0.0.0:%v", ui.cfg.GUIPort),
+				Handler:      ui.router,
+			}
+
+			if err := ui.server.ListenAndServeTLS(ui.cfg.TLSCertFile,
+				ui.cfg.TLSKeyFile); err != nil &&
+				err != http.ErrServerClosed {
+				log.Error(err)
+			}
+		}
+
+		if ui.cfg.UseLEHTTPS {
+			certCache := autocert.DirCache("certs")
+			ui.certMgr = &autocert.Manager{
+				Prompt:     autocert.AcceptTOS,
+				Cache:      certCache,
+				HostPolicy: autocert.HostWhitelist(ui.cfg.Domain),
+			}
+
+			// Ensure port 80 is not already in use.
+			port80 := ":80"
+			listener, err := net.Listen("tcp", port80)
+			if err != nil {
+				log.Error("port 80 is already in use")
+				return
+			}
+
+			listener.Close()
+
+			// Redirect all regular http requests to their https endpoints.
+			go func() {
+				if err := http.ListenAndServe(port80,
+					ui.certMgr.HTTPHandler(nil)); err != nil &&
+					err != http.ErrServerClosed {
+					log.Error(err)
+				}
+			}()
+
+			ui.server = &http.Server{
+				WriteTimeout: time.Second * 30,
+				ReadTimeout:  time.Second * 30,
+				IdleTimeout:  time.Second * 30,
+				Addr:         ":https",
+				Handler:      ui.router,
+				TLSConfig: &tls.Config{
+					GetCertificate: ui.certMgr.GetCertificate,
+					MinVersion:     tls.VersionTLS12,
+					CipherSuites: []uint16{
+						tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+						tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+						tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+						tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					},
+				},
+			}
+
+			if err := ui.server.ListenAndServeTLS("", ""); err != nil {
+				log.Error(err)
+			}
 		}
 	}()
-}
-
-// Shutdown tears down the user interface.
-func (ui *GUI) Shutdown() {
-	ctx, cl := context.WithTimeout(ui.cfg.Ctx, time.Second*5)
-	defer cl()
-	if err := ui.server.Shutdown(ctx); err != nil {
-		log.Error(err)
-	}
 }

--- a/pool.go
+++ b/pool.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"encoding/binary"
-	"github.com/decred/dcrd/chaincfg"
 	"math/big"
 	"net/http"
 	"os"
@@ -90,8 +89,7 @@ func (p *Pool) initDB() error {
 		}
 	}
 
-	// If the pool mode did not change, upgrade the database if there is a
-	// pending upgrade.
+	// If the pool mode did not change, upgrade the database.
 	if !switchMode {
 		err = database.Upgrade(p.db)
 		if err != nil {
@@ -153,25 +151,18 @@ func NewPool(cfg *config) (*Pool, error) {
 		return nil, err
 	}
 
-	var blockExplorerURL string
-	switch cfg.ActiveNet {
-	case chaincfg.TestNet3Params.Name:
-		blockExplorerURL = "https://testnet.dcrdata.org"
-	default:
-		blockExplorerURL = "https://explorer.dcrdata.org"
-	}
-
 	gcfg := &gui.Config{
-		Ctx:              p.ctx,
-		SoloPool:         cfg.SoloPool,
-		GUIDir:           cfg.GUIDir,
-		BackupPass:       cfg.BackupPass,
-		GUIPort:          cfg.GUIPort,
-		TLSCertFile:      defaultTLSCertFile,
-		TLSKeyFile:       defaultTLSKeyFile,
-		ActiveNet:        cfg.net,
-		PaymentMethod:    cfg.PaymentMethod,
-		BlockExplorerURL: blockExplorerURL,
+		Ctx:           p.ctx,
+		SoloPool:      cfg.SoloPool,
+		GUIDir:        cfg.GUIDir,
+		BackupPass:    cfg.BackupPass,
+		GUIPort:       cfg.GUIPort,
+		UseLEHTTPS:    cfg.UseLEHTTPS,
+		Domain:        cfg.Domain,
+		TLSCertFile:   defaultTLSCertFile,
+		TLSKeyFile:    defaultTLSKeyFile,
+		ActiveNet:     cfg.net,
+		PaymentMethod: cfg.PaymentMethod,
 	}
 
 	p.gui, err = gui.NewGUI(gcfg, p.hub, p.db)
@@ -222,5 +213,4 @@ func main() {
 
 	p.gui.Run()
 	p.hub.Run(p.ctx)
-	p.gui.Shutdown()
 }


### PR DESCRIPTION
This adds support for letsencrypt issued certs intended for use in production. Additional config options have been added to allow specifying the domain the cert should be issued for.