### PR TITLE
multi: refactor connection creation out of hub.

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -143,7 +143,7 @@ func newPool(cfg *config) (*miningPool, error) {
 	p.hub.SetNodeConnection(nodeConn)
 
 	// Establish a connection to the wallet if the pool is mining as a
-	// publicly available mining poolin solo.
+	// publicly available mining pool.
 	if !cfg.SoloPool {
 		creds, err := credentials.
 			NewClientTLSFromFile(cfg.WalletRPCCert, "localhost")

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/dcrutil/v2 v2.0.1
 	github.com/decred/dcrd/mempool/v3 v3.1.0
+	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.0
 	github.com/decred/dcrd/rpcclient/v5 v5.0.0
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/dcrwallet/rpc/walletrpc v0.3.0

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -179,6 +179,7 @@ func testPaymentMgr(t *testing.T, db *bolt.DB) {
 			"after feeA replenish to be %d, got %d", feeReserve+feeA, updatedTFR)
 	}
 
+	txFeeReserve = mgr.fetchTxFeeReserve()
 	feeB, err := dcrutil.NewAmount(2)
 	if err != nil {
 		t.Fatalf("[NewAmount] unexpected error: %v", err)
@@ -186,7 +187,7 @@ func testPaymentMgr(t *testing.T, db *bolt.DB) {
 	updatedFeeB := mgr.replenishTxFeeReserve(feeB)
 	if updatedFeeB >= feeB {
 		t.Fatalf("[replenishTxFeeReserve] expected fees after replenishing "+
-			" with feeB to be %d, got %d", zeroAmount, updatedFeeA)
+			" with feeB to be %d, got %d", feeB-(maxTxFeeReserve-txFeeReserve), updatedFeeB)
 	}
 	updatedTFR = mgr.fetchTxFeeReserve()
 	if updatedTFR != maxTxFeeReserve {


### PR DESCRIPTION
This refactors establishing node and wallet connections out of the hub which ultimately makes it easier to test. The hub's configuration struct has been updated to remove now unnecessary details.