### PR TITLE
pool: refactor & improve chainstate test coverage.

### DIFF
--- a/pool/acceptedwork.go
+++ b/pool/acceptedwork.go
@@ -244,9 +244,9 @@ func listMinedWorkByAccount(db *bolt.DB, accountID string, n int) ([]*AcceptedWo
 	return minedWork, nil
 }
 
-// PruneAcceptedWork removes all accepted work not confirmed as mined work with
+// pruneAcceptedWork removes all accepted work not confirmed as mined work with
 // heights less than the provided height.
-func PruneAcceptedWork(db *bolt.DB, height uint32) error {
+func pruneAcceptedWork(db *bolt.DB, height uint32) error {
 	err := db.Update(func(tx *bolt.Tx) error {
 		bkt, err := fetchWorkBucket(tx)
 		if err != nil {

--- a/pool/acceptedwork_test.go
+++ b/pool/acceptedwork_test.go
@@ -173,7 +173,7 @@ func testAcceptedWork(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure mined work cannot be pruned.
-	err = PruneAcceptedWork(db, workD.Height+1)
+	err = pruneAcceptedWork(db, workD.Height+1)
 	if err != nil {
 		t.Fatalf("PruneAcceptedWork error: %v", err)
 	}
@@ -201,7 +201,7 @@ func testAcceptedWork(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure unconfirmed work can be pruned.
-	err = PruneAcceptedWork(db, workD.Height+1)
+	err = pruneAcceptedWork(db, workD.Height+1)
 	if err != nil {
 		t.Fatalf("PruneAcceptedWork error: %v", err)
 	}

--- a/pool/job.go
+++ b/pool/job.go
@@ -121,8 +121,8 @@ func (job *Job) Delete(db *bolt.DB) error {
 	return deleteEntry(db, jobBkt, []byte(job.UUID))
 }
 
-// PruneJobs removes all jobs with heights less than the provided height.
-func PruneJobs(db *bolt.DB, height uint32) error {
+// pruneJobs removes all jobs with heights less than the provided height.
+func pruneJobs(db *bolt.DB, height uint32) error {
 	heightBE := heightToBigEndianBytes(height)
 	err := db.Update(func(tx *bolt.Tx) error {
 		bkt, err := fetchJobBucket(tx)

--- a/pool/job_test.go
+++ b/pool/job_test.go
@@ -70,7 +70,7 @@ func testJob(t *testing.T, db *bolt.DB) {
 	jobB.Height = 57
 
 	// Ensure jobs can be pruned.
-	err = PruneJobs(db, 57)
+	err = pruneJobs(db, 57)
 	if err != nil {
 		t.Fatalf("PruneJobs error: %v", err)
 	}


### PR DESCRIPTION
This fixes a bug with the chainstate where disconnected mined blocks were deleted instead of being unconfirmed. Disconnected blocks are also used to unconfirm mined work if the mined work is the associated parent. Additional tests have been added accordingly.