### PR TITLE
Prevent panic when logger is not initialised

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -179,7 +179,6 @@ func main() {
 	// and configures it accordingly.
 	cfg, _, err := loadConfig()
 	if err != nil {
-		mpLog.Error(err)
 		return
 	}
 	defer func() {


### PR DESCRIPTION
Using `mpLog` in the error handler for `loadConfig()` can cause a panic because this function is where the logger is initialised, and initialisation may not have occured yet.

```
error parsing config file: /home/jholdstock/harness/pool/pool.conf:15: unknown option: backup
Use dcrpool -h to show usage
2020-02-23 18:41:02.940 [ERR] MP: /home/jholdstock/harness/pool/pool.conf:15: unknown option: backup
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xa64506]

goroutine 1 [running]:
github.com/jrick/logrotate/rotator.(*Rotator).Write(0x0, 0xc0000ce200, 0x65, 0x78, 0x65, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/logrotate@v1.0.0/rotator/rotator.go:133 +0x26
main.logWriter.Write(0xc0000ce200, 0x65, 0x78, 0x43, 0xc0001d88f0, 0x0)
        /home/jholdstock/code/jholdstock/dcrpool/log.go:26 +0x7d
github.com/decred/slog.(*Backend).print(0xc0004d0b40, 0xc482a3, 0x3, 0xc480ed, 0x2, 0xc0001b9b70, 0x1, 0x1)
        /home/jholdstock/code/gopath/pkg/mod/github.com/decred/slog@v1.0.0/log.go:283 +0x25f
github.com/decred/slog.(*slog).Error(0xc0004d0b60, 0xc0001b9b70, 0x1, 0x1)
        /home/jholdstock/code/gopath/pkg/mod/github.com/decred/slog@v1.0.0/log.go:425 +0x85
main.main()
        /home/jholdstock/code/jholdstock/dcrpool/dcrpool.go:182 +0x137
```

To recreate, add an invalid config item to `dcrpool.conf`

`loadConfig()` already contains its own logging to stdout, so we don't need the line removed by this PR anyway.