### PR TITLE
Add PoolFee and Network to Pool Information

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,6 +49,7 @@ const (
 	defaultGUIPort         = 8080
 	defaultGUIDir          = "gui"
 	defaultUseLEHTTPS      = false
+	defaultDesignation     = "MyPool"
 )
 
 var (
@@ -101,6 +102,7 @@ type config struct {
 	GUIDir          string   `long:"guidir" ini-name:"guidir" description:"The path to the directory containing the pool's user interface assets (templates, css etc.)"`
 	Domain          string   `long:"domain" ini-name:"domain" description:"The domain of the mining pool, required for TLS."`
 	UseLEHTTPS      bool     `long:"uselehttps" ini-name:"uselehttps" description:"This enables HTTPS using a Letsencrypt certificate. By default the pool uses a self-signed certificate for HTTPS."`
+	Designation     string   `long:"designation" ini-name:"designation" description:"The designated codename for this pool. Customises the logo in the top toolbar."`
 	poolFeeAddrs    []dcrutil.Address
 	dcrdRPCCerts    []byte
 	net             *chaincfg.Params
@@ -264,6 +266,7 @@ func loadConfig() (*config, []string, error) {
 		GUIPort:         defaultGUIPort,
 		GUIDir:          defaultGUIDir,
 		UseLEHTTPS:      defaultUseLEHTTPS,
+		Designation:     defaultDesignation,
 	}
 
 	// Service options which are only added on Windows.

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -13,21 +13,24 @@ import (
 type adminPageData struct {
 	Connections map[string][]*network.ClientInfo
 	CSRF        template.HTML
+	Designation string
 }
 
 func (ui *GUI) GetAdmin(w http.ResponseWriter, r *http.Request) {
+	pageData := adminPageData{
+		CSRF:        csrf.TemplateField(r),
+		Designation: ui.cfg.Designation,
+	}
+
 	session, _ := ui.cookieStore.Get(r, "session")
 	if session.Values["IsAdmin"] != true {
-		ui.renderTemplate(w, r, "login", adminPageData{
-			CSRF: csrf.TemplateField(r),
-		})
+		ui.renderTemplate(w, r, "login", pageData)
 		return
 	}
 
-	ui.renderTemplate(w, r, "admin", adminPageData{
-		Connections: ui.hub.FetchClientInfo(),
-		CSRF:        csrf.TemplateField(r),
-	})
+	pageData.Connections = ui.hub.FetchClientInfo()
+
+	ui.renderTemplate(w, r, "admin", pageData)
 }
 
 func (ui *GUI) PostAdmin(w http.ResponseWriter, r *http.Request) {

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -43,6 +43,7 @@ type Config struct {
 	ActiveNet        *chaincfg.Params
 	BlockExplorerURL string
 	Designation      string
+	PoolFee          float64
 }
 
 // GUI represents the the mining pool user interface.
@@ -166,10 +167,11 @@ func (ui *GUI) loadTemplates() error {
 	}
 
 	httpTemplates := template.New("template").Funcs(template.FuncMap{
-		"hashString":    util.HashString,
-		"upper":         strings.ToUpper,
-		"percentString": util.PercentString,
-		"time":          util.FormatUnixTime,
+		"hashString":     util.HashString,
+		"upper":          strings.ToUpper,
+		"ratToPercent":   util.RatToPercent,
+		"floatToPercent": util.FloatToPercent,
+		"time":           util.FormatUnixTime,
 	})
 
 	// Since template.Must panics with non-nil error, it is much more

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -42,6 +42,7 @@ type Config struct {
 	Domain           string
 	ActiveNet        *chaincfg.Params
 	BlockExplorerURL string
+	Designation      string
 }
 
 // GUI represents the the mining pool user interface.

--- a/gui/index.go
+++ b/gui/index.go
@@ -21,6 +21,7 @@ type indexData struct {
 	Admin            bool
 	Error            string
 	BlockExplorerURL string
+	Designation      string
 }
 
 // AccountStats is a snapshot of an accounts contribution to the pool. This
@@ -64,6 +65,7 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 		SoloPool:         ui.cfg.SoloPool,
 		Admin:            false,
 		BlockExplorerURL: ui.cfg.BlockExplorerURL,
+		Designation:      ui.cfg.Designation,
 	}
 
 	address := r.FormValue("address")

--- a/gui/index.go
+++ b/gui/index.go
@@ -21,6 +21,7 @@ type indexData struct {
 	Admin            bool
 	Error            string
 	BlockExplorerURL string
+	Network          string
 	Designation      string
 	PoolFee          float64
 }
@@ -68,6 +69,7 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 		BlockExplorerURL: ui.cfg.BlockExplorerURL,
 		Designation:      ui.cfg.Designation,
 		PoolFee:          ui.cfg.PoolFee,
+		Network:          ui.cfg.ActiveNet.Name,
 	}
 
 	address := r.FormValue("address")

--- a/gui/index.go
+++ b/gui/index.go
@@ -22,6 +22,7 @@ type indexData struct {
 	Error            string
 	BlockExplorerURL string
 	Designation      string
+	PoolFee          float64
 }
 
 // AccountStats is a snapshot of an accounts contribution to the pool. This
@@ -66,6 +67,7 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 		Admin:            false,
 		BlockExplorerURL: ui.cfg.BlockExplorerURL,
 		Designation:      ui.cfg.Designation,
+		PoolFee:          ui.cfg.PoolFee,
 	}
 
 	address := r.FormValue("address")

--- a/gui/public/images/charts.svg
+++ b/gui/public/images/charts.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg18"
+   version="1.1"
+   viewBox="0 0 450 450"
+   height="450"
+   width="450">
+  <metadata
+     id="metadata24">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>charts</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs22" />
+  <title
+     id="title2">charts</title>
+  <g
+     id="g8"
+     style="fill:#527cc9;fill-opacity:1">
+    <path
+       style="fill:#527cc9;fill-opacity:1"
+       id="path4"
+       d="M 252.325,236.064 360.281,344.019 A 179.423,179.423 0 0 0 405,236.064 Z" />
+    <path
+       style="fill:#527cc9;fill-opacity:1"
+       id="path6"
+       d="M 236.424,213.576 H 405 A 180.185,180.185 0 0 0 236.424,45 Z" />
+  </g>
+  <path
+     style="fill:#99c1e3;fill-opacity:1"
+     id="path10"
+     d="M 213.936,229.478 V 45 C 119.665,50.806 45,129.087 45,224.82 a 180.169,180.169 0 0 0 299.38,135.1 z" />
+  <rect
+     width="450"
+     height="450"
+     id="rect14"
+     x="0"
+     y="0"
+     style="fill:none" />
+</svg>

--- a/gui/public/images/server.svg
+++ b/gui/public/images/server.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg32"
+   version="1.1"
+   viewBox="0 0 450 450"
+   height="450"
+   width="450">
+  <metadata
+     id="metadata38">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>server</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs36" />
+  <title
+     id="title2">server</title>
+  <path
+     d="M 25,281 H 425 V 169 H 25 Z"
+     id="path4"
+     style="fill:#99c1e3;fill-opacity:1" />
+  <circle
+     cx="337.5"
+     cy="225"
+     r="12.5"
+     id="circle6"
+     style="fill:#527cc9;fill-opacity:1" />
+  <circle
+     cx="287.5"
+     cy="225"
+     r="12.5"
+     id="circle8"
+     style="fill:#527cc9;fill-opacity:1" />
+  <circle
+     cx="387.5"
+     cy="225"
+     r="12.5"
+     id="circle10"
+     style="fill:#527cc9;fill-opacity:1" />
+  <path
+     d="M 25,425 H 425 V 306 H 25 Z"
+     id="path12"
+     style="fill:#99c1e3;fill-opacity:1" />
+  <circle
+     cx="337.5"
+     cy="362.50101"
+     r="12.5"
+     id="circle14"
+     style="fill:#527cc9;fill-opacity:1" />
+  <circle
+     cx="287.5"
+     cy="362.50101"
+     r="12.5"
+     id="circle16"
+     style="fill:#527cc9;fill-opacity:1" />
+  <circle
+     cx="387.5"
+     cy="362.50101"
+     r="12.5"
+     id="circle18"
+     style="fill:#527cc9;fill-opacity:1" />
+  <path
+     d="M 25,144 H 425 V 25 H 25 Z"
+     id="path20"
+     style="fill:#99c1e3;fill-opacity:1" />
+  <circle
+     cx="337.5"
+     cy="87.5"
+     r="12.5"
+     id="circle22"
+     style="fill:#527cc9;fill-opacity:1" />
+  <circle
+     cx="287.5"
+     cy="87.5"
+     r="12.5"
+     id="circle24"
+     style="fill:#527cc9;fill-opacity:1" />
+  <circle
+     cx="387.5"
+     cy="87.5"
+     r="12.5"
+     id="circle26"
+     style="fill:#527cc9;fill-opacity:1" />
+  <rect
+     width="450"
+     height="450"
+     id="rect28"
+     x="0"
+     y="0"
+     style="fill:none" />
+</svg>

--- a/gui/templates/header.html
+++ b/gui/templates/header.html
@@ -50,7 +50,7 @@
                             </div>
                             <div class="logo--text">
                                 dcrpool<br>
-                                <b>Simnet</b>
+                                <b>{{.Designation}}</b>
                             </div>
                         </a>
                     </div>

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -155,6 +155,12 @@
                         <div class="row mb-3">
                             <div class="col-6">
                                 <div class="d-lg-flex align-items-start align-items-lg-center">
+                                    <img class="info-icon mb-1" src="/images/server.svg" alt="">
+                                    <p class="ml-lg-3 mb-0"><strong>Network:&nbsp;</strong>{{.Network}}</p>
+                                </div>
+                            </div>
+                            <div class="col-6">
+                                <div class="d-lg-flex align-items-start align-items-lg-center">
                                     <img class="info-icon mb-1" src="/images/charts.svg" alt="">
                                     <p class="ml-lg-3 mb-0"><strong>Pool Fee:&nbsp;</strong>{{floatToPercent .PoolFee }}</p>
                                 </div>

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -152,6 +152,14 @@
                             </div>
                         </div>
                         {{end}}
+                        <div class="row mb-3">
+                            <div class="col-6">
+                                <div class="d-lg-flex align-items-start align-items-lg-center">
+                                    <img class="info-icon mb-1" src="/images/charts.svg" alt="">
+                                    <p class="ml-lg-3 mb-0"><strong>Pool Fee:&nbsp;</strong>{{floatToPercent .PoolFee }}</p>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </section>
             </div>
@@ -171,7 +179,7 @@
                                 {{ range .WorkQuotas }}
                                     <tr>
                                         <td>{{ printf "%.12s" .AccountID}}...</td>
-                                        <td>{{percentString .Percentage}}</td>
+                                        <td>{{ratToPercent .Percentage}}</td>
                                     </tr>
                                 {{else}}
                                     <tr>

--- a/pool.go
+++ b/pool.go
@@ -163,6 +163,7 @@ func NewPool(cfg *config) (*Pool, error) {
 		TLSKeyFile:    defaultTLSKeyFile,
 		ActiveNet:     cfg.net,
 		PaymentMethod: cfg.PaymentMethod,
+		Designation:   cfg.Designation,
 	}
 
 	p.gui, err = gui.NewGUI(gcfg, p.hub, p.db)

--- a/pool.go
+++ b/pool.go
@@ -164,6 +164,7 @@ func NewPool(cfg *config) (*Pool, error) {
 		ActiveNet:     cfg.net,
 		PaymentMethod: cfg.PaymentMethod,
 		Designation:   cfg.Designation,
+		PoolFee:       cfg.PoolFee,
 	}
 
 	p.gui, err = gui.NewGUI(gcfg, p.hub, p.db)

--- a/util/format.go
+++ b/util/format.go
@@ -67,12 +67,18 @@ func HashString(hash *big.Rat) string {
 	return "< 1KH/s"
 }
 
-// PercentString formats the provided big.Rat as a percentage,
+// RatToPercent formats the provided big.Rat as a percentage,
 // rounded to the nearest decimal place. eg. "10.5%"
-func PercentString(rat *big.Rat) string {
+func RatToPercent(rat *big.Rat) string {
 	real, _ := rat.Float64()
-	real = real * 100
-	str := fmt.Sprintf("%.1f", real)
+	return FloatToPercent(real)
+}
+
+// FloatToPercent formats the provided float64 as a percentage,
+// rounded to the nearest decimal place. eg. "10.5%"
+func FloatToPercent(rat float64) string {
+	rat = rat * 100
+	str := fmt.Sprintf("%.1f", rat)
 	return str + "%"
 }
 


### PR DESCRIPTION
- Make pool designation configurable (as per the specification for VSP design)
- Show `PoolFee` and `Network` in Pool Information

![Screenshot from 2019-06-23 11-16-59](https://user-images.githubusercontent.com/6762864/59974834-7581dc80-95a8-11e9-834a-ed382313ce3a.png)

Closes #93 