### PR TITLE
miner: fix miner shutdown panic.

### DIFF
--- a/cmd/miner/cpuminer.go
+++ b/cmd/miner/cpuminer.go
@@ -187,6 +187,7 @@ func (m *CPUMiner) solve(ctx context.Context) {
 			case <-ctx.Done():
 				m.miner.wg.Done()
 				return
+
 			default:
 				continue
 			}
@@ -208,18 +209,19 @@ func (m *CPUMiner) solve(ctx context.Context) {
 				m.workData.extraNonce2, m.workData.nTime, m.workData.nonce)
 			m.workCh <- req
 
+			// Stall to prevent mining too quickly.
+			time.Sleep(time.Millisecond * 500)
+
 		case false:
 			select {
 			case <-ctx.Done():
 				m.miner.wg.Done()
 				return
+
 			default:
 				// Non-blocking receive fallthrough.
 			}
 		}
-
-		// Stall to prevent mining too quickly.
-		time.Sleep(time.Millisecond * 500)
 	}
 }
 


### PR DESCRIPTION
This updates miner shutdown processes to avoid prematurely closing channels or blocking on a send or receive when shutting down, all processes fully terminate before the miner shuts down.