### PR TITLE
multi: miner port config.

### DIFF
--- a/cmd/miner/cpuminer.go
+++ b/cmd/miner/cpuminer.go
@@ -105,8 +105,11 @@ func (m *CPUMiner) solveBlock(ctx context.Context, headerB []byte, target *big.I
 					return false
 
 				case <-ticker.C:
-					m.updateHashes <- hashesCompleted
-					hashesCompleted = 0
+					select {
+					case m.updateHashes <- hashesCompleted:
+						hashesCompleted = 0
+					default:
+					}
 
 				case <-m.miner.chainCh:
 					// Stop current work if the chain updates or a new work

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -53,7 +53,6 @@ func main() {
 			miner.cancel()
 
 		case <-ctx.Done():
-			miner.conn.Close()
 			return
 		}
 	}()

--- a/config.go
+++ b/config.go
@@ -51,6 +51,11 @@ const (
 	defaultGUIDir          = "gui"
 	defaultUseLEHTTPS      = false
 	defaultDesignation     = "MyPool"
+	defaultCPUPort         = 5550
+	defaultD9Port          = 5552
+	defaultDR3Port         = 5553
+	defaultDR5Port         = 5554
+	defaultD1Port          = 5555
 )
 
 var (
@@ -104,6 +109,11 @@ type config struct {
 	Domain          string   `long:"domain" ini-name:"domain" description:"The domain of the mining pool, required for TLS."`
 	UseLEHTTPS      bool     `long:"uselehttps" ini-name:"uselehttps" description:"This enables HTTPS using a Letsencrypt certificate. By default the pool uses a self-signed certificate for HTTPS."`
 	Designation     string   `long:"designation" ini-name:"designation" description:"The designated codename for this pool. Customises the logo in the top toolbar."`
+	CPUPort         uint32   `long:"cpuport" ini-name:"cpuport" description:"CPU miner connection port."`
+	D9Port          uint32   `long:"d9port" ini-name:"d9port" description:"Innosilicon D9 connection port."`
+	DR3Port         uint32   `long:"dr3port" ini-name:"dr3port" description:"Antminer DR3 connection port."`
+	DR5Port         uint32   `long:"dr5port" ini-name:"dr5port" description:"Antminer DR5 connection port."`
+	D1Port          uint32   `long:"d1port" ini-name:"d1port" description:"Whatsminer D1 connection port."`
 	poolFeeAddrs    []dcrutil.Address
 	dcrdRPCCerts    []byte
 	net             *chaincfg.Params
@@ -325,6 +335,11 @@ func loadConfig() (*config, []string, error) {
 		GUIDir:          defaultGUIDir,
 		UseLEHTTPS:      defaultUseLEHTTPS,
 		Designation:     defaultDesignation,
+		CPUPort:         defaultCPUPort,
+		D9Port:          defaultD9Port,
+		DR3Port:         defaultDR3Port,
+		DR5Port:         defaultDR5Port,
+		D1Port:          defaultD1Port,
 	}
 
 	// Service options which are only added on Windows.

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -61,18 +61,6 @@ var (
 	// pool clients since pool shares are a non factor in solo pool mode.
 	soloMaxGenTime = new(big.Int).SetInt64(28)
 
-	// minerPorts is a map of all supported miners and their coresponding
-	// connection ports.
-	//
-	// Port 5551 has been reserved for the Obelisk DCR1.
-	minerPorts = map[string]uint32{
-		CPU:           5550,
-		InnosiliconD9: 5552,
-		AntminerDR3:   5553,
-		AntminerDR5:   5554,
-		WhatsminerD1:  5555,
-	}
-
 	// minerHashes is a map of all known DCR miners and their coressponding
 	// hashrates.
 	minerHashes = map[string]*big.Int{
@@ -103,6 +91,7 @@ type HubConfig struct {
 	BackupPass        string
 	Secret            string
 	NonceIterations   float64
+	MinerPorts        map[string]uint32
 }
 
 // DifficultyData captures the pool target difficulty and pool difficulty
@@ -398,7 +387,7 @@ func NewHub(ctx context.Context, cancel context.CancelFunc, httpc *http.Client, 
 	}
 
 	// Setup listeners for all supported pool clients.
-	for miner, port := range minerPorts {
+	for miner, port := range h.cfg.MinerPorts {
 		endpoint, err := newEndpoint(h, port, miner)
 		if err != nil {
 			return nil, MakeError(ErrOther, "failed to create listeners", err)


### PR DESCRIPTION
This adds miner listening port configuration options to the pool. The old ports used are now the default
ports of the miners.