### PR TITLE
multi: assert account exists before work lookup.

### DIFF
--- a/dividend/payment.go
+++ b/dividend/payment.go
@@ -321,7 +321,7 @@ func replenishTxFeeReserve(maxTxFeeReserve dcrutil.Amount, txFeeReserve *dcrutil
 	return poolFee
 }
 
-// CalculatePPLNSSharePercentages computes the current dividend
+// CalculatePPSSharePercentages computes the current dividend
 // percentages due pool accounts based on work performed measured by the
 // PPS payment scheme.
 func CalculatePPSSharePercentages(db *bolt.DB, poolFee float64, height uint32) (map[string]*big.Rat, error) {

--- a/gui/index.go
+++ b/gui/index.go
@@ -94,12 +94,17 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 
 	// Ensure address is on the active network.
 	if !addr.IsForNet(ui.cfg.ActiveNet) {
-		data.Error = fmt.Sprintf("This is not a %s address", ui.cfg.ActiveNet.Name)
+		data.Error = fmt.Sprintf("Invalid %s addresss", ui.cfg.ActiveNet.Name)
 		ui.renderTemplate(w, r, "index", data)
 		return
 	}
 
 	accountID := *dividend.AccountID(address)
+	if !ui.hub.AccountExists(accountID) {
+		data.Error = fmt.Sprintf("Nothing found for address %s", address)
+		ui.renderTemplate(w, r, "index", data)
+		return
+	}
 
 	work, err := ui.hub.FetchMinedWorkByAddress(accountID)
 	if err != nil {
@@ -118,8 +123,7 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(work) == 0 && len(payments) == 0 {
-		log.Infof("Nothing found for address: %s", address)
-		data.Error = fmt.Sprintf("Nothing found for address: %s", address)
+		data.Error = fmt.Sprintf("No confirmed work for %s", address)
 		ui.renderTemplate(w, r, "index", data)
 		return
 	}

--- a/network/acceptedwork.go
+++ b/network/acceptedwork.go
@@ -226,7 +226,7 @@ func ListMinedWorkByAccount(db *bolt.DB, accountID string, n uint) ([]*AcceptedW
 				return err
 			}
 
-			if strings.Compare(work.MinedBy, accountID) == 0 {
+			if strings.Compare(work.MinedBy, accountID) == 0 && work.Confirmed {
 				minedWork = append(minedWork, &work)
 				if len(minedWork) == int(n) {
 					return nil

--- a/network/hub.go
+++ b/network/hub.go
@@ -1044,3 +1044,14 @@ func (h *Hub) FetchPaymentsForAddress(id string) ([]*dividend.Payment, error) {
 	payments, err := dividend.FetchArchivedPaymentsForAccount(h.db, id, 10)
 	return payments, err
 }
+
+// AccountExists asserts if the provided account id references a pool account.
+func (h *Hub) AccountExists(accountID string) bool {
+	_, err := dividend.FetchAccount(h.db, []byte(accountID))
+	if err != nil {
+		log.Tracef("Unable to fetch account for id: %s", accountID)
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
This asserts the generated account id exists before looking up work and payment data. Related error messages have been improved.