### PR TITLE
multi: add fetchPaymentsForAccount.

### DIFF
--- a/config.go
+++ b/config.go
@@ -97,7 +97,7 @@ type config struct {
 	MaxTxFeeReserve       float64  `long:"maxtxfeereserve" ini-name:"maxtxfeereserve" description:"The maximum amount reserved for transaction fees, in DCR."`
 	MaxGenTime            uint64   `long:"maxgentime" ini-name:"maxgentime" description:"The share creation target time for the pool in seconds. This currently should be below 30 seconds to increase the likelihood a work submission for clients between new work distributions by the pool."`
 	PaymentMethod         string   `long:"paymentmethod" ini-name:"paymentmethod" description:"The payment method of the pool. {pps, pplns}"`
-	LastNPeriod           uint32   `long:"lastnperiod" ini-name:"lastnperiod" description:"The time period of interest, when using PPLNS payment scheme."`
+	LastNPeriod           uint32   `long:"lastnperiod" ini-name:"lastnperiod" description:"The time period of interest, in seconds, when using PPLNS payment scheme."`
 	WalletPass            string   `long:"walletpass" ini-name:"walletpass" description:"The wallet passphrase."`
 	MinPayment            float64  `long:"minpayment" ini-name:"minpayment" description:"The minimum payment to process for an account."`
 	SoloPool              bool     `long:"solopool" ini-name:"solopool" description:"Solo pool mode. This disables payment processing when enabled."`

--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// bufferSize represents the block notification buffer size.
-	bufferSize = 10
+	bufferSize = 128
 )
 
 type ChainStateConfig struct {
@@ -34,7 +34,7 @@ type ChainStateConfig struct {
 	HubWg *sync.WaitGroup
 }
 
-// blockNotification wraps a block header notification with a done channel.
+// blockNotification wraps a block header notification and a done channel.
 type blockNotification struct {
 	Header []byte
 	Done   chan bool

--- a/pool/endpoint.go
+++ b/pool/endpoint.go
@@ -46,7 +46,7 @@ type EndpointConfig struct {
 	FetchHostConnections func(string) uint32
 }
 
-// connection wraps a client connection a done channel.
+// connection wraps a client connection and a done channel.
 type connection struct {
 	Conn net.Conn
 	Done chan bool

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -632,7 +632,7 @@ func (h *Hub) FetchMinedWorkByAccount(id string) ([]*AcceptedWork, error) {
 // FetchPaymentsForAccount returns a list or payments made to the provided address.
 // List is ordered, most recent comes first.
 func (h *Hub) FetchPaymentsForAccount(id string) ([]*Payment, error) {
-	payments, err := fetchArchivedPaymentsForAccount(h.db, id, 10)
+	payments, err := fetchPaymentsForAccount(h.db, id, 10)
 	return payments, err
 }
 

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -167,12 +167,18 @@ func testHub(t *testing.T, db *bolt.DB) {
 	}
 
 	// Send the cpu endpoint a client-side connection.
-	connA, _, err := makeConn(ln, serverCh)
+	connA, srvA, err := makeConn(ln, serverCh)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	cpuEndpoint.connCh <- connA
-	time.Sleep(time.Millisecond * 100)
+	defer connA.Close()
+	defer srvA.Close()
+	msgA := &connection{
+		Conn: connA,
+		Done: make(chan bool),
+	}
+	cpuEndpoint.connCh <- msgA
+	<-msgA.Done
 	if !hub.HasClients() {
 		t.Fatal("expected hub to have clients")
 	}

--- a/pool/payment_test.go
+++ b/pool/payment_test.go
@@ -158,8 +158,6 @@ func testAccountPayments(t *testing.T, db *bolt.DB) {
 		}
 	}
 
-	time.Sleep(time.Millisecond * 10)
-
 	// Create archived payments for account X.
 	abx := makePaymentBundle(xID, count, amt)
 	abx.UpdateAsPaid(db, 10, "")

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -23,8 +23,8 @@ type PaymentMgrConfig struct {
 	ActiveNet *chaincfg.Params
 	// PoolFee represents the fee charged to participating accounts of the pool.
 	PoolFee float64
-	// LastNPeriod represents the period to source shares from with the
-	// PPLNS payment scheme.
+	// LastNPeriod represents the period, in seconds, to source shares from
+	// with the PPLNS payment scheme.
 	LastNPeriod uint32
 	// SoloPool represents the solo pool mining mode.
 	SoloPool bool

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -101,6 +101,7 @@ func TestPool(t *testing.T) {
 	testCalculatePoolTarget(t)
 	testGeneratePaymentDetails(t, db)
 	testArchivedPaymentsFiltering(t, db)
+	testAccountPayments(t, db)
 	testDifficulty(t)
 	testEndpoint(t, db)
 	testClient(t, db)


### PR DESCRIPTION
This fixes a channel sync issue with endpoint tests and adds `fetchPaymentsForAccount` for listing both pending and archived payments for an account.