### PR TITLE
multi: Pass contexts.

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -122,13 +122,12 @@ func newPool(cfg *config) (*miningPool, error) {
 		MaxConnectionsPerHost: cfg.MaxConnectionsPerHost,
 	}
 
-	p.hub, err = pool.NewHub(p.ctx, p.cancel, p.httpc, hcfg, p.limiter)
+	p.hub, err = pool.NewHub(p.cancel, p.httpc, hcfg, p.limiter)
 	if err != nil {
 		return nil, err
 	}
 
 	gcfg := &gui.Config{
-		Ctx:           p.ctx,
 		SoloPool:      cfg.SoloPool,
 		GUIDir:        cfg.GUIDir,
 		BackupPass:    cfg.BackupPass,

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -31,7 +31,6 @@ import (
 
 // Config represents configuration details for the pool user interface.
 type Config struct {
-	Ctx              context.Context
 	SoloPool         bool
 	PaymentMethod    string
 	GUIDir           string


### PR DESCRIPTION
This removes context fields from structs with preference of passing them where needed, as should be for contexts. The expected hashrate for a cpu miner has been reduced further to make it easier to mine on cheap single core cloud servers.