### PR TITLE
Use wallet gRPC

### DIFF
--- a/cmd/miner/config.go
+++ b/cmd/miner/config.go
@@ -391,6 +391,9 @@ func loadConfig() (*config, []string, error) {
 		cfg.net = chaincfg.TestNet3Params()
 	case chaincfg.MainNetParams().Name:
 		cfg.net = chaincfg.MainNetParams()
+	default:
+		return nil, nil, fmt.Errorf("unknown network provided %v",
+			cfg.ActiveNet)
 	}
 
 	// Validate format of profile, can be an address:port, or just a port.

--- a/config.go
+++ b/config.go
@@ -554,7 +554,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Add default ports for the active network if there are no ports specified.
 	cfg.DcrdRPCHost = normalizeAddress(cfg.DcrdRPCHost, cfg.net.DcrdRPCServerPort)
-	cfg.WalletGRPCHost = normalizeAddress(cfg.WalletGRPCHost, cfg.net.WalletRPCServerPort)
+	cfg.WalletGRPCHost = normalizeAddress(cfg.WalletGRPCHost, cfg.net.WalletGRPCServerPort)
 
 	if !cfg.SoloPool {
 		// Ensure a valid payment method is set.

--- a/params.go
+++ b/params.go
@@ -10,24 +10,24 @@ import (
 
 type params struct {
 	*chaincfg.Params
-	DcrdRPCServerPort   string
-	WalletRPCServerPort string
+	DcrdRPCServerPort    string
+	WalletGRPCServerPort string
 }
 
 var mainNetParams = params{
-	Params:              chaincfg.MainNetParams(),
-	DcrdRPCServerPort:   "9109",
-	WalletRPCServerPort: "9110",
+	Params:               chaincfg.MainNetParams(),
+	DcrdRPCServerPort:    "9109",
+	WalletGRPCServerPort: "9111",
 }
 
 var testNet3Params = params{
-	Params:              chaincfg.TestNet3Params(),
-	DcrdRPCServerPort:   "19109",
-	WalletRPCServerPort: "19110",
+	Params:               chaincfg.TestNet3Params(),
+	DcrdRPCServerPort:    "19109",
+	WalletGRPCServerPort: "19111",
 }
 
 var simNetParams = params{
-	Params:              chaincfg.SimNetParams(),
-	DcrdRPCServerPort:   "19556",
-	WalletRPCServerPort: "19557",
+	Params:               chaincfg.SimNetParams(),
+	DcrdRPCServerPort:    "19556",
+	WalletGRPCServerPort: "19558",
 }

--- a/pool/message.go
+++ b/pool/message.go
@@ -349,14 +349,16 @@ func ParseSubscribeResponse(resp *Response) (string, string, string, uint64, err
 // SetDifficultyNotification creates a set difficulty notification message.
 func SetDifficultyNotification(difficulty *big.Rat) *Request {
 	diff, _ := difficulty.Float64()
-	iDiff := uint64(diff)
-	if iDiff == 0 {
-		iDiff = 1
+
+	// Convert the diff to a uint64 to ensure it does not get rounded to zero.
+	roundDiff := uint64(diff)
+	if roundDiff == 0 {
+		roundDiff = 1
 	}
 
 	return &Request{
 		Method: SetDifficulty,
-		Params: []uint64{iDiff},
+		Params: []uint64{roundDiff},
 	}
 }
 

--- a/pool/message.go
+++ b/pool/message.go
@@ -349,9 +349,14 @@ func ParseSubscribeResponse(resp *Response) (string, string, string, uint64, err
 // SetDifficultyNotification creates a set difficulty notification message.
 func SetDifficultyNotification(difficulty *big.Rat) *Request {
 	diff, _ := difficulty.Float64()
+	iDiff := uint64(diff)
+	if iDiff == 0 {
+		iDiff = 1
+	}
+
 	return &Request{
 		Method: SetDifficulty,
-		Params: []uint64{uint64(diff)},
+		Params: []uint64{iDiff},
 	}
 }
 

--- a/pool/message.go
+++ b/pool/message.go
@@ -350,7 +350,8 @@ func ParseSubscribeResponse(resp *Response) (string, string, string, uint64, err
 func SetDifficultyNotification(difficulty *big.Rat) *Request {
 	diff, _ := difficulty.Float64()
 
-	// Convert the diff to a uint64 to ensure it does not get rounded to zero.
+	// Convert the diff to a uint64 and if the result is zero, set it to one
+	// instead. This ensures that a zero difficulty is never sent to the client.
 	roundDiff := uint64(diff)
 	if roundDiff == 0 {
 		roundDiff = 1


### PR DESCRIPTION
- Use correct gRPC ports for dcrwallet.
- `cmd/miner` - log an error on invalid network selection
- Ensure difficulty is not zero - return 1 instead.