### PR TITLE
gui: display miner config info

### DIFF
--- a/gui/index.go
+++ b/gui/index.go
@@ -12,6 +12,7 @@ import (
 
 type indexData struct {
 	PoolStats        *network.PoolStats
+	PoolDomain       string
 	WorkQuotas       []network.Quota
 	PoolHashRate     *big.Rat
 	SoloPool         bool
@@ -61,6 +62,7 @@ func (ui *GUI) GetIndex(w http.ResponseWriter, r *http.Request) {
 		PaymentMethod:    ui.cfg.PaymentMethod,
 		PoolStats:        poolStats,
 		PoolHashRate:     poolHashRate,
+		PoolDomain:       ui.cfg.Domain,
 		SoloPool:         ui.cfg.SoloPool,
 		Admin:            false,
 		BlockExplorerURL: ui.cfg.BlockExplorerURL,

--- a/gui/public/css/dcrpool.css
+++ b/gui/public/css/dcrpool.css
@@ -8089,9 +8089,26 @@ input[type="submit"]:disabled {
   .block__content {
     background-color: #223767;
     padding: 20px 30px; }
-    .block__content p {
+    .block__content p,
+    .block__content li,
+    .block__content td,
+    .block__content th {
       color: #99C1E3;
       line-height: 1.4; }
+    .block__content th {
+      font-weight: bold;
+      padding-right: 15px;
+      text-align: right;
+    }
+    .block__content table td,
+    .block__content table th {
+      vertical-align: top;
+      word-wrap: break-word;
+      white-space: normal; }
+    .block__content table td .config {
+      font-family: "dcrpool-code";
+      background: none;
+      color: #E9F8FE; }
     .block__content span {
       border-radius: 2px;
       background-color: #d4f0fd;

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -62,10 +62,11 @@
                             <div style="overflow: auto; max-height: 250px;">
                                 <table class="table">
                                     <tr>
-                                        <th>Height</th>
-                                        <th>Paid on Height</th>
+                                        <th>Work Height</th>
+                                        <th>Payment Height</th>
                                         <th>Created On</th>
                                         <th>Amount</th>
+                                        <th>Tx ID</th>
                                     </tr>
                                     {{ range .AccountStats.Payments }}
                                     <tr>
@@ -73,6 +74,7 @@
                                         <td><a href={{$.BlockExplorerURL}}/block/{{.PaidOnHeight}} rel="noopener noreferrer">{{.PaidOnHeight}}</a></td>
                                         <td>{{ time .CreatedOn }}</td>
                                         <td>{{ printf "%.3f" .Amount.ToCoin }}&nbsp;DCR</td>
+                                        <td><a href="{{$.BlockExplorerURL}}/tx/{{ .TransactionID }}">{{ printf "%.10s" .TransactionID }}...</a></td>
                                     </tr>
                                     {{else}}
                                     <tr>
@@ -102,12 +104,69 @@
                             <h1><span>Mining Pool Overview</span></h1>
                         </div>
                         <div class="col-12 block__content">
-                            <p>Voting Service Providers (VSPs) allow you to participate in Decred’s proof-of-stake (PoS) system without the need to keep a constantly unlocked wallet or worry about losses due to downtime, flaky internet.</p>
+                            <p>You don't need to create an account to mine with dcrpool. Simply direct your miner to the pool and provide an address for receiving reward payments.</p>
 
-                            <p>VSPs are used to delegate your voting powers. The VSP can cast a vote on your behalf when a ticket is called to vote. VSPs do not hold, manage, or transfer any of your DCR funds. The VSP cannot steal your funds.</p>
+                            <p>If you have contributed some work to the pool, you can search for your mining address in the toolbar above. You can view your contributions to the pool and any payment information.</p>
 
-                            <a href="/" class="btn btn-outline-primary btn-outline-primary--inverted d-lg-inline-block d-block mb-3" rel="noopener noreferrer">Register</a>
+                            <p>The pool currently supports the following miners:</p>
+
+                            <ul>
+                                <li>Innosilicon D9</li>
+                                <li>Antminer DR3</li>
+                                <li>Antminer DR5</li>
+                                <li>Whatsminer D1</li>
+                            </ul>
+
                         </div>
+                    </section>
+
+                    <section class="block">
+                        <div class="col-12 block__title">
+                            <h1><span>Miner Configuration</span></h1>
+                        </div>
+                        <div class="col-12 block__content">
+                            
+                            <table>
+                                <tr>
+                                    <th>Pool URL:</th>
+                                    <td><span class="config">{{if .PoolDomain}}{{.PoolDomain}}{{else}}localhost{{end}}</span></td>
+                                </tr>
+                                <tr>
+                                    <td><br/></td>
+                                </tr>
+                                <tr>
+                                    <th>Port:</th>
+                                    <td><span class="config">5552</span>&nbsp;(Innosilicon D9)</td>
+                                </tr>
+                                <tr>
+                                    <th></th>
+                                    <td><span class="config">5553</span>&nbsp;(Antminer DR3)</td>
+                                </tr>
+                                <tr>
+                                    <th></th>
+                                    <td><span class="config">5554</span>&nbsp;(Antminer DR5)</td>
+                                </tr>
+                                <tr>
+                                    <th></th>
+                                    <td><span class="config">5555</span>&nbsp;(Whatsminer D1)</td>
+                                </tr>
+                                <tr>
+                                    <td><br/></td>
+                                </tr>
+                                <tr>
+                                    <th>Username:</th>
+                                    <td>
+                                    {{ if .SoloPool }}
+                                        Any unique name identifying the client
+                                    {{else}}
+                                        The payment address for receiving rewards and a unique name identifying the client, formatted as <span class="config">address.name</span>
+                                    {{end}}
+                                    </td>
+                                </tr>
+                            </table>
+
+                        </div>
+
                     </section>
                 </div>
 

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -215,6 +215,7 @@
                 </section>
             </div>
 
+            {{ with .WorkQuotas}}
             <div class="row ml-md-1">
                 <section class="block">
                     <div class="col-12 block__title">
@@ -227,14 +228,10 @@
                                     <th>Account</th>
                                     <th>Reward Percentage</th>
                                 </tr>
-                                {{ range .WorkQuotas }}
+                                {{ range . }}
                                     <tr>
                                         <td>{{ printf "%.12s" .AccountID}}...</td>
                                         <td>{{percentString .Percentage}}</td>
-                                    </tr>
-                                {{else}}
-                                    <tr>
-                                        <td colspan="100%">No work quotas</td>
                                     </tr>
                                 {{end}}
                             </table>
@@ -242,6 +239,7 @@
                     </div>
                 </section>
             </div>
+            {{end}}
             
             <div class="row ml-md-1">
                 <section class="block">

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -108,15 +108,6 @@
 
                             <p>If you have contributed some work to the pool, you can search for your mining address in the toolbar above. You can view your contributions to the pool and any payment information.</p>
 
-                            <p>The pool currently supports the following miners:</p>
-
-                            <ul>
-                                <li>Innosilicon D9</li>
-                                <li>Antminer DR3</li>
-                                <li>Antminer DR5</li>
-                                <li>Whatsminer D1</li>
-                            </ul>
-
                         </div>
                     </section>
 

--- a/network/hub.go
+++ b/network/hub.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -999,8 +998,7 @@ type Quota struct {
 // based on work contributed per the peyment scheme used by the pool.
 func (h *Hub) FetchWorkQuotas() ([]Quota, error) {
 	if h.cfg.SoloPool {
-		return nil, errors.New("share percentages not available when mining" +
-			" in solo pool mode")
+		return nil, nil
 	}
 
 	height := atomic.LoadUint32(&h.lastWorkHeight)


### PR DESCRIPTION
- Add miner configuration info to the home page (Closes #86)
- Add links to the block explorer for payments (Closes #99)
- Fix an issue where GUI was completely broken in solo pool mode. It was hitting an error attempting to retrieve work quotas which were not available. This section of the front page is no longer drawn when the pool is in solo mode.

![Screenshot from 2019-06-24 21-57-05](https://user-images.githubusercontent.com/6762864/60051846-d8b85f80-96cb-11e9-913d-638062abc0ab.png)
