### PR TITLE
Pagination for blocks mined by account

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -162,7 +162,6 @@ func newPool(cfg *config) (*miningPool, error) {
 		BackupDB:                p.hub.BackupDB,
 		FetchClientInfo:         p.hub.FetchClientInfo,
 		AccountExists:           p.hub.AccountExists,
-		FetchMinedWorkByAccount: p.hub.FetchMinedWorkByAccount,
 		FetchPaymentsForAccount: p.hub.FetchPaymentsForAccount,
 		FetchAccountClientInfo:  p.hub.FetchAccountClientInfo,
 	}

--- a/gui/account.go
+++ b/gui/account.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gui
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/decred/dcrpool/pool"
+	"github.com/gorilla/csrf"
+	"github.com/gorilla/mux"
+)
+
+// accountPageData contains all of the necessary information to render the
+// account template.
+type accountPageData struct {
+	HeaderData       headerData
+	MinedWork        []*pool.AcceptedWork
+	Payments         []*pool.Payment
+	Clients          []*pool.ClientInfo
+	AccountID        string
+	Address          string
+	BlockExplorerURL string
+}
+
+// Account is the handler for "GET /account/{address}". Renders the account
+// template if the provided address is valid and has associated account
+// information, otherwise renders the index template with an appopriate error
+// message.
+func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		http.Error(w, "Session error", http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	address := mux.Vars(r)["address"]
+	if address == "" {
+		ui.renderIndex(w, r, "No address provided")
+		return
+	}
+
+	// Generate the account id of the provided address.
+	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
+	if err != nil {
+		ui.renderIndex(w, r, "Unable to generate account ID for address")
+		return
+	}
+
+	if !ui.cfg.AccountExists(accountID) {
+		ui.renderIndex(w, r, "Nothing found for address")
+		return
+	}
+
+	work, err := ui.cfg.FetchMinedWorkByAccount(accountID)
+	if err != nil {
+		ui.renderIndex(w, r, fmt.Sprintf("FetchMinedWorkByAddress error: %v",
+			err.Error()))
+		return
+
+	}
+
+	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
+	if err != nil {
+		ui.renderIndex(w, r, fmt.Sprintf("FetchPaymentsForAddress error: %v",
+			err.Error()))
+		return
+	}
+
+	data := &accountPageData{
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    true,
+		},
+		MinedWork:        work,
+		Payments:         payments,
+		Clients:          ui.cfg.FetchAccountClientInfo(accountID),
+		AccountID:        accountID,
+		Address:          address,
+		BlockExplorerURL: ui.cfg.BlockExplorerURL,
+	}
+
+	ui.renderTemplate(w, "account", data)
+}
+
+// IsPoolAccount is the handler for "GET /account_exist". If the provided
+// address has an account on the server a "200 OK" response is returned,
+// otherwise a "400 Bad Request" is returned.
+func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		http.Error(w, "Session error", http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	address := r.FormValue("address")
+
+	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
+	if err != nil {
+		http.Error(w, "Invalid address", http.StatusBadRequest)
+		return
+	}
+
+	if !ui.cfg.AccountExists(accountID) {
+		http.Error(w, "Nothing found for address", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/gui/account.go
+++ b/gui/account.go
@@ -61,17 +61,16 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the most recently mined blocks by this account (max 10)
-	work := make([]minedWork, 0)
-	ui.minedWorkMtx.RLock()
-	for _, v := range ui.minedWork {
+	allWork := ui.cache.getMinedWork()
+	recentWork := make([]minedWork, 0)
+	for _, v := range allWork {
 		if v.AccountID == accountID {
-			work = append(work, v)
-			if len(work) >= 10 {
+			recentWork = append(recentWork, v)
+			if len(recentWork) >= 10 {
 				break
 			}
 		}
 	}
-	ui.minedWorkMtx.RUnlock()
 
 	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
 	if err != nil {
@@ -86,7 +85,7 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 			Designation: ui.cfg.Designation,
 			ShowMenu:    true,
 		},
-		MinedWork:        work,
+		MinedWork:        recentWork,
 		Payments:         payments,
 		Clients:          ui.cfg.FetchAccountClientInfo(accountID),
 		AccountID:        accountID,

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package gui
 
 import (
-	"html/template"
 	"net/http"
 
 	"github.com/gorilla/csrf"
@@ -13,12 +12,12 @@ import (
 	"github.com/decred/dcrpool/pool"
 )
 
+// adminPageData contains all of the necessary information to render the admin
+// template.
 type adminPageData struct {
-	Connections map[string][]*pool.ClientInfo
-	CSRF        template.HTML
-	Designation string
-	PoolStats   poolStats
-	Admin       bool
+	HeaderData    headerData
+	PoolStatsData poolStatsData
+	Connections   map[string][]*pool.ClientInfo
 }
 
 // AdminPage is the handler for "GET /admin". If the current session is
@@ -46,22 +45,22 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 	poolHash := ui.poolHash
 	ui.poolHashMtx.RUnlock()
 
-	poolStats := poolStats{
-		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
-		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		PaymentMethod:     ui.cfg.PaymentMethod,
-		Network:           ui.cfg.ActiveNet.Name,
-		PoolFee:           ui.cfg.PoolFee,
-		SoloPool:          ui.cfg.SoloPool,
-	}
-
 	pageData := adminPageData{
-		CSRF:        csrf.TemplateField(r),
-		Designation: ui.cfg.Designation,
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    false,
+		},
+		PoolStatsData: poolStatsData{
+			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
+			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
+			PoolHashRate:      poolHash,
+			PaymentMethod:     ui.cfg.PaymentMethod,
+			Network:           ui.cfg.ActiveNet.Name,
+			PoolFee:           ui.cfg.PoolFee,
+			SoloPool:          ui.cfg.SoloPool,
+		},
 		Connections: ui.cfg.FetchClientInfo(),
-		PoolStats:   poolStats,
-		Admin:       true,
 	}
 
 	ui.renderTemplate(w, "admin", pageData)

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -41,10 +41,6 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ui.poolHashMtx.RLock()
-	poolHash := ui.poolHash
-	ui.poolHashMtx.RUnlock()
-
 	pageData := adminPageData{
 		HeaderData: headerData{
 			CSRF:        csrf.TemplateField(r),
@@ -54,7 +50,7 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 		PoolStatsData: poolStatsData{
 			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
 			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-			PoolHashRate:      poolHash,
+			PoolHashRate:      ui.cache.getPoolHash(),
 			PaymentMethod:     ui.cfg.PaymentMethod,
 			Network:           ui.cfg.ActiveNet.Name,
 			PoolFee:           ui.cfg.PoolFee,

--- a/gui/assets/public/css/dcrpool.css
+++ b/gui/assets/public/css/dcrpool.css
@@ -1946,7 +1946,7 @@ textarea.form-control {
 
 .btn {
   display: inline-block;
-  font-weight: 400;
+  font-weight: bold;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -2004,8 +2004,8 @@ fieldset:disabled a.btn {
     border-color: #005cbf; }
     .btn-primary:not(:disabled):not(.disabled):active:focus, .btn-primary:not(:disabled):not(.disabled).active:focus,
     .show > .btn-primary.dropdown-toggle:focus {
-      -webkit-box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);
-              box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5); }
+      -webkit-box-shadow: none;
+              box-shadow: none; }
 
 .btn-secondary {
   color: #fff;
@@ -4342,26 +4342,30 @@ input[type="button"].btn-block {
     background-color: #1b1e21;
     border-color: #1b1e21; }
 
-.close {
+.modal-close {
   float: right;
   font-size: 1.7rem;
   font-weight: 100;
   line-height: 1;
   color: #000;
   text-shadow: 0 1px 0 #fff;
-  opacity: .4; }
-  .close:not(:disabled):not(.disabled) {
-    cursor: pointer; }
-    .close:not(:disabled):not(.disabled):hover, .close:not(:disabled):not(.disabled):focus {
-      color: #000;
-      text-decoration: none;
-      opacity: .65; }
-
-button.close {
   padding: 0;
   background-color: transparent;
   border: 0;
-  -webkit-appearance: none; }
+  -webkit-appearance: none;
+  opacity: .4; }
+.modal-close:not(:disabled):not(.disabled) {
+  cursor: pointer; }
+.modal-close:not(:disabled):not(.disabled):hover,
+.modal-close:not(:disabled):not(.disabled):focus {
+  color: #000;
+  text-decoration: none;
+  opacity: .65; }
+
+.modal-close:active,
+.modal-close:focus {
+  outline: none;
+}
 
 .modal-open {
   overflow: hidden; }
@@ -4440,11 +4444,11 @@ button.close {
   bottom: 0;
   left: 0;
   z-index: 1040;
-  background-color: #000; }
+  background-color: #091440; }
   .modal-backdrop.fade {
     opacity: 0; }
   .modal-backdrop.show {
-    opacity: 0.5; }
+    opacity: 0.3; }
 
 .modal-header {
   display: -webkit-box;
@@ -8334,20 +8338,6 @@ input[type="submit"]:disabled {
             box-shadow: 0 1px 2px 0 rgba(9, 20, 64, 0.21); }
     .modal-blockquote span {
       color: #fd704a; }
-  .modal-close {
-    padding: 0;
-    cursor: pointer;
-    -webkit-appearance: none !important;
-    border: 0;
-    background: transparent; }
-  .modal-close img {
-    vertical-align: super;
-  }
-    .modal-close:focus {
-      outline: none; }
-    @media (max-width: 1199.98px) {
-      .modal-close img {
-        width: 16px; } }
   .modal-header {
     border: 0; }
   .modal-dialog {
@@ -8359,8 +8349,6 @@ input[type="submit"]:disabled {
   .modal-header--long-title .modal-title {
     max-width: 60%;
     text-align: right; }
-  .modal-header--long-title .modal-close {
-    margin: -20px 0 4px 0; }
   .modal-header--long-title img {
     float: right; }
   .modal-header--long-title span {
@@ -8381,7 +8369,7 @@ input[type="submit"]:disabled {
     font-size: 28px;
     line-height: 1.26;
     letter-spacing: normal;
-    color: #48566e; }
+    color: #3D5873; }
     @media (max-width: 767.98px) {
       .modal-title {
         font-size: 18px; } }
@@ -8394,7 +8382,7 @@ input[type="submit"]:disabled {
         max-height: 100vh; } }
     .modal-body p {
       font-size: 16px;
-      color: #48566e; }
+      color: #091440; }
     .modal-body strong {
       color: #091440;
       margin-bottom: 1rem;

--- a/gui/assets/public/js/modal.js
+++ b/gui/assets/public/js/modal.js
@@ -48,7 +48,7 @@ $("#account-form").on("submit", function (e) {
         type: $(this).attr('method'),
         data: $(this).serialize(),
         success: function() {
-            window.location.replace("/?address="+address);
+            window.location.replace("/account/"+address);
         },
         error: function(response) {
             if (response.status === 400 || response.status === 429) {

--- a/gui/assets/public/js/pagination.js
+++ b/gui/assets/public/js/pagination.js
@@ -1,25 +1,49 @@
-$('#mined-blocks-page-select').pagination({
-    dataSource: "/mined_blocks",
-    autoHideNext: false,
-    autoHidePrevious: false,
-    hideWhenLessThanOnePage: true,
-    pageSize: 10,
-    nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
-    prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',
-    locator: "blocks",
-    totalNumberLocator: function(response) {
-        return response.count;
-    },
-    callback: function(data) {
-        var html = '';
-
-        if (data.length > 0) {
-            $.each(data, function(index, item){
-                html += '<tr><td><a href="' + item.blockurl + '" rel="noopener noreferrer">' + item.blockheight + '</a></td><td>' + item.miner + '</td><td><span class="dcr-label">' + item.minedby + '</span></td></tr>';
-            });
-        } else {
-            html += '<tr><td colspan="100%"><span class="no-data">No mined blocks</span></td></tr>';
+if ( $('#blocks-page-select').length ) {
+    $('#blocks-page-select').pagination({
+        dataSource: "/blocks",
+        hideWhenLessThanOnePage: true,
+        nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
+        prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',
+        locator: "blocks",
+        totalNumberLocator: function(response) {
+            return response.count;
+        },
+        callback: function(data) {
+            var html = '';
+    
+            if (data.length > 0) {
+                $.each(data, function(_, item){
+                    html += '<tr><td><a href="' + item.blockurl + '" rel="noopener noreferrer">' + item.blockheight + '</a></td><td>' + item.miner + '</td><td><span class="dcr-label">' + item.minedby + '</span></td></tr>';
+                });
+            } else {
+                html += '<tr><td colspan="100%"><span class="no-data">No mined blocks</span></td></tr>';
+            }
+            $('#blocks-table').html(html);
         }
-        $('#mined-blocks-table-body').html(html);
-    }
-})
+    });
+};
+
+if ( $('#blocks-by-account-page-select').length ) {
+    $('#blocks-by-account-page-select').pagination({
+        dataSource: "/blocks_by_account?accountID=" + accountID + "&",
+        hideWhenLessThanOnePage: true,
+        nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
+        prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',
+        locator: "blocks",
+        totalNumberLocator: function(response) {
+            return response.count;
+        },
+        callback: function(data) {
+            var html = '';
+
+            if (data.length > 0) {
+                $.each(data, function(_, item){
+                    html += '<tr><td><a href="' + item.blockurl + '" rel="noopener noreferrer">' + item.blockheight + '</a></td><td>' + item.confirmed + '</td><td>' + item.miner + '</td></tr>';
+                });
+            } else {
+                html += '<tr><td colspan="100%"><span class="no-data">No mined blocks</span></td></tr>';
+            }
+            $('#blocks-by-account-table').html(html);
+        }
+    });
+};

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -83,31 +83,30 @@
         <div class="col-lg-6 col-12 p-3">
             <div class="block__content">
                 <h1>Blocks Mined</h1>
-                <div class="overflow-auto">
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th>Height</th>
-                                <th>Confirmed</th>
-                                <th>Miner</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {{ range .MinedWork }}
-                            <tr>
-                                <td><a href="{{ .BlockURL}}"
-                                        rel="noopener noreferrer">{{.BlockHeight}}</a></td>
-                                <td>{{.Confirmed}}</td>
-                                <td>{{.Miner}}</td>
-                            </tr>
-                            {{else}}
-                            <tr>
-                                <td colspan="100%"><span class="no-data">No mined work</span></td>
-                            </tr>
-                            {{end}}
-                        </tbody>
-                    </table>
-                </div>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Height</th>
+                            <th>Confirmed</th>
+                            <th>Miner</th>
+                        </tr>
+                    </thead>
+                    <tbody id="blocks-by-account-table">
+                        {{ range .MinedWork }}
+                        <tr>
+                            <td><a href="{{ .BlockURL}}" rel="noopener noreferrer">{{.BlockHeight}}</a></td>
+                            <td>{{.Confirmed}}</td>
+                            <td>{{.Miner}}</td>
+                        </tr>
+                        {{else}}
+                        <tr>
+                            <td colspan="100%"><span class="no-data">No mined blocks</span></td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+
+                <div id="blocks-by-account-page-select" class="page-select"></div>
 
             </div>
         </div>
@@ -144,7 +143,11 @@
 
 </div>
 
+<script>
+    var accountID = "{{.AccountID}}";
+</script>
 <script src='/js/modal.js'></script>
+<script src='/js/pagination.js'></script>
 
 </body>
 </html>

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -1,5 +1,5 @@
 {{define "account"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
 <noscript style="display:inherit;">
     <div class="snackbar snackbar-warning">
@@ -18,7 +18,7 @@
             <div class="col-lg-7 col-12 py-2">
                 <div class="d-flex flex-column">
                     <div class="account-info-title pb-2">Account</div>
-                    <div><span class="dcr-label">{{.AccountStats.AccountID}}</span></div>
+                    <div><span class="dcr-label">{{.AccountID}}</span></div>
                 </div>
             </div>
 
@@ -52,7 +52,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.Payments }}
+                            {{ range .Payments }}
                             <tr>
                                 <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
                                         rel="noopener noreferrer">{{.Height}}</a></td>
@@ -93,7 +93,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.MinedWork }}
+                            {{ range .MinedWork }}
                             <tr>
                                 <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
                                         rel="noopener noreferrer">{{.Height}}</a></td>
@@ -126,7 +126,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.Clients }}
+                            {{ range .Clients }}
                             <tr>
                                 <td>{{.Miner}}</td>
                                 <td>{{hashString .HashRate}}</td>

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -95,8 +95,8 @@
                         <tbody>
                             {{ range .MinedWork }}
                             <tr>
-                                <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
-                                        rel="noopener noreferrer">{{.Height}}</a></td>
+                                <td><a href="{{ .BlockURL}}"
+                                        rel="noopener noreferrer">{{.BlockHeight}}</a></td>
                                 <td>{{.Confirmed}}</td>
                                 <td>{{.Miner}}</td>
                             </tr>

--- a/gui/assets/templates/admin.html
+++ b/gui/assets/templates/admin.html
@@ -1,5 +1,5 @@
 {{define "admin"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
 <div class="pool-overview pt-4 pb-3 mb-3">
     <div class="container">
@@ -10,18 +10,18 @@
             
             <div class="row mr-1">
                 <form class="p-2" action="/backup" method="post">
-                    {{.CSRF}}
+                    {{.HeaderData.CSRF}}
                     <button type="submit" class="btn btn-primary" style="padding:6px 6px; font-size: 12px;">Backup</button>
                 </form>
                 
                 <form class="p-2" action="/logout" method="post">
-                    {{.CSRF}}
+                    {{.HeaderData.CSRF}}
                     <button type="submit" class="btn btn-primary" style="padding:6px 6px; font-size: 12px;">Logout</button>
                 </form>
             </div>
         </div>
             
-        {{template "pool-stats" .PoolStats}}
+        {{template "pool-stats" .PoolStatsData}}
 
     </div>
 </div>

--- a/gui/assets/templates/header.html
+++ b/gui/assets/templates/header.html
@@ -75,7 +75,7 @@
                 </a>
             </div>
 
-            {{ if not .Admin }}
+            {{ if .ShowMenu }}
             <a class="modalbtn" data-toggle="modal" data-target="#account-modal"></a>
 
             <div class="modal fade" id="account-modal">
@@ -83,13 +83,13 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title">Account Information</h1>
-                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                            <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
                         </div>
                         <div class="modal-body">
                             <p>To know your mining account details, enter your mining address.</p>
-                            <form class="modal-form" id="account-form" action="/account" method="get">
+                            <form class="modal-form" id="account-form" action="/account_exist" method="get">
                                 <div class="modal-input">
-                                    <input type="text" name="address" placeholder="Mining Address" spellcheck="false">
+                                    <input type="text" name="address" required placeholder="Mining Address" spellcheck="false">
                                     <div class="icon-warning"></div>
                                 </div>
                                 <div class="err-message"></div>
@@ -108,7 +108,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title">Admin Login</h1>
-                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                            <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
                         </div>
                         <div class="modal-body">
                             <form class="modal-form" id="admin-form" action="/admin" method="post">

--- a/gui/assets/templates/index.html
+++ b/gui/assets/templates/index.html
@@ -1,13 +1,29 @@
 {{define "index"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
-{{ with .Error }}
-<div class="snackbar snackbar-error">
-    <div class="snackbar-message">
-        <p>{{.}}</p>
+{{ if .ModalError }}
+<div class="modal fade" id="error-modal">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title">Invalid Address</h1>
+                <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p>{{ .ModalError }}</p>
+                <div class="d-flex flex-row pt-4 align-items-center">
+                    <button class="btn btn-primary ml-auto" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+        
     </div>
 </div>
-{{end}}
+
+<script>
+    $("#error-modal").modal();
+</script>
+{{ end }}
 
 <noscript style="display:inherit;">
     <div class="snackbar snackbar-warning">
@@ -25,7 +41,7 @@
         <p class="pt-1 pb-2">To mine, point your miner to the pool and set the username as described below in the miner
             configuration section.</p>
         
-        {{template "pool-stats" .PoolStats}}
+        {{template "pool-stats" .PoolStatsData}}
         
     </div>
 </div>
@@ -44,7 +60,7 @@
                         </div>
                         <div class="col-lg-8 col-12 py-3 px-4">
                             <h2>Identify the Miner</h2>
-                            <p>{{.Designation}} pool currently supports:</p>
+                            <p>{{.HeaderData.Designation}} pool currently supports:</p>
                             <div class="d-flex flex-row">
                                 <ul>
                                     <li>Innosilicon&nbsp;D9</li>
@@ -153,7 +169,7 @@
             </div>
         </div>
 
-        {{ if not .PoolStats.SoloPool}}
+        {{ if not .PoolStatsData.SoloPool}}
         <div class="col-lg-6 col-12 p-3">
             <div class="block__content">
                 <h1>Next Reward Payment</h1>

--- a/gui/assets/templates/index.html
+++ b/gui/assets/templates/index.html
@@ -141,20 +141,17 @@
                 <table class="table">
                     <thead>
                         <tr>
-                            <th data-sort-method="number" data-sort-default>Height</th>
-                            <th data-sort-method="none">Miner</th>
-                            <th data-sort-method="none">Mined By</th>
+                            <th>Height</th>
+                            <th>Miner</th>
+                            <th>Mined By</th>
                         </tr>
                     </thead>
-                    <tbody id="mined-blocks-table-body">
+                    <tbody id="blocks-table">
                         {{ range .MinedWork }}
-                        <tr data-row-id="{{ .BlockHeight }}">
-                            <td><a href="{{ .BlockURL }}" rel="noopener noreferrer">{{ .BlockHeight }}</a>
-                            </td>
+                        <tr>
+                            <td><a href="{{ .BlockURL }}" rel="noopener noreferrer">{{ .BlockHeight }}</a></td>
                             <td>{{ .Miner }}</td>
-                            <td>
-                                <span class="dcr-label">{{ .MinedBy }}</span>
-                            </td>
+                            <td><span class="dcr-label">{{ .MinedBy }}</span></td>
                         </tr>
                         {{ else }}
                         <tr>
@@ -164,7 +161,7 @@
                     </tbody>
                 </table>
 
-                <div id="mined-blocks-page-select" class="page-select"></div>
+                <div id="blocks-page-select" class="page-select"></div>
 
             </div>
         </div>

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gui
+
+import (
+	"math/big"
+	"sync"
+
+	"github.com/decred/dcrpool/pool"
+)
+
+// minedWork represents a block mined by the pool. It is json annotated so it
+// can easily be encoded and sent over a websocket or pagination request.
+type minedWork struct {
+	BlockHeight uint32 `json:"blockheight"`
+	BlockURL    string `json:"blockurl"`
+	MinedBy     string `json:"minedby"`
+	Miner       string `json:"miner"`
+	Confirmed   bool   `json:"confirmed"`
+	// AccountID holds the full ID (not truncated) and so should not be json encoded
+	AccountID string `json:"-"`
+}
+
+// workQuota represents dividend garnered by pool accounts through work
+// contributed. It is json annotated so it can easily be encoded and sent over a
+// websocket or pagination request.
+type workQuota struct {
+	AccountID string `json:"accountid"`
+	Percent   string `json:"percent"`
+}
+
+// Cache stores data which is required for the GUI. Each field has a setter and
+// getter, and they are protected by a mutex so they are safe for concurrent
+// access. Data returned by the getters is already formatted for display in the
+// GUI, so the formatting does not need to be repeated.
+type Cache struct {
+	blockExplorerURL string
+
+	minedWork    []minedWork
+	minedWorkMtx sync.RWMutex
+
+	workQuotas    []workQuota
+	workQuotasMtx sync.RWMutex
+
+	poolHash    string
+	poolHashMtx sync.RWMutex
+}
+
+// InitCache initialises and returns a cache for use in the GUI.
+func InitCache(work []*pool.AcceptedWork, quotas []*pool.Quota, poolHash *big.Rat, blockExplorerURL string) *Cache {
+	cache := Cache{blockExplorerURL: blockExplorerURL}
+	cache.updateMinedWork(work)
+	cache.updateQuotas(quotas)
+	cache.updateHashrate(poolHash)
+	return &cache
+}
+
+func (c *Cache) updateMinedWork(work []*pool.AcceptedWork) {
+	// Parse and format mined work by the pool.
+	workData := make([]minedWork, 0)
+	for _, work := range work {
+		workData = append(workData, minedWork{
+			BlockHeight: work.Height,
+			BlockURL:    blockURL(c.blockExplorerURL, work.Height),
+			MinedBy:     truncateAccountID(work.MinedBy),
+			Miner:       work.Miner,
+			AccountID:   work.MinedBy,
+			Confirmed:   work.Confirmed,
+		})
+	}
+
+	c.minedWorkMtx.Lock()
+	c.minedWork = workData
+	c.minedWorkMtx.Unlock()
+}
+
+func (c *Cache) getMinedWork() []minedWork {
+	c.minedWorkMtx.RLock()
+	defer c.minedWorkMtx.RUnlock()
+	return c.minedWork
+}
+
+func (c *Cache) updateQuotas(quotas []*pool.Quota) {
+	quotaData := make([]workQuota, 0)
+	for _, quota := range quotas {
+		quotaData = append(quotaData, workQuota{
+			AccountID: truncateAccountID(quota.AccountID),
+			Percent:   ratToPercent(quota.Percentage),
+		})
+	}
+
+	c.workQuotasMtx.Lock()
+	c.workQuotas = quotaData
+	c.workQuotasMtx.Unlock()
+}
+
+func (c *Cache) getQuotas() []workQuota {
+	c.workQuotasMtx.RLock()
+	defer c.workQuotasMtx.RUnlock()
+	return c.workQuotas
+}
+
+func (c *Cache) updateHashrate(poolHash *big.Rat) {
+	c.poolHashMtx.Lock()
+	c.poolHash = hashString(poolHash)
+	c.poolHashMtx.Unlock()
+}
+
+func (c *Cache) getPoolHash() string {
+	c.poolHashMtx.RLock()
+	defer c.poolHashMtx.RUnlock()
+	return c.poolHash
+}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -71,7 +71,7 @@ type Config struct {
 	// AddPaymentRequest creates a payment request from the provided account
 	// if not already requested.
 	AddPaymentRequest func(addr string) error
-	// FetchMinedWork returns all confirmed blocks mined by the pool.
+	// FetchMinedWork returns all blocks mined by the pool.
 	FetchMinedWork func() ([]*pool.AcceptedWork, error)
 	// FetchWorkQuotas returns the reward distribution to pool accounts
 	// based on work contributed per the payment scheme used by the pool.
@@ -84,8 +84,6 @@ type Config struct {
 	FetchClientInfo func() map[string][]*pool.ClientInfo
 	// AccountExists checks if the provided account id references a pool account.
 	AccountExists func(accountID string) bool
-	// FetchMinedWorkByAccount returns a list of mined work by the provided address.
-	FetchMinedWorkByAccount func(id string) ([]*pool.AcceptedWork, error)
 	// FetchPaymentsForAccount returns a list or payments made to the provided address.
 	FetchPaymentsForAccount func(id string) ([]*pool.Payment, error)
 	// FetchAccountClientInfo returns all clients belonging to the provided
@@ -357,6 +355,8 @@ func (ui *GUI) Run(ctx context.Context) {
 				BlockURL:    blockURL(ui.cfg.BlockExplorerURL, work.Height),
 				MinedBy:     truncateAccountID(work.MinedBy),
 				Miner:       work.Miner,
+				AccountID:   work.MinedBy,
+				Confirmed:   work.Confirmed,
 			})
 		}
 

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -112,7 +112,9 @@ type GUI struct {
 	poolHashMtx   sync.RWMutex
 }
 
-type poolStats struct {
+// poolStatsData contains all of the necessary information to render the
+// pool-stats template.
+type poolStatsData struct {
 	SoloPool          bool
 	PoolFee           float64
 	Network           string
@@ -120,6 +122,14 @@ type poolStats struct {
 	LastWorkHeight    uint32
 	LastPaymentHeight uint32
 	PoolHashRate      string
+}
+
+// headerData contains all of the necessary information to render the
+// header template.
+type headerData struct {
+	CSRF        template.HTML
+	Designation string
+	ShowMenu    bool
 }
 
 // route configures the http router of the user interface.
@@ -140,7 +150,8 @@ func (ui *GUI) route() {
 		http.FileServer(jsDir)))
 
 	ui.router.HandleFunc("/", ui.Homepage).Methods("GET")
-	ui.router.HandleFunc("/account", ui.IsPoolAccount).Methods("GET")
+	ui.router.HandleFunc("/account/{address}", ui.Account).Methods("GET")
+	ui.router.HandleFunc("/account_exist", ui.IsPoolAccount).Methods("GET")
 	ui.router.HandleFunc("/admin", ui.AdminPage).Methods("GET")
 	ui.router.HandleFunc("/admin", ui.AdminLogin).Methods("POST")
 	ui.router.HandleFunc("/backup", ui.DownloadDatabaseBackup).Methods("POST")

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -156,7 +156,8 @@ func (ui *GUI) route() {
 	ui.router.HandleFunc("/logout", ui.AdminLogout).Methods("POST")
 
 	// Paginated endpoints allow the GUI to request pages of data
-	ui.router.HandleFunc("/mined_blocks", ui.PaginatedMinedBlocks).Methods("GET")
+	ui.router.HandleFunc("/blocks", ui.PaginatedBlocks).Methods("GET")
+	ui.router.HandleFunc("/blocks_by_account", ui.PaginatedBlocksByAccount).Methods("GET")
 
 	// Websocket endpoint allows the GUI to receive updated values
 	ui.router.HandleFunc("/ws", ui.registerWebSocket).Methods("GET")

--- a/gui/index.go
+++ b/gui/index.go
@@ -1,58 +1,35 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package gui
 
 import (
-	"fmt"
-	"html/template"
 	"net/http"
 
 	"github.com/decred/dcrpool/pool"
 	"github.com/gorilla/csrf"
 )
 
-type indexData struct {
-	MinerPorts       map[string]uint32
-	MinedWork        []minedWork
-	PoolDomain       string
-	PoolStats        poolStats
-	WorkQuotas       []workQuota
-	AccountStats     *AccountStats
-	Address          string
-	Admin            bool
-	Error            string
-	BlockExplorerURL string
-	Designation      string
-	CSRF             template.HTML
+// indexPageData contains all of the necessary information to render the index
+// template.
+type indexPageData struct {
+	HeaderData    headerData
+	PoolStatsData poolStatsData
+	MinerPorts    map[string]uint32
+	MinedWork     []minedWork
+	PoolDomain    string
+	WorkQuotas    []workQuota
+	Address       string
+	ModalError    string
 }
 
-// AccountStats is a snapshot of an accounts contribution to the pool. This is
-// comprised of blocks mined by the pool and payments made to the account.
-type AccountStats struct {
-	MinedWork []*pool.AcceptedWork
-	Payments  []*pool.Payment
-	Clients   []*pool.ClientInfo
-	AccountID string
-}
-
-// Homepage is the handler for "GET /". If a valid address parameter is
-// provided, the account.html template is rendered and populated with the
-// relevant account information, otherwise the index.html template is rendered.
-func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
-	session, err := getSession(r, ui.cookieStore)
-	if err != nil {
-		log.Errorf("getSession error: %v", err)
-		http.Error(w, "Session error", http.StatusInternalServerError)
-		return
-	}
-
-	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
-		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
-		return
-	}
-
+// renderIndex renders the index template. It accepts an optional modalError
+// which can be used to include a pop-up error message on the page. This
+// function can be called from any HTTP handler which needs to display an error
+// message. The error message will only be displayed if the browser has
+// Javascript enabled.
+func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
 	// Get the most recently mined blocks (max 10)
 	ui.minedWorkMtx.RLock()
 	lastBlock := 10
@@ -71,82 +48,33 @@ func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
 	poolHash := ui.poolHash
 	ui.poolHashMtx.RUnlock()
 
-	poolStats := poolStats{
-		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
-		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		PaymentMethod:     ui.cfg.PaymentMethod,
-		Network:           ui.cfg.ActiveNet.Name,
-		PoolFee:           ui.cfg.PoolFee,
-		SoloPool:          ui.cfg.SoloPool,
+	data := indexPageData{
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    true,
+		},
+		PoolStatsData: poolStatsData{
+			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
+			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
+			PoolHashRate:      poolHash,
+			PaymentMethod:     ui.cfg.PaymentMethod,
+			Network:           ui.cfg.ActiveNet.Name,
+			PoolFee:           ui.cfg.PoolFee,
+			SoloPool:          ui.cfg.SoloPool,
+		},
+		WorkQuotas: wQuotas,
+		MinedWork:  mWork,
+		PoolDomain: ui.cfg.Domain,
+		MinerPorts: ui.cfg.MinerPorts,
+		ModalError: modalError,
 	}
 
-	data := indexData{
-		WorkQuotas:       wQuotas,
-		MinedWork:        mWork,
-		PoolDomain:       ui.cfg.Domain,
-		PoolStats:        poolStats,
-		Admin:            false,
-		BlockExplorerURL: ui.cfg.BlockExplorerURL,
-		Designation:      ui.cfg.Designation,
-		MinerPorts:       ui.cfg.MinerPorts,
-		CSRF:             csrf.TemplateField(r),
-	}
-
-	address := r.FormValue("address")
-	if address == "" {
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	// Add address to template data so the input field can be repopulated
-	// with the users input.
-	data.Address = address
-
-	// Generate the account id of the provided address.
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		data.Error = fmt.Sprintf("Unable to generate account ID for address %s", address)
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	if !ui.cfg.AccountExists(accountID) {
-		data.Error = fmt.Sprintf("Nothing found for address %s", address)
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	work, err := ui.cfg.FetchMinedWorkByAccount(accountID)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, "FetchMinedWorkByAddress error: "+err.Error(),
-			http.StatusInternalServerError)
-		return
-	}
-
-	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, "FetchPaymentsForAddress error: "+err.Error(),
-			http.StatusInternalServerError)
-		return
-	}
-
-	data.AccountStats = &AccountStats{
-		MinedWork: work,
-		Payments:  payments,
-		Clients:   ui.cfg.FetchAccountClientInfo(accountID),
-		AccountID: accountID,
-	}
-
-	ui.renderTemplate(w, "account", data)
+	ui.renderTemplate(w, "index", data)
 }
 
-// IsPoolAccount is the handler for "GET /account". If the provided address
-// has an account on the server a "200 OK" response is returned, otherwise a
-// "400 Bad Request" is returned.
-func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
+// Homepage is the handler for "GET /". It renders the index template.
+func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
 	session, err := getSession(r, ui.cookieStore)
 	if err != nil {
 		log.Errorf("getSession error: %v", err)
@@ -159,18 +87,5 @@ func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	address := r.FormValue("address")
-
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		http.Error(w, "Invalid address", http.StatusBadRequest)
-		return
-	}
-
-	if !ui.cfg.AccountExists(accountID) {
-		http.Error(w, "Nothing found for address", http.StatusBadRequest)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
+	ui.renderIndex(w, r, "")
 }

--- a/gui/index.go
+++ b/gui/index.go
@@ -30,14 +30,18 @@ type indexPageData struct {
 // message. The error message will only be displayed if the browser has
 // Javascript enabled.
 func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
-	// Get the most recently mined blocks (max 10)
+
+	// Get the most recent confirmed mined blocks (max 10)
+	work := make([]minedWork, 0)
 	ui.minedWorkMtx.RLock()
-	lastBlock := 10
-	count := len(ui.minedWork)
-	if count < 10 {
-		lastBlock = count
+	for _, v := range ui.minedWork {
+		if v.Confirmed {
+			work = append(work, v)
+			if len(work) >= 10 {
+				break
+			}
+		}
 	}
-	mWork := ui.minedWork[0:lastBlock]
 	ui.minedWorkMtx.RUnlock()
 
 	ui.workQuotasMtx.RLock()
@@ -64,7 +68,7 @@ func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError st
 			SoloPool:          ui.cfg.SoloPool,
 		},
 		WorkQuotas: wQuotas,
-		MinedWork:  mWork,
+		MinedWork:  work,
 		PoolDomain: ui.cfg.Domain,
 		MinerPorts: ui.cfg.MinerPorts,
 		ModalError: modalError,

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -17,6 +17,9 @@ type minedWork struct {
 	BlockURL    string `json:"blockurl"`
 	MinedBy     string `json:"minedby"`
 	Miner       string `json:"miner"`
+	Confirmed   bool   `json:"confirmed"`
+	// AccountID holds the full ID (not truncated) and so should not be json encoded
+	AccountID string `json:"-"`
 }
 
 type minedWorkPayload struct {

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -27,10 +27,10 @@ type minedWorkPayload struct {
 	Count  int         `json:"count"`
 }
 
-// PaginatedMinedBlocks is the handler for "GET /mined_blocks". It will use
+// PaginatedBlocks is the handler for "GET /blocks". It will use
 // parameters pageNumber and pageSize to prepare a json payload describing
 // blocks mined by the pool, as well as the total count of all confirmed blocks.
-func (ui *GUI) PaginatedMinedBlocks(w http.ResponseWriter, r *http.Request) {
+func (ui *GUI) PaginatedBlocks(w http.ResponseWriter, r *http.Request) {
 	session, err := getSession(r, ui.cookieStore)
 	if err != nil {
 		log.Errorf("getSession error: %v", err)
@@ -68,6 +68,75 @@ func (ui *GUI) PaginatedMinedBlocks(w http.ResponseWriter, r *http.Request) {
 	}
 	requestedBlocks := ui.minedWork[offset:lastBlock]
 	ui.minedWorkMtx.RUnlock()
+
+	// Prepare json response
+	payload := minedWorkPayload{
+		Count:  count,
+		Blocks: requestedBlocks,
+	}
+	js, err := json.Marshal(payload)
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Send json response
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+// PaginatedBlocksByAccount is the handler for "GET /blocks_by_account". It will
+// use parameters pageNumber, pageSize and accountID to prepare a json payload
+// describing blocks mined by the account, as well as the total count of all
+// blocks mined by the account.
+func (ui *GUI) PaginatedBlocksByAccount(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+
+	// Parse request parameters
+	pageNumber, err := strconv.Atoi(r.FormValue("pageNumber"))
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	pageSize, err := strconv.Atoi(r.FormValue("pageSize"))
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	accountID := r.FormValue("accountID")
+
+	offset := (pageNumber - 1) * pageSize
+	lastBlock := offset + pageSize
+
+	// Get all blocks mined by this account
+	work := make([]minedWork, 0)
+	ui.minedWorkMtx.RLock()
+	for _, v := range ui.minedWork {
+		if v.AccountID == accountID {
+			work = append(work, v)
+		}
+	}
+	ui.minedWorkMtx.RUnlock()
+
+	count := len(work)
+	if lastBlock > count {
+		lastBlock = count
+	}
+	requestedBlocks := work[offset:lastBlock]
 
 	// Prepare json response
 	payload := minedWorkPayload{

--- a/gui/websocket.go
+++ b/gui/websocket.go
@@ -20,13 +20,6 @@ type payload struct {
 	WorkQuotas        []workQuota `json:"workquotas"`
 }
 
-// workQuota represents dividend garnered by pool accounts through work
-// contributed.
-type workQuota struct {
-	AccountID string `json:"accountid"`
-	Percent   string `json:"percent"`
-}
-
 // registerWebSocket is the handler for "GET /ws". It updates the HTTP request
 // to a websocket and adds the caller to a list of connected clients.
 func (ui *GUI) registerWebSocket(w http.ResponseWriter, r *http.Request) {
@@ -42,17 +35,11 @@ func (ui *GUI) registerWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // updateWebSocket sends updates to all connected websocket clients.
 func (ui *GUI) updateWebSocket() {
-	ui.poolHashMtx.RLock()
-	poolHash := ui.poolHash
-	ui.poolHashMtx.RUnlock()
-	ui.workQuotasMtx.RLock()
-	workQuotas := append(ui.workQuotas[:0:0], ui.workQuotas...)
-	ui.workQuotasMtx.RUnlock()
 	msg := payload{
 		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
 		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		WorkQuotas:        workQuotas,
+		PoolHashRate:      ui.cache.getPoolHash(),
+		WorkQuotas:        ui.cache.getQuotas(),
 	}
 	clientsMtx.Lock()
 	for client := range clients {

--- a/pool/acceptedwork_test.go
+++ b/pool/acceptedwork_test.go
@@ -93,27 +93,14 @@ func testAcceptedWork(t *testing.T, db *bolt.DB) {
 			fetchedWork.Height, workC.Height)
 	}
 
-	// Ensure requesting negative or zero most recent accepted work returns
-	// an error.
-	_, err = listMinedWorkByAccount(db, string(id), -1)
-	if err == nil {
-		t.Fatalf("listMinedWorkByAccount: expected negative N error")
-	}
-
-	_, err = listMinedWorkByAccount(db, string(id), 0)
-	if err == nil {
-		t.Fatalf("listMinedWorkByAccount: expected zero N error")
-	}
-
-	// Ensure the accepted work are not listed as mined since they are not
-	// confirmed.
+	// Ensure unconfirmed work is returned
 	minedWork, err := ListMinedWork(db)
 	if err != nil {
 		t.Fatalf("ListMinedWork error: %v", err)
 	}
 
-	if len(minedWork) != 0 {
-		t.Fatalf("expected no mined work")
+	if len(minedWork) != 4 {
+		t.Fatalf("expected unconfirmed work to be returned")
 	}
 
 	// Confirm all accepted work a mined work.
@@ -149,17 +136,6 @@ func testAcceptedWork(t *testing.T, db *bolt.DB) {
 
 	if len(minedWork) != 4 {
 		t.Fatalf("expected %v mined work, got %v", 4, len(minedWork))
-	}
-
-	// Ensure account Y has only one associated mined work.
-	minedWork, err = listMinedWorkByAccount(db, yID, 4)
-	if err != nil {
-		t.Fatalf("ListMinedWork error: %v", err)
-	}
-
-	if len(minedWork) != 1 {
-		t.Fatalf("expected %v mined work for account %v, got %v", 1,
-			yID, len(minedWork))
 	}
 
 	// Ensure mined work cannot be pruned.

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -611,7 +611,10 @@ func (h *Hub) FetchAccountClientInfo(accountID string) []*ClientInfo {
 	return info
 }
 
-// FetchMinedWork returns all confirmed blocks mined by the pool.
+// FetchMinedWork returns work data associated with all blocks mined by the pool
+// regardless of whether they are confirmed or not.
+//
+// List is ordered, most recent comes first.
 func (h *Hub) FetchMinedWork() ([]*AcceptedWork, error) {
 	return ListMinedWork(h.db)
 }
@@ -661,13 +664,6 @@ func (h *Hub) FetchWorkQuotas() ([]*Quota, error) {
 		})
 	}
 	return quotas, nil
-}
-
-// FetchMinedWorkByAccount returns a list of mined work by the provided address.
-// List is ordered, most recent comes first.
-func (h *Hub) FetchMinedWorkByAccount(id string) ([]*AcceptedWork, error) {
-	work, err := listMinedWorkByAccount(h.db, id, 10)
-	return work, err
 }
 
 // FetchPaymentsForAccount returns a list or payments made to the provided address.


### PR DESCRIPTION
Rebased on #173 

This PR implements pagination for mined blocks on the account details page. Also moves the GUI caching code into its own file which means we don't need to be concerned with the mutex handling outside of this file. Should also make #167 easier.