### PR TITLE
gui: Implement new style errors.

### DIFF
--- a/gui/account.go
+++ b/gui/account.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gui
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/decred/dcrpool/pool"
+	"github.com/gorilla/csrf"
+	"github.com/gorilla/mux"
+)
+
+// accountPageData contains all of the necessary information to render the
+// account template.
+type accountPageData struct {
+	HeaderData       headerData
+	MinedWork        []*pool.AcceptedWork
+	Payments         []*pool.Payment
+	Clients          []*pool.ClientInfo
+	AccountID        string
+	Address          string
+	BlockExplorerURL string
+}
+
+// Account is the handler for "GET /account/{address}". Renders the account
+// template if the provided address is valid and has associated account
+// information, otherwise renders the index template with an appopriate error
+// message.
+func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		http.Error(w, "Session error", http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	address := mux.Vars(r)["address"]
+	if address == "" {
+		ui.renderIndex(w, r, "No address provided")
+		return
+	}
+
+	// Generate the account id of the provided address.
+	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
+	if err != nil {
+		ui.renderIndex(w, r, "Unable to generate account ID for address")
+		return
+	}
+
+	if !ui.cfg.AccountExists(accountID) {
+		ui.renderIndex(w, r, "Nothing found for address")
+		return
+	}
+
+	work, err := ui.cfg.FetchMinedWorkByAccount(accountID)
+	if err != nil {
+		ui.renderIndex(w, r, fmt.Sprintf("FetchMinedWorkByAddress error: %v",
+			err.Error()))
+		return
+
+	}
+
+	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
+	if err != nil {
+		ui.renderIndex(w, r, fmt.Sprintf("FetchPaymentsForAddress error: %v",
+			err.Error()))
+		return
+	}
+
+	data := &accountPageData{
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    true,
+		},
+		MinedWork:        work,
+		Payments:         payments,
+		Clients:          ui.cfg.FetchAccountClientInfo(accountID),
+		AccountID:        accountID,
+		Address:          address,
+		BlockExplorerURL: ui.cfg.BlockExplorerURL,
+	}
+
+	ui.renderTemplate(w, "account", data)
+}
+
+// IsPoolAccount is the handler for "GET /account_exist". If the provided
+// address has an account on the server a "200 OK" response is returned,
+// otherwise a "400 Bad Request" is returned.
+func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		http.Error(w, "Session error", http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	address := r.FormValue("address")
+
+	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
+	if err != nil {
+		http.Error(w, "Invalid address", http.StatusBadRequest)
+		return
+	}
+
+	if !ui.cfg.AccountExists(accountID) {
+		http.Error(w, "Nothing found for address", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package gui
 
 import (
-	"html/template"
 	"net/http"
 
 	"github.com/gorilla/csrf"
@@ -13,12 +12,12 @@ import (
 	"github.com/decred/dcrpool/pool"
 )
 
+// adminPageData contains all of the necessary information to render the admin
+// template.
 type adminPageData struct {
-	Connections map[string][]*pool.ClientInfo
-	CSRF        template.HTML
-	Designation string
-	PoolStats   poolStats
-	Admin       bool
+	HeaderData    headerData
+	PoolStatsData poolStatsData
+	Connections   map[string][]*pool.ClientInfo
 }
 
 // AdminPage is the handler for "GET /admin". If the current session is
@@ -46,22 +45,22 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 	poolHash := ui.poolHash
 	ui.poolHashMtx.RUnlock()
 
-	poolStats := poolStats{
-		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
-		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		PaymentMethod:     ui.cfg.PaymentMethod,
-		Network:           ui.cfg.ActiveNet.Name,
-		PoolFee:           ui.cfg.PoolFee,
-		SoloPool:          ui.cfg.SoloPool,
-	}
-
 	pageData := adminPageData{
-		CSRF:        csrf.TemplateField(r),
-		Designation: ui.cfg.Designation,
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    false,
+		},
+		PoolStatsData: poolStatsData{
+			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
+			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
+			PoolHashRate:      poolHash,
+			PaymentMethod:     ui.cfg.PaymentMethod,
+			Network:           ui.cfg.ActiveNet.Name,
+			PoolFee:           ui.cfg.PoolFee,
+			SoloPool:          ui.cfg.SoloPool,
+		},
 		Connections: ui.cfg.FetchClientInfo(),
-		PoolStats:   poolStats,
-		Admin:       true,
 	}
 
 	ui.renderTemplate(w, "admin", pageData)

--- a/gui/assets/public/css/dcrpool.css
+++ b/gui/assets/public/css/dcrpool.css
@@ -1946,7 +1946,7 @@ textarea.form-control {
 
 .btn {
   display: inline-block;
-  font-weight: 400;
+  font-weight: bold;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -2004,8 +2004,8 @@ fieldset:disabled a.btn {
     border-color: #005cbf; }
     .btn-primary:not(:disabled):not(.disabled):active:focus, .btn-primary:not(:disabled):not(.disabled).active:focus,
     .show > .btn-primary.dropdown-toggle:focus {
-      -webkit-box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);
-              box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5); }
+      -webkit-box-shadow: none;
+              box-shadow: none; }
 
 .btn-secondary {
   color: #fff;
@@ -4342,26 +4342,30 @@ input[type="button"].btn-block {
     background-color: #1b1e21;
     border-color: #1b1e21; }
 
-.close {
+.modal-close {
   float: right;
   font-size: 1.7rem;
   font-weight: 100;
   line-height: 1;
   color: #000;
   text-shadow: 0 1px 0 #fff;
-  opacity: .4; }
-  .close:not(:disabled):not(.disabled) {
-    cursor: pointer; }
-    .close:not(:disabled):not(.disabled):hover, .close:not(:disabled):not(.disabled):focus {
-      color: #000;
-      text-decoration: none;
-      opacity: .65; }
-
-button.close {
   padding: 0;
   background-color: transparent;
   border: 0;
-  -webkit-appearance: none; }
+  -webkit-appearance: none;
+  opacity: .4; }
+.modal-close:not(:disabled):not(.disabled) {
+  cursor: pointer; }
+.modal-close:not(:disabled):not(.disabled):hover,
+.modal-close:not(:disabled):not(.disabled):focus {
+  color: #000;
+  text-decoration: none;
+  opacity: .65; }
+
+.modal-close:active,
+.modal-close:focus {
+  outline: none;
+}
 
 .modal-open {
   overflow: hidden; }
@@ -4440,11 +4444,11 @@ button.close {
   bottom: 0;
   left: 0;
   z-index: 1040;
-  background-color: #000; }
+  background-color: #091440; }
   .modal-backdrop.fade {
     opacity: 0; }
   .modal-backdrop.show {
-    opacity: 0.5; }
+    opacity: 0.3; }
 
 .modal-header {
   display: -webkit-box;
@@ -8334,20 +8338,6 @@ input[type="submit"]:disabled {
             box-shadow: 0 1px 2px 0 rgba(9, 20, 64, 0.21); }
     .modal-blockquote span {
       color: #fd704a; }
-  .modal-close {
-    padding: 0;
-    cursor: pointer;
-    -webkit-appearance: none !important;
-    border: 0;
-    background: transparent; }
-  .modal-close img {
-    vertical-align: super;
-  }
-    .modal-close:focus {
-      outline: none; }
-    @media (max-width: 1199.98px) {
-      .modal-close img {
-        width: 16px; } }
   .modal-header {
     border: 0; }
   .modal-dialog {
@@ -8359,8 +8349,6 @@ input[type="submit"]:disabled {
   .modal-header--long-title .modal-title {
     max-width: 60%;
     text-align: right; }
-  .modal-header--long-title .modal-close {
-    margin: -20px 0 4px 0; }
   .modal-header--long-title img {
     float: right; }
   .modal-header--long-title span {
@@ -8381,7 +8369,7 @@ input[type="submit"]:disabled {
     font-size: 28px;
     line-height: 1.26;
     letter-spacing: normal;
-    color: #48566e; }
+    color: #3D5873; }
     @media (max-width: 767.98px) {
       .modal-title {
         font-size: 18px; } }
@@ -8394,7 +8382,7 @@ input[type="submit"]:disabled {
         max-height: 100vh; } }
     .modal-body p {
       font-size: 16px;
-      color: #48566e; }
+      color: #091440; }
     .modal-body strong {
       color: #091440;
       margin-bottom: 1rem;

--- a/gui/assets/public/js/modal.js
+++ b/gui/assets/public/js/modal.js
@@ -48,7 +48,7 @@ $("#account-form").on("submit", function (e) {
         type: $(this).attr('method'),
         data: $(this).serialize(),
         success: function() {
-            window.location.replace("/?address="+address);
+            window.location.replace("/account/"+address);
         },
         error: function(response) {
             if (response.status === 400 || response.status === 429) {

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -1,5 +1,5 @@
 {{define "account"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
 <noscript style="display:inherit;">
     <div class="snackbar snackbar-warning">
@@ -18,7 +18,7 @@
             <div class="col-lg-7 col-12 py-2">
                 <div class="d-flex flex-column">
                     <div class="account-info-title pb-2">Account</div>
-                    <div><span class="dcr-label">{{.AccountStats.AccountID}}</span></div>
+                    <div><span class="dcr-label">{{.AccountID}}</span></div>
                 </div>
             </div>
 
@@ -52,7 +52,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.Payments }}
+                            {{ range .Payments }}
                             <tr>
                                 <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
                                         rel="noopener noreferrer">{{.Height}}</a></td>
@@ -93,7 +93,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.MinedWork }}
+                            {{ range .MinedWork }}
                             <tr>
                                 <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
                                         rel="noopener noreferrer">{{.Height}}</a></td>
@@ -126,7 +126,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.Clients }}
+                            {{ range .Clients }}
                             <tr>
                                 <td>{{.Miner}}</td>
                                 <td>{{hashString .HashRate}}</td>

--- a/gui/assets/templates/admin.html
+++ b/gui/assets/templates/admin.html
@@ -1,5 +1,5 @@
 {{define "admin"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
 <div class="pool-overview pt-4 pb-3 mb-3">
     <div class="container">
@@ -10,18 +10,18 @@
             
             <div class="row mr-1">
                 <form class="p-2" action="/backup" method="post">
-                    {{.CSRF}}
+                    {{.HeaderData.CSRF}}
                     <button type="submit" class="btn btn-primary" style="padding:6px 6px; font-size: 12px;">Backup</button>
                 </form>
                 
                 <form class="p-2" action="/logout" method="post">
-                    {{.CSRF}}
+                    {{.HeaderData.CSRF}}
                     <button type="submit" class="btn btn-primary" style="padding:6px 6px; font-size: 12px;">Logout</button>
                 </form>
             </div>
         </div>
             
-        {{template "pool-stats" .PoolStats}}
+        {{template "pool-stats" .PoolStatsData}}
 
     </div>
 </div>

--- a/gui/assets/templates/header.html
+++ b/gui/assets/templates/header.html
@@ -75,7 +75,7 @@
                 </a>
             </div>
 
-            {{ if not .Admin }}
+            {{ if .ShowMenu }}
             <a class="modalbtn" data-toggle="modal" data-target="#account-modal"></a>
 
             <div class="modal fade" id="account-modal">
@@ -83,13 +83,13 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title">Account Information</h1>
-                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                            <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
                         </div>
                         <div class="modal-body">
                             <p>To know your mining account details, enter your mining address.</p>
-                            <form class="modal-form" id="account-form" action="/account" method="get">
+                            <form class="modal-form" id="account-form" action="/account_exist" method="get">
                                 <div class="modal-input">
-                                    <input type="text" name="address" placeholder="Mining Address" spellcheck="false">
+                                    <input type="text" name="address" required placeholder="Mining Address" spellcheck="false">
                                     <div class="icon-warning"></div>
                                 </div>
                                 <div class="err-message"></div>
@@ -108,7 +108,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title">Admin Login</h1>
-                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                            <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
                         </div>
                         <div class="modal-body">
                             <form class="modal-form" id="admin-form" action="/admin" method="post">

--- a/gui/assets/templates/index.html
+++ b/gui/assets/templates/index.html
@@ -1,13 +1,29 @@
 {{define "index"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
-{{ with .Error }}
-<div class="snackbar snackbar-error">
-    <div class="snackbar-message">
-        <p>{{.}}</p>
+{{ if .ModalError }}
+<div class="modal fade" id="error-modal">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title">Invalid Address</h1>
+                <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p>{{ .ModalError }}</p>
+                <div class="d-flex flex-row pt-4 align-items-center">
+                    <button class="btn btn-primary ml-auto" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+        
     </div>
 </div>
-{{end}}
+
+<script>
+    $("#error-modal").modal();
+</script>
+{{ end }}
 
 <noscript style="display:inherit;">
     <div class="snackbar snackbar-warning">
@@ -25,7 +41,7 @@
         <p class="pt-1 pb-2">To mine, point your miner to the pool and set the username as described below in the miner
             configuration section.</p>
         
-        {{template "pool-stats" .PoolStats}}
+        {{template "pool-stats" .PoolStatsData}}
         
     </div>
 </div>
@@ -44,7 +60,7 @@
                         </div>
                         <div class="col-lg-8 col-12 py-3 px-4">
                             <h2>Identify the Miner</h2>
-                            <p>{{.Designation}} pool currently supports:</p>
+                            <p>{{.HeaderData.Designation}} pool currently supports:</p>
                             <div class="d-flex flex-row">
                                 <ul>
                                     <li>Innosilicon&nbsp;D9</li>
@@ -153,7 +169,7 @@
             </div>
         </div>
 
-        {{ if not .PoolStats.SoloPool}}
+        {{ if not .PoolStatsData.SoloPool}}
         <div class="col-lg-6 col-12 p-3">
             <div class="block__content">
                 <h1>Next Reward Payment</h1>

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -112,7 +112,9 @@ type GUI struct {
 	poolHashMtx   sync.RWMutex
 }
 
-type poolStats struct {
+// poolStatsData contains all of the necessary information to render the
+// pool-stats template.
+type poolStatsData struct {
 	SoloPool          bool
 	PoolFee           float64
 	Network           string
@@ -120,6 +122,14 @@ type poolStats struct {
 	LastWorkHeight    uint32
 	LastPaymentHeight uint32
 	PoolHashRate      string
+}
+
+// headerData contains all of the necessary information to render the
+// header template.
+type headerData struct {
+	CSRF        template.HTML
+	Designation string
+	ShowMenu    bool
 }
 
 // route configures the http router of the user interface.
@@ -140,7 +150,8 @@ func (ui *GUI) route() {
 		http.FileServer(jsDir)))
 
 	ui.router.HandleFunc("/", ui.Homepage).Methods("GET")
-	ui.router.HandleFunc("/account", ui.IsPoolAccount).Methods("GET")
+	ui.router.HandleFunc("/account/{address}", ui.Account).Methods("GET")
+	ui.router.HandleFunc("/account_exist", ui.IsPoolAccount).Methods("GET")
 	ui.router.HandleFunc("/admin", ui.AdminPage).Methods("GET")
 	ui.router.HandleFunc("/admin", ui.AdminLogin).Methods("POST")
 	ui.router.HandleFunc("/backup", ui.DownloadDatabaseBackup).Methods("POST")

--- a/gui/index.go
+++ b/gui/index.go
@@ -1,58 +1,35 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package gui
 
 import (
-	"fmt"
-	"html/template"
 	"net/http"
 
 	"github.com/decred/dcrpool/pool"
 	"github.com/gorilla/csrf"
 )
 
-type indexData struct {
-	MinerPorts       map[string]uint32
-	MinedWork        []minedWork
-	PoolDomain       string
-	PoolStats        poolStats
-	WorkQuotas       []workQuota
-	AccountStats     *AccountStats
-	Address          string
-	Admin            bool
-	Error            string
-	BlockExplorerURL string
-	Designation      string
-	CSRF             template.HTML
+// indexPageData contains all of the necessary information to render the index
+// template.
+type indexPageData struct {
+	HeaderData    headerData
+	PoolStatsData poolStatsData
+	MinerPorts    map[string]uint32
+	MinedWork     []minedWork
+	PoolDomain    string
+	WorkQuotas    []workQuota
+	Address       string
+	ModalError    string
 }
 
-// AccountStats is a snapshot of an accounts contribution to the pool. This is
-// comprised of blocks mined by the pool and payments made to the account.
-type AccountStats struct {
-	MinedWork []*pool.AcceptedWork
-	Payments  []*pool.Payment
-	Clients   []*pool.ClientInfo
-	AccountID string
-}
-
-// Homepage is the handler for "GET /". If a valid address parameter is
-// provided, the account.html template is rendered and populated with the
-// relevant account information, otherwise the index.html template is rendered.
-func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
-	session, err := getSession(r, ui.cookieStore)
-	if err != nil {
-		log.Errorf("getSession error: %v", err)
-		http.Error(w, "Session error", http.StatusInternalServerError)
-		return
-	}
-
-	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
-		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
-		return
-	}
-
+// renderIndex renders the index template. It accepts an optional modalError
+// which can be used to include a pop-up error message on the page. This
+// function can be called from any HTTP handler which needs to display an error
+// message. The error message will only be displayed if the browser has
+// Javascript enabled.
+func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
 	// Get the most recently mined blocks (max 10)
 	ui.minedWorkMtx.RLock()
 	lastBlock := 10
@@ -71,82 +48,33 @@ func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
 	poolHash := ui.poolHash
 	ui.poolHashMtx.RUnlock()
 
-	poolStats := poolStats{
-		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
-		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		PaymentMethod:     ui.cfg.PaymentMethod,
-		Network:           ui.cfg.ActiveNet.Name,
-		PoolFee:           ui.cfg.PoolFee,
-		SoloPool:          ui.cfg.SoloPool,
+	data := indexPageData{
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    true,
+		},
+		PoolStatsData: poolStatsData{
+			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
+			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
+			PoolHashRate:      poolHash,
+			PaymentMethod:     ui.cfg.PaymentMethod,
+			Network:           ui.cfg.ActiveNet.Name,
+			PoolFee:           ui.cfg.PoolFee,
+			SoloPool:          ui.cfg.SoloPool,
+		},
+		WorkQuotas: wQuotas,
+		MinedWork:  mWork,
+		PoolDomain: ui.cfg.Domain,
+		MinerPorts: ui.cfg.MinerPorts,
+		ModalError: modalError,
 	}
 
-	data := indexData{
-		WorkQuotas:       wQuotas,
-		MinedWork:        mWork,
-		PoolDomain:       ui.cfg.Domain,
-		PoolStats:        poolStats,
-		Admin:            false,
-		BlockExplorerURL: ui.cfg.BlockExplorerURL,
-		Designation:      ui.cfg.Designation,
-		MinerPorts:       ui.cfg.MinerPorts,
-		CSRF:             csrf.TemplateField(r),
-	}
-
-	address := r.FormValue("address")
-	if address == "" {
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	// Add address to template data so the input field can be repopulated
-	// with the users input.
-	data.Address = address
-
-	// Generate the account id of the provided address.
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		data.Error = fmt.Sprintf("Unable to generate account ID for address %s", address)
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	if !ui.cfg.AccountExists(accountID) {
-		data.Error = fmt.Sprintf("Nothing found for address %s", address)
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	work, err := ui.cfg.FetchMinedWorkByAccount(accountID)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, "FetchMinedWorkByAddress error: "+err.Error(),
-			http.StatusInternalServerError)
-		return
-	}
-
-	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, "FetchPaymentsForAddress error: "+err.Error(),
-			http.StatusInternalServerError)
-		return
-	}
-
-	data.AccountStats = &AccountStats{
-		MinedWork: work,
-		Payments:  payments,
-		Clients:   ui.cfg.FetchAccountClientInfo(accountID),
-		AccountID: accountID,
-	}
-
-	ui.renderTemplate(w, "account", data)
+	ui.renderTemplate(w, "index", data)
 }
 
-// IsPoolAccount is the handler for "GET /account". If the provided address
-// has an account on the server a "200 OK" response is returned, otherwise a
-// "400 Bad Request" is returned.
-func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
+// Homepage is the handler for "GET /". It renders the index template.
+func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
 	session, err := getSession(r, ui.cookieStore)
 	if err != nil {
 		log.Errorf("getSession error: %v", err)
@@ -159,18 +87,5 @@ func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	address := r.FormValue("address")
-
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		http.Error(w, "Invalid address", http.StatusBadRequest)
-		return
-	}
-
-	if !ui.cfg.AccountExists(accountID) {
-		http.Error(w, "Nothing found for address", http.StatusBadRequest)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
+	ui.renderIndex(w, r, "")
 }


### PR DESCRIPTION
This PR implements the new error modals as defined by @MariaPleshkova in https://xd.adobe.com/view/a814493c-193a-4dfc-5735-0e6d459a6924-de25/

Also...
- Account details page is now on its own path `/account/{address}`. Previously it made sense to have the account details and index page on the same path because they were two very similar pages, but now they have diverged quite significantly (eg. they each have their own templates).
- The old path to check if an account exists has been renamed from `/account` to `/account_exist`
- The modal backdrop is now the correct color as per the design spec.