### PR TITLE
harness: mine past SVH.

### DIFF
--- a/cmd/miner/cpuminer.go
+++ b/cmd/miner/cpuminer.go
@@ -187,6 +187,9 @@ func (m *CPUMiner) solve(ctx context.Context) {
 			req := pool.SubmitWorkRequest(&id, worker, jobID,
 				m.workData.extraNonce2, m.workData.nTime, m.workData.nonce)
 			m.workCh <- req
+
+			// Stall to prevent mining too quickly.
+			time.Sleep(time.Millisecond * 500)
 		}
 	}
 }

--- a/harness.sh
+++ b/harness.sh
@@ -105,6 +105,7 @@ paymentmethod=${PAYMENT_METHOD}
 lastnperiod=${LAST_N_PERIOD}
 backuppass=${BACKUP_PASS}
 guidir=${GUI_DIR}
+designation=${SESSION}
 EOF
 
 cat > "${NODES_ROOT}/dcrmwctl.conf" <<EOF
@@ -193,6 +194,7 @@ paymentmethod=${PAYMENT_METHOD}
 lastnperiod=${LAST_N_PERIOD}
 backuppass=${BACKUP_PASS}
 guidir=${GUI_DIR}
+designation=${SESSION}
 EOF
 fi
 
@@ -283,7 +285,7 @@ tmux send-keys "dcrwallet -C mwallet.conf " C-m # --debuglevel=warn
 # ################################################################################
 # # Setup the pool wallet's dcrctl (wctl).
 # ################################################################################
-sleep 5
+sleep 10
 # The consensus daemon must be synced for account generation to 
 # work as expected.
 echo "Setting up pool wallet accounts"
@@ -347,7 +349,7 @@ tmux send-keys "cd ${NODES_ROOT}/vnode" C-m
 
 # mine some blocks to start the chain if the active network is simnet.
 tmux send-keys "./mine 30" C-m
-sleep 5
+sleep 10
 echo "Mined 30 blocks, at stake enabled height (SEH)"
 
 ################################################################################

--- a/harness.sh
+++ b/harness.sh
@@ -5,12 +5,11 @@ SESSION="harness"
 NODES_ROOT=~/harness
 RPC_USER="user"
 RPC_PASS="pass"
-WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e1402eac"
+MASTER_WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e1402eac"
+VOTING_WALLET_SEED="aabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbc"
 WALLET_PASS=123
 BACKUP_PASS=b@ckUp
-NETWORK="simnet"
-# NETWORK="testnet3"
-# NETWORK="mainnet"
+NETWORK="simnet" # testnet3
 SOLO_POOL=0
 MAX_GEN_TIME=20
 MINER_MAX_PROCS=1
@@ -18,24 +17,19 @@ PAYMENT_METHOD="pplns"
 LAST_N_PERIOD=300 # PPLNS range, 5 minutes.
 
 if [ "${NETWORK}" = "simnet" ]; then
+ CPU_MINING_ADDR="SsiuwSRYvH7pqWmRxFJWR8Vmqc3AWsjmK2Y"
  POOL_MINING_ADDR="SspUvSyDGSzvPz2NfdZ5LW15uq6rmuGZyhL"
  PFEE_ADDR="SsVPfV8yoMu7AvF5fGjxTGmQ57pGkaY6n8z"
  CLIENT_ONE_ADDR="SsZckVrqHRBtvhJA5UqLZ3MDXpZHi5mK6uU"
  CLIENT_TWO_ADDR="Ssn23a3rJaCUxjqXiVSNwU6FxV45sLkiFpz"
 fi
 
-if [ "${NETWORK}" = "mainnet" ]; then
-POOL_MINING_ADDR="DsXete8zpkHZXGd4vcxhz4rPqmEqydC9u5E"
-PFEE_ADDR="DsXete8zpkHZXGd4vcxhz4rPqmEqydC9u5E"
-CLIENT_ADDR="DsXete8zpkHZXGd4vcxhz4rPqmEqydC9u5E"
-fi
-
 if [ "${NETWORK}" = "testnet3" ]; then
-POOL_MINING_ADDR="TsWP4MhHZn77F6tQprHhFoJHMWifaDdh2Mc"
-PFEE_ADDR="TsWP4MhHZn77F6tQprHhFoJHMWifaDdh2Mc"
-CLIENT_ADDR="TsWP4MhHZn77F6tQprHhFoJHMWifaDdh2Mc"
+POOL_MINING_ADDR="TsZT7gjAt4tEfQaSVLDUgrmzypMNfzPq2wr"
+PFEE_ADDR="TskLJuhkrBSqxbL2pa9oCnwTP7RzB7mkNsz"
+CLIENT_ONE_ADDR="TsVbBwJxeZ5ymmbB1TSR8mXKsE6UyrfTCAV"
+CLIENT_TWO_ADDR="Tsggat7kHZcYgc24TnQFofnrVYGJLc5tySv"
 fi
-
 
 if [ -d "${NODES_ROOT}" ]; then
   rm -R "${NODES_ROOT}"
@@ -50,7 +44,9 @@ GUI_DIR="${NODES_ROOT}/gui"
 
 echo "Writing node config files"
 mkdir -p "${NODES_ROOT}/master"
-mkdir -p "${NODES_ROOT}/wallet"
+mkdir -p "${NODES_ROOT}/vnode"
+mkdir -p "${NODES_ROOT}/mwallet"
+mkdir -p "${NODES_ROOT}/vwallet"
 mkdir -p "${NODES_ROOT}/pool"
 mkdir -p "${NODES_ROOT}/gui"
 mkdir -p "${NODES_ROOT}/c1"
@@ -77,40 +73,19 @@ pool=127.0.0.1:5550
 maxprocs=${MINER_MAX_PROCS}
 EOF
 
-if [ "${NETWORK}" = "mainnet" ]; then
-cat > "${NODES_ROOT}/dcrctl.conf" <<EOF
-rpcuser=${RPC_USER}
-rpcpass=${RPC_PASS}
-rpccert=${DCRD_RPC_CERT}
-rpcserver=127.0.0.1:9109
-EOF
-
-cat > "${NODES_ROOT}/pool/pool.conf" <<EOF
-rpcuser=${RPC_USER}
-rpcpass=${RPC_PASS}
-dcrdrpchost=127.0.0.1:9109
-dcrdrpccert=${DCRD_RPC_CERT}
-walletgrpchost=127.0.0.1:9111
-walletrpccert=${WALLET_RPC_CERT}
-debuglevel=trace
-maxgentime=${MAX_GEN_TIME}
-solopool=${SOLO_POOL}
-activenet=${NETWORK}
-walletpass=${WALLET_PASS}
-poolfeeaddrs=${PFEE_ADDR}
-paymentmethod=${PAYMENT_METHOD}
-lastnperiod=${LAST_N_PERIOD}
-backuppass=${BACKUP_PASS}
-guidir=${GUI_DIR}
-EOF
-fi
-
 if [ "${NETWORK}" = "simnet" ]; then
-cat > "${NODES_ROOT}/dcrctl.conf" <<EOF
+cat > "${NODES_ROOT}/dcrmctl.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
 rpccert=${DCRD_RPC_CERT}
 rpcserver=127.0.0.1:19556
+EOF
+
+cat > "${NODES_ROOT}/dcrvctl.conf" <<EOF
+rpcuser=${RPC_USER}
+rpcpass=${RPC_PASS}
+rpccert=${DCRD_RPC_CERT}
+rpcserver=127.0.0.1:19560
 EOF
 
 cat > "${NODES_ROOT}/pool/pool.conf" <<EOF
@@ -132,32 +107,73 @@ backuppass=${BACKUP_PASS}
 guidir=${GUI_DIR}
 EOF
 
-cat > "${NODES_ROOT}/dcrwctl.conf" <<EOF
+cat > "${NODES_ROOT}/dcrmwctl.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
 rpccert=${WALLET_RPC_CERT}
 rpcserver=127.0.0.1:19557
 EOF
 
-cat > "${NODES_ROOT}/wallet/wallet.conf" <<EOF
+cat > "${NODES_ROOT}/dcrvwctl.conf" <<EOF
+rpcuser=${RPC_USER}
+rpcpass=${RPC_PASS}
+rpccert=${WALLET_RPC_CERT}
+rpcserver=127.0.0.1:19562
+EOF
+
+cat > "${NODES_ROOT}/mwallet/mwallet.conf" <<EOF
 username=${RPC_USER}
 password=${RPC_PASS}
 rpccert=${WALLET_RPC_CERT}
 rpckey=${WALLET_RPC_KEY}
-logdir=./log
-appdata=./data
+logdir=${NODES_ROOT}/mwallet/log
+appdata=${NODES_ROOT}/mwallet
 simnet=1
 pass=${WALLET_PASS}
-debuglevel=debug
+EOF
+
+cat > "${NODES_ROOT}/vwallet/vwallet.conf" <<EOF
+username=${RPC_USER}
+password=${RPC_PASS}
+rpccert=${WALLET_RPC_CERT}
+rpckey=${WALLET_RPC_KEY}
+logdir=${NODES_ROOT}/vwallet/log
+appdata=${NODES_ROOT}/vwallet
+simnet=1
+enablevoting=1
+enableticketbuyer=1
+ticketbuyer.limit=2
+pass=${WALLET_PASS}
+rpcconnect=127.0.0.1:19560
+grpclisten=127.0.0.1:19561
+rpclisten=127.0.0.1:19562
 EOF
 fi
 
 if [ "${NETWORK}" = "testnet3" ]; then
-cat > "${NODES_ROOT}/dcrctl.conf" <<EOF
+cat > "${NODES_ROOT}/dcrmctl.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
 rpccert=${DCRD_RPC_CERT}
 rpcserver=127.0.0.1:19109
+EOF
+
+cat > "${NODES_ROOT}/dcrmwctl.conf" <<EOF
+rpcuser=${RPC_USER}
+rpcpass=${RPC_PASS}
+rpccert=${WALLET_RPC_CERT}
+rpcserver=127.0.0.1:19110
+EOF
+
+cat > "${NODES_ROOT}/mwallet/mwallet.conf" <<EOF
+username=${RPC_USER}
+password=${RPC_PASS}
+rpccert=${WALLET_RPC_CERT}
+rpckey=${WALLET_RPC_KEY}
+logdir=${NODES_ROOT}/mwallet/log
+appdata=${NODES_ROOT}/mwallet
+testnet=1
+pass=${WALLET_PASS}
 EOF
 
 cat > "${NODES_ROOT}/pool/pool.conf" <<EOF
@@ -186,28 +202,23 @@ cd ${NODES_ROOT} && tmux new-session -d -s $SESSION
 # Setup the master node.
 ################################################################################
 cat > "${NODES_ROOT}/master/ctl" <<EOF
-#!/bin/zsh
-dcrctl -C ../dcrctl.conf \$*
+#!/bin/sh
+dcrctl -C ../dcrmctl.conf \$*
 EOF
 chmod +x "${NODES_ROOT}/master/ctl"
 
 tmux rename-window -t $SESSION:0 'master'
 tmux send-keys "cd ${NODES_ROOT}/master" C-m
 
-echo "Starting ${NETWORK} dcrd"
-if [ "${NETWORK}" = "mainnet" ]; then
-tmux send-keys "dcrd -C ${DCRD_CONF} \
---rpccert=${DCRD_RPC_CERT} --rpckey=${DCRD_RPC_KEY} \
---rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
---miningaddr=${POOL_MINING_ADDR}" C-m
-fi
+echo "Starting ${NETWORK} master node"
 
 if [ "${NETWORK}" = "testnet3" ]; then
 tmux send-keys "dcrd -C ${DCRD_CONF} \
 --rpccert=${DCRD_RPC_CERT} --rpckey=${DCRD_RPC_KEY} \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --miningaddr=${POOL_MINING_ADDR} \
---testnet" C-m
+--debuglevel=info \
+--testnet" C-m 
 fi
 
 if [ "${NETWORK}" = "simnet" ]; then
@@ -215,6 +226,8 @@ tmux send-keys "dcrd -C ${DCRD_CONF} \
 --rpccert=${DCRD_RPC_CERT} --rpckey=${DCRD_RPC_KEY} \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --miningaddr=${POOL_MINING_ADDR} \
+--txindex \
+--debuglevel=info \
 --simnet" C-m
 fi
 
@@ -229,7 +242,7 @@ cat > "${NODES_ROOT}/master/mine" <<EOF
       *) NUM=\$1 ;;
   esac
   for i in \$(seq \$NUM) ; do
-    dcrctl -C ../dcrctl.conf  generate 1
+    dcrctl -C ../dcrmctl.conf generate 1
     sleep 0.5
   done
 EOF
@@ -238,43 +251,44 @@ chmod +x "${NODES_ROOT}/master/mine"
 tmux new-window -t $SESSION:1 -n 'mctl'
 tmux send-keys "cd ${NODES_ROOT}/master" C-m
 
-if [ "${NETWORK}" = "simnet" ]; then
-echo "Waiting for some ${NETWORK} blocks to be mined"
-sleep 2
+sleep 3
 # mine some blocks to start the chain if the active network is simnet.
+if [ "${NETWORK}" = "simnet" ]; then
 tmux send-keys "./mine 2" C-m
+echo "Mined 2 blocks"
+sleep 1
 fi
 
-if [ "${NETWORK}" = "simnet" ]; then
+tmux send-keys "./ctl livetickets"
+
 ################################################################################
 # Setup the pool wallet.
 ################################################################################
-cat > "${NODES_ROOT}/wallet/ctl" <<EOF
+cat > "${NODES_ROOT}/mwallet/ctl" <<EOF
 #!/bin/sh
-dcrctl -C ../dcrwctl.conf --wallet \$*
+dcrctl -C ../dcrmwctl.conf --wallet \$*
 EOF
-chmod +x "${NODES_ROOT}/wallet/ctl"
+chmod +x "${NODES_ROOT}/mwallet/ctl"
 
-tmux new-window -t $SESSION:2 -n 'wallet'
-tmux send-keys "cd ${NODES_ROOT}/wallet" C-m
-tmux send-keys "dcrwallet -C wallet.conf --create" C-m
-echo "Creating ${NETWORK} wallet"
-sleep 2
-tmux send-keys "${WALLET_PASS}" C-m "${WALLET_PASS}" C-m "n" C-m "y" C-m
-echo "Setting wallet passphrase"
+tmux new-window -t $SESSION:2 -n 'mwallet'
+tmux send-keys "cd ${NODES_ROOT}/mwallet" C-m
+tmux send-keys "dcrwallet -C mwallet.conf --create" C-m
+echo "Creating ${NETWORK} master wallet"
 sleep 1
-tmux send-keys "${WALLET_SEED}" C-m C-m
-tmux send-keys "dcrwallet -C wallet.conf" C-m
+tmux send-keys "${WALLET_PASS}" C-m "${WALLET_PASS}" C-m "n" C-m "y" C-m
+sleep 1
+tmux send-keys "${MASTER_WALLET_SEED}" C-m C-m
+tmux send-keys "dcrwallet -C mwallet.conf " C-m # --debuglevel=warn
 
-################################################################################
-# Setup the pool wallet's dcrctl (wctl).
-################################################################################
-echo "Waiting for nodes to be synced"
-sleep 6
+# ################################################################################
+# # Setup the pool wallet's dcrctl (wctl).
+# ################################################################################
+sleep 5
 # The consensus daemon must be synced for account generation to 
 # work as expected.
-tmux new-window -t $SESSION:3 -n 'wctl'
-tmux send-keys "cd ${NODES_ROOT}/wallet" C-m
+echo "Setting up pool wallet accounts"
+tmux new-window -t $SESSION:3 -n 'mwctl'
+tmux send-keys "cd ${NODES_ROOT}/mwallet" C-m
 tmux send-keys "./ctl createnewaccount pfee" C-m
 tmux send-keys "./ctl getnewaddress pfee" C-m
 tmux send-keys "./ctl createnewaccount c1" C-m
@@ -283,14 +297,103 @@ tmux send-keys "./ctl createnewaccount c2" C-m
 tmux send-keys "./ctl getnewaddress c2" C-m
 tmux send-keys "./ctl getnewaddress default" C-m
 tmux send-keys "./ctl getbalance"
+
+if [ "${NETWORK}" = "simnet" ]; then
+################################################################################
+# Setup the voting node.
+################################################################################
+cat > "${NODES_ROOT}/vnode/ctl" <<EOF
+#!/bin/sh
+dcrctl -C ../dcrvctl.conf \$*
+EOF
+chmod +x "${NODES_ROOT}/vnode/ctl"
+
+tmux new-window -t $SESSION:4 -n 'vnode'
+tmux send-keys "cd ${NODES_ROOT}/vnode" C-m
+
+echo "Starting ${NETWORK} voting node"
+
+tmux send-keys "dcrd -C ${DCRD_CONF} \
+--rpccert=${DCRD_RPC_CERT} --rpckey=${DCRD_RPC_KEY} \
+--rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
+--connect=127.0.0.1:18555 \
+--listen=127.0.0.1:19559 --rpclisten=127.0.0.1:19560 \
+--miningaddr=${CPU_MINING_ADDR} \
+--appdata=${NODES_ROOT}/vnode \
+--txindex \
+--debuglevel=info \
+--simnet" C-m
+
+################################################################################
+# Setup the voting node's dcrctl (vctl).
+################################################################################
+sleep 3
+cat > "${NODES_ROOT}/vnode/mine" <<EOF
+#!/bin/sh
+  NUM=1
+  case \$1 in
+      ''|*[!0-9]*)  ;;
+      *) NUM=\$1 ;;
+  esac
+  for i in \$(seq \$NUM) ; do
+    dcrctl -C ../dcrvctl.conf generate 1
+    sleep 0.5
+  done
+EOF
+chmod +x "${NODES_ROOT}/vnode/mine"
+
+tmux new-window -t $SESSION:5 -n 'vctl'
+tmux send-keys "cd ${NODES_ROOT}/vnode" C-m
+
+# mine some blocks to start the chain if the active network is simnet.
+tmux send-keys "./mine 30" C-m
+sleep 5
+echo "Mined 30 blocks, at stake enabled height (SEH)"
+
+################################################################################
+# Setup the voting wallet.
+################################################################################
+cat > "${NODES_ROOT}/vwallet/ctl" <<EOF
+#!/bin/sh
+dcrctl -C ../dcrvwctl.conf --wallet \$*
+EOF
+chmod +x "${NODES_ROOT}/vwallet/ctl"
+
+cat > "${NODES_ROOT}/vwallet/tickets" <<EOF
+#!/bin/sh
+NUM=1
+case \$1 in
+    ''|*[!0-9]*) ;;
+    *) NUM=\$1 ;;
+esac
+./ctl purchaseticket default 999999 1 \`./ctl getnewaddress\` \$NUM
+EOF
+chmod +x "${NODES_ROOT}/vwallet/tickets"
+
+tmux new-window -t $SESSION:6 -n 'vwallet'
+tmux send-keys "cd ${NODES_ROOT}/vwallet" C-m
+tmux send-keys "dcrwallet -C vwallet.conf --create" C-m
+echo "Creating ${NETWORK} voting wallet"
+sleep 1
+tmux send-keys "${WALLET_PASS}" C-m "${WALLET_PASS}" C-m "n" C-m "y" C-m
+sleep 1
+tmux send-keys "${VOTING_WALLET_SEED}" C-m C-m
+tmux send-keys "dcrwallet -C vwallet.conf --debuglevel=debug" C-m
+
+################################################################################
+# Setup the voting wallet's dcrctl (vwctl).
+################################################################################
+sleep 1
+tmux new-window -t $SESSION:7 -n 'vwctl'
+tmux send-keys "cd ${NODES_ROOT}/vwallet" C-m
 fi
 
 ################################################################################
 # Setup dcrpool.
 ################################################################################
 echo "Starting dcrpool"
-sleep 4
-tmux new-window -t $SESSION:4 -n 'pool'
+sleep 5
+tmux new-window -t $SESSION:8 -n 'pool'
 tmux send-keys "cd ${NODES_ROOT}/pool" C-m
 tmux send-keys "dcrpool --configfile=pool.conf --homedir=${NODES_ROOT}/pool" C-m
 
@@ -300,7 +403,7 @@ if [ "${NETWORK}" = "simnet" ]; then
 ################################################################################
 echo "Starting mining client 1"
 sleep 1
-tmux new-window -t $SESSION:5 -n 'c1'
+tmux new-window -t $SESSION:9 -n 'c1'
 tmux send-keys "cd ${NODES_ROOT}/c1" C-m
 tmux send-keys "miner --configfile=client.conf --homedir=${NODES_ROOT}/c1" C-m
 
@@ -309,7 +412,7 @@ tmux send-keys "miner --configfile=client.conf --homedir=${NODES_ROOT}/c1" C-m
 ################################################################################
 echo "Starting mining client 2"
 sleep 1
-tmux new-window -t $SESSION:6 -n 'c2'
+tmux new-window -t $SESSION:10 -n 'c2'
 tmux send-keys "cd ${NODES_ROOT}/c2" C-m
 tmux send-keys "miner --configfile=client.conf --homedir=${NODES_ROOT}/c2" C-m
 fi


### PR DESCRIPTION
This updates the mining harness to only use testnet and simnet for testing, mainnet has been removed. A bug with the harness which prevented mining past stake validation height (SVH) was identified and fixed.

The harness provides scripts for mining and buying tickets, by default ticket purchases are done using the voting wallet's ticketbuyer.

This also stalls the miner after finding a block to prevent mining too quickly.

NB: To test, build the wallet on [dcrwallet PR #1484](https://github.com/decred/dcrwallet/pull/1484)