### PR TITLE
multi: send work to only authorized and subscribed clients.

### DIFF
--- a/cmd/miner/client.go
+++ b/cmd/miner/client.go
@@ -343,6 +343,12 @@ func (m *Miner) process(ctx context.Context) {
 					m.workMtx.Unlock()
 
 				case network.Notify:
+					// Do not process work notifications if the miner is not
+					// authorized or subscribed.
+					if !m.authorized || !m.subscribed {
+						continue
+					}
+
 					jobID, prevBlockE, genTx1E, genTx2E, blockVersionE, _, _, _, err :=
 						network.ParseWorkNotification(notif)
 					if err != nil {

--- a/network/client.go
+++ b/network/client.go
@@ -709,6 +709,11 @@ func (c *Client) send(ctx context.Context) {
 				if req.Method == Notify {
 					id := c.generateID()
 
+					// Only send work to authorized and subscribed clients.
+					if !c.authorized || !c.subscribed {
+						continue
+					}
+
 					switch c.endpoint.miner {
 					case dividend.CPU:
 						err := c.encoder.Encode(msg)

--- a/network/message.go
+++ b/network/message.go
@@ -438,7 +438,7 @@ func GenerateBlockHeader(blockVersionE string, prevBlockE string, genTx1E string
 	var header wire.BlockHeader
 	err = header.FromBytes(headerD)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create header from bytes: %v", err)
 	}
 
 	return &header, nil


### PR DESCRIPTION
This fixes a bug where connected unauthorized and unsubscribed miners received work notifications as seen here:
```
❯ miner --configfile=client.conf --homedir=/home/dnldd/harness/c1
2019-06-11 17:58:37.546 [INF] MN: Version: 0.1.0+dev
2019-06-11 17:58:37.546 [INF] MN: Runtime: Go version go1.12.5
2019-06-11 17:58:37.546 [INF] MN: Home dir: /home/dnldd/harness/c1
2019-06-11 17:58:37.546 [INF] MN: Started miner.
2019-06-11 17:58:37.546 [TRC] MN: Miner generate blocks started.
2019-06-11 17:58:37.585 [TRC] MN: Started connection handler.
2019-06-11 17:58:37.585 [TRC] MN: Miner listener started.
2019-06-11 17:58:37.585 [TRC] MN: Miner hash rate monitor started.
2019-06-11 17:58:37.625 [TRC] MN: Message received is: (string) (len=413) "{\"id\":null,\"method\":\"mining.notify\",\"params\":[\"0000000315a736ae2b3a4ad1\",\"1324d71e96df6de01f41cb384e5c7b3d3d2c14168be06111d23020953a740d3c\",\"9f5e7b707c44e65d9ac0a2b06b0cf0ab0cca160f5b4309604376095ce4596ccd000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000ffff7f20204e0000000000000300000066010000cdebff5c00000000\",\"00000000\",[],\"06000000\",\"ffff7f20\",\"cdebff5c\",true]}\n"
...
```