### PR TITLE
pool: fix client read goroutine termination.

### DIFF
--- a/pool/message.go
+++ b/pool/message.go
@@ -150,6 +150,10 @@ func IdentifyMessage(data []byte) (Message, string, error) {
 		return nil, "", err
 	}
 
+	if resp.ID == 0 {
+		return nil, "", fmt.Errorf("unable to parse message")
+	}
+
 	return &resp, ResponseType, nil
 }
 


### PR DESCRIPTION
This fixes an issue where the read goroutine of a client lingers due to the client sending invalid messages.