### PR TITLE
Config improvements

### DIFF
--- a/config.go
+++ b/config.go
@@ -467,16 +467,14 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	if preCfg.ConfigFile != defaultConfigFile {
-		err := flags.NewIniParser(parser).ParseFile(preCfg.ConfigFile)
-		if err != nil {
-			if _, ok := err.(*os.PathError); !ok {
-				fmt.Fprintf(os.Stderr, "error parsing config file: %v\n", err)
-				fmt.Fprintln(os.Stderr, usageMessage)
-				return nil, nil, err
-			}
-			configFileError = err
+	err = flags.NewIniParser(parser).ParseFile(preCfg.ConfigFile)
+	if err != nil {
+		if _, ok := err.(*os.PathError); !ok {
+			fmt.Fprintf(os.Stderr, "error parsing config file: %v\n", err)
+			fmt.Fprintln(os.Stderr, usageMessage)
+			return nil, nil, err
 		}
+		configFileError = err
 	}
 
 	// Parse command line options again to ensure they take precedence.

--- a/config.go
+++ b/config.go
@@ -581,8 +581,9 @@ func loadConfig() (*config, []string, error) {
 
 		// Ensure address to collect pool fees is provided.
 		// jessevdk/go-flags does not automatically split the string, so at this
-		// point the first item of the array contains the full string.
-		if len(cfg.PoolFeeAddrs[0]) == 0 {
+		// point either the array is empty, or the first item of the array
+		// contains the full string.
+		if len(cfg.PoolFeeAddrs) == 0 || len(cfg.PoolFeeAddrs[0]) == 0 {
 			str := "%s: the poolfeeaddrs option is not set"
 			err := fmt.Errorf(str, funcName)
 			return nil, nil, err

--- a/config.go
+++ b/config.go
@@ -580,13 +580,15 @@ func loadConfig() (*config, []string, error) {
 		}
 
 		// Ensure address to collect pool fees is provided.
+		// jessevdk/go-flags does not automatically split the string, so at this
+		// point the first item of the array contains the full string.
 		if len(cfg.PoolFeeAddrs[0]) == 0 {
 			str := "%s: the poolfeeaddrs option is not set"
 			err := fmt.Errorf(str, funcName)
 			return nil, nil, err
 		}
 
-		// Parse pool fee addresses.
+		// Split the string into an array, and parse pool fee addresses.
 		cfg.PoolFeeAddrs = strings.Split(cfg.PoolFeeAddrs[0], ",")
 		for _, pAddr := range cfg.PoolFeeAddrs {
 			addr, err := dcrutil.DecodeAddress(pAddr, cfg.net)

--- a/config.go
+++ b/config.go
@@ -552,7 +552,7 @@ func loadConfig() (*config, []string, error) {
 			cfg.ActiveNet)
 	}
 
-	// Add default ports for the active network if there's no ports specified
+	// Add default ports for the active network if there are no ports specified.
 	cfg.DcrdRPCHost = normalizeAddress(cfg.DcrdRPCHost, cfg.net.DcrdRPCServerPort)
 	cfg.WalletGRPCHost = normalizeAddress(cfg.WalletGRPCHost, cfg.net.WalletRPCServerPort)
 
@@ -564,15 +564,15 @@ func loadConfig() (*config, []string, error) {
 			return nil, nil, err
 		}
 
-		// Ensure pool fee is valid
+		// Ensure pool fee is valid.
 		if cfg.PoolFee < 0 || cfg.PoolFee > 1 {
 			str := "%s: poolfee should be between 0 and 1"
 			err := fmt.Errorf(str, funcName)
 			return nil, nil, err
 		}
 
-		// Ensure the password to unlock the wallet.
-		// Needed to pay dividends to pool contributors.
+		// Ensure the password to unlock the wallet is provided.
+		// Wallet password is required to pay dividends to pool contributors.
 		if cfg.WalletPass == "" {
 			str := "%s: the walletpass option is not set"
 			err := fmt.Errorf(str, funcName)
@@ -586,7 +586,7 @@ func loadConfig() (*config, []string, error) {
 			return nil, nil, err
 		}
 
-		// Parse pool fee addresses
+		// Parse pool fee addresses.
 		cfg.PoolFeeAddrs = strings.Split(cfg.PoolFeeAddrs[0], ",")
 		for _, pAddr := range cfg.PoolFeeAddrs {
 			addr, err := dcrutil.DecodeAddress(pAddr, cfg.net)

--- a/dcrpool.go
+++ b/dcrpool.go
@@ -227,8 +227,8 @@ func main() {
 	// and configures it accordingly.
 	cfg, _, err := loadConfig()
 	if err != nil {
-		fmt.Println(err)
-		return
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 	defer func() {
 		if logRotator != nil {
@@ -239,7 +239,7 @@ func main() {
 	p, err := newPool(cfg)
 	if err != nil {
 		mpLog.Error(err)
-		return
+		os.Exit(1)
 	}
 
 	if cfg.Profile != "" {

--- a/dcrpool.go
+++ b/dcrpool.go
@@ -105,7 +105,7 @@ func newPool(cfg *config) (*miningPool, error) {
 
 	hcfg := &pool.HubConfig{
 		DB:                    db,
-		ActiveNet:             cfg.net,
+		ActiveNet:             cfg.net.Params,
 		PoolFee:               cfg.PoolFee,
 		MaxTxFeeReserve:       maxTxFeeReserve,
 		MaxGenTime:            cfg.MaxGenTime,
@@ -190,7 +190,7 @@ func newPool(cfg *config) (*miningPool, error) {
 		Domain:                  cfg.Domain,
 		TLSCertFile:             cfg.TLSCert,
 		TLSKeyFile:              cfg.TLSKey,
-		ActiveNet:               cfg.net,
+		ActiveNet:               cfg.net.Params,
 		PaymentMethod:           cfg.PaymentMethod,
 		Designation:             cfg.Designation,
 		PoolFee:                 cfg.PoolFee,

--- a/params.go
+++ b/params.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/decred/dcrd/chaincfg/v2"
+)
+
+type params struct {
+	*chaincfg.Params
+	DcrdRPCServerPort   string
+	WalletRPCServerPort string
+}
+
+var mainNetParams = params{
+	Params:              chaincfg.MainNetParams(),
+	DcrdRPCServerPort:   "9109",
+	WalletRPCServerPort: "9110",
+}
+
+var testNet3Params = params{
+	Params:              chaincfg.TestNet3Params(),
+	DcrdRPCServerPort:   "19109",
+	WalletRPCServerPort: "19110",
+}
+
+var simNetParams = params{
+	Params:              chaincfg.SimNetParams(),
+	DcrdRPCServerPort:   "19556",
+	WalletRPCServerPort: "19557",
+}


### PR DESCRIPTION
- Remove default dcrd user/pass and provide a descriptive error if they are not set.
- Remove default `WalletPass` and `PoolFeeAddr`. They were set to `""`, which is already the zero value for a string.
- Remove an errant `if` statement which was preventing the default config file from loading
- Ensure `PoolFee` is `>=0` and `<=1` in solo mode. **Question: Do we actually want to allow 0% or 100%?**
- Ensure `WalletPass` is provided when in solo mode.
- Ensure `PoolFeeAddrs` is provided when in solo mode, and also ensure it is properly split when multiple addresses are provided.
- If the pool cannot start, log error to stderr and finished with exit code 1.
- Automatically use the default main/test/sim network ports for dcrd/dcrwallet 