### PR TITLE
multi: improve timestamp-rolled work.

### DIFF
--- a/cmd/miner/config.go
+++ b/cmd/miner/config.go
@@ -42,16 +42,17 @@ var runServiceCommand func(string) error
 
 // config describes the connection parameters for the client.
 type config struct {
-	HomeDir    string `long:"homedir" description:"Path to application home directory"`
-	ConfigFile string `long:"configfile" description:"Path to configuration file"`
-	ActiveNet  string `long:"activenet" description:"The active network being mined on. {simnet, testnet, mainnet}"`
-	User       string `long:"user" description:"The username of the mining account"`
-	Address    string `long:"address" description:"The address of the mining account"`
-	Pool       string `long:"pool" description:"The stratum domain and port of the mining pool to connect to. eg. dcrpool.com:4445"`
-	DebugLevel string `long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	LogDir     string `long:"logdir" description:"The log output directory."`
-	MaxProcs   int    `long:"maxprocs" description:"Number of CPU cores to use. Default is all cores."`
-	Profile    string `long:"profile" init-name:"Enable HTTP profiling on given [addr:]port -- NOTE port must be between 1024 and 65536"`
+	HomeDir    string `long:"homedir" ini-name:"homedir" description:"Path to application home directory"`
+	ConfigFile string `long:"configfile" ini-name:"configfile" description:"Path to configuration file"`
+	ActiveNet  string `long:"activenet" ini-name:"activenet" description:"The active network being mined on. {simnet, testnet, mainnet}"`
+	User       string `long:"user" ini-name:"user" description:"The username of the mining account"`
+	Address    string `long:"address" ini-name:"address" description:"The address of the mining account"`
+	Pool       string `long:"pool" ini-name:"pool" description:"The stratum domain and port of the mining pool to connect to. eg. dcrpool.com:4445"`
+	DebugLevel string `long:"debuglevel" ini-name:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	LogDir     string `long:"logdir" ini-name:"logdir" description:"The log output directory."`
+	MaxProcs   int    `long:"maxprocs" ini-name:"maxprocs" description:"Number of CPU cores to use. Default is all cores."`
+	Profile    string `long:"profile" ini-name:"profile" description:"Enable HTTP profiling on given [addr:]port -- NOTE port must be between 1024 and 65536"`
+	Stall      bool   `long:"stall" ini-name:"stall" description:"Do not generate work submissions"`
 
 	net *chaincfg.Params
 }

--- a/config.go
+++ b/config.go
@@ -108,8 +108,8 @@ type config struct {
 	TLSCert               string   `long:"tlscert" ini-name:"tlscert" description:"Path to the TLS cert file."`
 	TLSKey                string   `long:"tlskey" ini-name:"tlskey" description:"Path to the TLS key file."`
 	Designation           string   `long:"designation" ini-name:"designation" description:"The designated codename for this pool. Customises the logo in the top toolbar."`
-	MaxConnectionsPerHost uint32   `long:"maxconnperhost" init-name:"maxconnperhost" description:"The maximum number of connections allowed per host."`
-	Profile               string   `long:"profile" init-name:"profile" description:"Enable HTTP profiling on given [addr:]port -- NOTE port must be between 1024 and 65536"`
+	MaxConnectionsPerHost uint32   `long:"maxconnperhost" ini-name:"maxconnperhost" description:"The maximum number of connections allowed per host."`
+	Profile               string   `long:"profile" ini-name:"profile" description:"Enable HTTP profiling on given [addr:]port -- NOTE port must be between 1024 and 65536"`
 	CPUPort               uint32   `long:"cpuport" ini-name:"cpuport" description:"CPU miner connection port."`
 	D9Port                uint32   `long:"d9port" ini-name:"d9port" description:"Innosilicon D9 connection port."`
 	DR3Port               uint32   `long:"dr3port" ini-name:"dr3port" description:"Antminer DR3 connection port."`

--- a/pool/client.go
+++ b/pool/client.go
@@ -381,7 +381,7 @@ func (c *Client) handleSubmitWorkRequest(req *Request, allowed bool) {
 	}
 	hash := header.BlockHash()
 	hashTarget := new(big.Rat).SetInt(standalone.HashToBig(&hash))
-	netDiff := new(big.Rat).Quo(diffInfo.powLimit, diffInfo.target)
+	netDiff := new(big.Rat).Quo(diffInfo.powLimit, target)
 	hashDiff := new(big.Rat).Quo(diffInfo.powLimit, hashTarget)
 	log.Tracef("network difficulty is: %s", netDiff.FloatString(4))
 	log.Tracef("pool difficulty is: %s", diffInfo.difficulty.FloatString(4))
@@ -491,6 +491,7 @@ func (c *Client) read() {
 		data, err := c.reader.ReadBytes('\n')
 		if err != nil {
 			if err == io.EOF {
+				log.Errorf("%s: EOF", c.id)
 				c.cancel()
 				return
 			}

--- a/pool/endpoint.go
+++ b/pool/endpoint.go
@@ -30,6 +30,9 @@ type EndpointConfig struct {
 	// MaxConnectionsPerHost represents the maximum number of connections
 	// allowed per host.
 	MaxConnectionsPerHost uint32
+	// MaxGenTime represents the share creation target time for the pool
+	// in seconds.
+	MaxGenTime uint64
 	// HubWg represents the hub's waitgroup.
 	HubWg *sync.WaitGroup
 	// SubmitWork sends solved block data to the consensus daemon.
@@ -164,6 +167,7 @@ func (e *Endpoint) connect(ctx context.Context) {
 				FetchCurrentWork:  e.cfg.FetchCurrentWork,
 				WithinLimit:       e.cfg.WithinLimit,
 				HashCalcThreshold: hashCalcThreshold,
+				MaxGenTime:        e.cfg.MaxGenTime,
 			}
 			client, err := NewClient(msg.Conn, tcpAddr, cCfg)
 			if err != nil {

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -333,6 +333,7 @@ func (h *Hub) Listen() error {
 			AddConnection:         h.addConnection,
 			RemoveConnection:      h.removeConnection,
 			FetchHostConnections:  h.fetchHostConnections,
+			MaxGenTime:            h.cfg.MaxGenTime,
 		}
 		endpoint, err := NewEndpoint(eCfg, diffInfo, port, miner)
 		if err != nil {


### PR DESCRIPTION
This resolves a case where a client stalling on current work doesn't receive timestamp-rolled work. Network difficulty log calculation errors and config related typos have been fixed as well.

