### PR TITLE
miner: Make MaxProcs configurable

### DIFF
--- a/cmd/miner/config.go
+++ b/cmd/miner/config.go
@@ -31,6 +31,7 @@ var (
 	defaultHomeDir    = dcrutil.AppDataDir("miner", false)
 	defaultConfigFile = filepath.Join(defaultHomeDir, defaultConfigFilename)
 	defaultLogDir     = filepath.Join(defaultHomeDir, defaultLogDirname)
+	defaultMaxProcs   = runtime.NumCPU()
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -47,6 +48,7 @@ type config struct {
 	Pool       string `long:"pool" description:"The stratum domain and port of the mining pool to connect to. eg. dcrpool.com:4445"`
 	DebugLevel string `long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	LogDir     string `long:"logdir" description:"The log output directory."`
+	MaxProcs   int    `long:"maxprocs" description:"Number of CPU cores to use. Default is all cores."`
 
 	net *chaincfg.Params
 }

--- a/cmd/miner/config.go
+++ b/cmd/miner/config.go
@@ -31,7 +31,6 @@ var (
 	defaultHomeDir    = dcrutil.AppDataDir("miner", false)
 	defaultConfigFile = filepath.Join(defaultHomeDir, defaultConfigFilename)
 	defaultLogDir     = filepath.Join(defaultHomeDir, defaultLogDirname)
-	defaultMaxProcs   = runtime.NumCPU()
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -322,6 +321,12 @@ func loadConfig() (*config, []string, error) {
 		cfg.net = &chaincfg.TestNet3Params
 	case chaincfg.MainNetParams.Name:
 		cfg.net = &chaincfg.MainNetParams
+	}
+
+	availableCPUs := runtime.NumCPU()
+	if cfg.MaxProcs < 1 || cfg.MaxProcs > availableCPUs {
+		log.Warnf("%d is not a valid value for MaxProcs. Defaulting to %d.", cfg.MaxProcs, availableCPUs)
+		cfg.MaxProcs = availableCPUs
 	}
 
 	// Warn about missing config file only after all other configuration is

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -13,8 +13,6 @@ import (
 )
 
 func main() {
-	// Use all processor cores.
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Listen for interrupt signals.
 	interrupt := make(chan os.Signal, 1)
@@ -27,6 +25,8 @@ func main() {
 		fmt.Println(err)
 		return
 	}
+
+	runtime.GOMAXPROCS(cfg.MaxProcs)
 
 	defer func() {
 		if logRotator != nil {

--- a/harness.sh
+++ b/harness.sh
@@ -13,6 +13,7 @@ NETWORK="simnet"
 # NETWORK="mainnet"
 SOLO_POOL=0
 MAX_GEN_TIME=20
+MINER_MAX_PROCS=1
 PAYMENT_METHOD="pplns"
 LAST_N_PERIOD=300 # PPLNS range, 5 minutes.
 
@@ -64,6 +65,7 @@ activenet=${NETWORK}
 user=m1
 address=${CLIENT_ONE_ADDR}
 pool=127.0.0.1:5550
+maxprocs=${MINER_MAX_PROCS}
 EOF
 
 cat > "${NODES_ROOT}/c2/client.conf" <<EOF
@@ -72,6 +74,7 @@ activenet=${NETWORK}
 user=m2
 address=${CLIENT_TWO_ADDR}
 pool=127.0.0.1:5550
+maxprocs=${MINER_MAX_PROCS}
 EOF
 
 if [ "${NETWORK}" = "mainnet" ]; then


### PR DESCRIPTION
Running the test harness on a laptop is threatening to burn my house down. CPU mining on all cores by default is not ideal when working on a laptop.

This makes the max procs configurable.