### PR TITLE
fix loadConfig error output.

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -227,6 +227,7 @@ func main() {
 	// and configures it accordingly.
 	cfg, _, err := loadConfig()
 	if err != nil {
+		fmt.Println(err)
 		return
 	}
 	defer func() {


### PR DESCRIPTION
This fixes a bug were the error from a `loadConfig` call was not getting outputted. dcrpool would exit without any errors as a result. Using `fmt` there instead of the logger because it's possible the logger is not initialized by `loadConfig` at the point where the error is generated.