### PR TITLE
Introduce cache and more pagination.

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -158,12 +158,10 @@ func newPool(cfg *config) (*miningPool, error) {
 		AddPaymentRequest:       p.hub.AddPaymentRequest,
 		FetchMinedWork:          p.hub.FetchMinedWork,
 		FetchWorkQuotas:         p.hub.FetchWorkQuotas,
-		FetchPoolHashRate:       p.hub.FetchPoolHashRate,
 		BackupDB:                p.hub.BackupDB,
 		FetchClientInfo:         p.hub.FetchClientInfo,
 		AccountExists:           p.hub.AccountExists,
 		FetchPaymentsForAccount: p.hub.FetchPaymentsForAccount,
-		FetchAccountClientInfo:  p.hub.FetchAccountClientInfo,
 	}
 	p.gui, err = gui.NewGUI(gcfg)
 	if err != nil {

--- a/dcrpool.go
+++ b/dcrpool.go
@@ -162,7 +162,6 @@ func newPool(cfg *config) (*miningPool, error) {
 		BackupDB:                p.hub.BackupDB,
 		FetchClientInfo:         p.hub.FetchClientInfo,
 		AccountExists:           p.hub.AccountExists,
-		FetchMinedWorkByAccount: p.hub.FetchMinedWorkByAccount,
 		FetchPaymentsForAccount: p.hub.FetchPaymentsForAccount,
 		FetchAccountClientInfo:  p.hub.FetchAccountClientInfo,
 	}

--- a/dcrpool.go
+++ b/dcrpool.go
@@ -159,7 +159,7 @@ func newPool(cfg *config) (*miningPool, error) {
 		FetchMinedWork:          p.hub.FetchMinedWork,
 		FetchWorkQuotas:         p.hub.FetchWorkQuotas,
 		BackupDB:                p.hub.BackupDB,
-		FetchClientInfo:         p.hub.FetchClientInfo,
+		FetchClients:            p.hub.FetchClients,
 		AccountExists:           p.hub.AccountExists,
 		FetchPaymentsForAccount: p.hub.FetchPaymentsForAccount,
 	}

--- a/gui/account.go
+++ b/gui/account.go
@@ -18,7 +18,7 @@ type accountPageData struct {
 	HeaderData       headerData
 	MinedWork        []minedWork
 	Payments         []*pool.Payment
-	Clients          []*pool.ClientInfo
+	ConnectedClients []client
 	AccountID        string
 	Address          string
 	BlockExplorerURL string
@@ -66,6 +66,8 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clients := ui.cache.getClients()[accountID]
+
 	data := &accountPageData{
 		HeaderData: headerData{
 			CSRF:        csrf.TemplateField(r),
@@ -74,7 +76,7 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 		},
 		MinedWork:        recentWork,
 		Payments:         payments,
-		Clients:          ui.cfg.FetchAccountClientInfo(accountID),
+		ConnectedClients: clients,
 		AccountID:        accountID,
 		Address:          address,
 		BlockExplorerURL: ui.cfg.BlockExplorerURL,

--- a/gui/account.go
+++ b/gui/account.go
@@ -66,7 +66,11 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Get this accounts connected clients (max 10).
 	clients := ui.cache.getClients()[accountID]
+	if len(clients) > 10 {
+		clients = clients[0:10]
+	}
 
 	data := &accountPageData{
 		HeaderData: headerData{

--- a/gui/account.go
+++ b/gui/account.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gui
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/decred/dcrpool/pool"
+	"github.com/gorilla/csrf"
+	"github.com/gorilla/mux"
+)
+
+// accountPageData contains all of the necessary information to render the
+// account template.
+type accountPageData struct {
+	HeaderData       headerData
+	MinedWork        []*pool.AcceptedWork
+	Payments         []*pool.Payment
+	Clients          []*pool.ClientInfo
+	AccountID        string
+	Address          string
+	BlockExplorerURL string
+}
+
+// Account is the handler for "GET /account/{address}". Renders the account
+// template if the provided address is valid and has associated account
+// information, otherwise renders the index template with an appopriate error
+// message.
+func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		http.Error(w, "Session error", http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	address := mux.Vars(r)["address"]
+	if address == "" {
+		ui.renderIndex(w, r, "No address provided")
+		return
+	}
+
+	// Generate the account id of the provided address.
+	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
+	if err != nil {
+		ui.renderIndex(w, r, "Unable to generate account ID for address")
+		return
+	}
+
+	if !ui.cfg.AccountExists(accountID) {
+		ui.renderIndex(w, r, "Nothing found for address")
+		return
+	}
+
+	work, err := ui.cfg.FetchMinedWorkByAccount(accountID)
+	if err != nil {
+		ui.renderIndex(w, r, fmt.Sprintf("FetchMinedWorkByAddress error: %v",
+			err.Error()))
+		return
+
+	}
+
+	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
+	if err != nil {
+		ui.renderIndex(w, r, fmt.Sprintf("FetchPaymentsForAddress error: %v",
+			err.Error()))
+		return
+	}
+
+	data := &accountPageData{
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    true,
+		},
+		MinedWork:        work,
+		Payments:         payments,
+		Clients:          ui.cfg.FetchAccountClientInfo(accountID),
+		AccountID:        accountID,
+		Address:          address,
+		BlockExplorerURL: ui.cfg.BlockExplorerURL,
+	}
+
+	ui.renderTemplate(w, "account", data)
+}
+
+// IsPoolAccount is the handler for "GET /account_exist". If the provided
+// address has an account on the server a "200 OK" response is returned,
+// otherwise a "400 Bad Request" is returned.
+func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		http.Error(w, "Session error", http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	address := r.FormValue("address")
+
+	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
+	if err != nil {
+		http.Error(w, "Invalid address", http.StatusBadRequest)
+		return
+	}
+
+	if !ui.cfg.AccountExists(accountID) {
+		http.Error(w, "Nothing found for address", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/gui/account.go
+++ b/gui/account.go
@@ -61,17 +61,16 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the most recently mined blocks by this account (max 10)
-	work := make([]minedWork, 0)
-	ui.minedWorkMtx.RLock()
-	for _, v := range ui.minedWork {
+	allWork := ui.cache.getMinedWork()
+	recentWork := make([]minedWork, 0)
+	for _, v := range allWork {
 		if v.AccountID == accountID {
-			work = append(work, v)
-			if len(work) >= 10 {
+			recentWork = append(recentWork, v)
+			if len(recentWork) >= 10 {
 				break
 			}
 		}
 	}
-	ui.minedWorkMtx.RUnlock()
 
 	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
 	if err != nil {
@@ -86,7 +85,7 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 			Designation: ui.cfg.Designation,
 			ShowMenu:    true,
 		},
-		MinedWork:        work,
+		MinedWork:        recentWork,
 		Payments:         payments,
 		Clients:          ui.cfg.FetchAccountClientInfo(accountID),
 		AccountID:        accountID,

--- a/gui/account.go
+++ b/gui/account.go
@@ -89,21 +89,21 @@ func (ui *GUI) Account(w http.ResponseWriter, r *http.Request) {
 	ui.renderTemplate(w, "account", data)
 }
 
-// IsPoolAccount is the handler for "GET /account_exist". If the provided
+// IsPoolAccount is the handler for "HEAD /account". If the provided
 // address has an account on the server a "200 OK" response is returned,
-// otherwise a "400 Bad Request" is returned.
+// otherwise a "400 Bad Request" or "404 Not Found" are returned.
 func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
 
 	address := r.FormValue("address")
 
 	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
 	if err != nil {
-		http.Error(w, "Invalid address", http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	if !ui.cfg.AccountExists(accountID) {
-		http.Error(w, "Nothing found for address", http.StatusBadRequest)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package gui
 
 import (
-	"html/template"
 	"net/http"
 
 	"github.com/gorilla/csrf"
@@ -13,12 +12,12 @@ import (
 	"github.com/decred/dcrpool/pool"
 )
 
+// adminPageData contains all of the necessary information to render the admin
+// template.
 type adminPageData struct {
-	Connections map[string][]*pool.ClientInfo
-	CSRF        template.HTML
-	Designation string
-	PoolStats   poolStats
-	Admin       bool
+	HeaderData    headerData
+	PoolStatsData poolStatsData
+	Connections   map[string][]*pool.ClientInfo
 }
 
 // AdminPage is the handler for "GET /admin". If the current session is
@@ -46,22 +45,22 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 	poolHash := ui.poolHash
 	ui.poolHashMtx.RUnlock()
 
-	poolStats := poolStats{
-		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
-		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		PaymentMethod:     ui.cfg.PaymentMethod,
-		Network:           ui.cfg.ActiveNet.Name,
-		PoolFee:           ui.cfg.PoolFee,
-		SoloPool:          ui.cfg.SoloPool,
-	}
-
 	pageData := adminPageData{
-		CSRF:        csrf.TemplateField(r),
-		Designation: ui.cfg.Designation,
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    false,
+		},
+		PoolStatsData: poolStatsData{
+			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
+			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
+			PoolHashRate:      poolHash,
+			PaymentMethod:     ui.cfg.PaymentMethod,
+			Network:           ui.cfg.ActiveNet.Name,
+			PoolFee:           ui.cfg.PoolFee,
+			SoloPool:          ui.cfg.SoloPool,
+		},
 		Connections: ui.cfg.FetchClientInfo(),
-		PoolStats:   poolStats,
-		Admin:       true,
 	}
 
 	ui.renderTemplate(w, "admin", pageData)

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -41,10 +41,6 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ui.poolHashMtx.RLock()
-	poolHash := ui.poolHash
-	ui.poolHashMtx.RUnlock()
-
 	pageData := adminPageData{
 		HeaderData: headerData{
 			CSRF:        csrf.TemplateField(r),
@@ -54,7 +50,7 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 		PoolStatsData: poolStatsData{
 			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
 			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-			PoolHashRate:      poolHash,
+			PoolHashRate:      ui.cache.getPoolHash(),
 			PaymentMethod:     ui.cfg.PaymentMethod,
 			Network:           ui.cfg.ActiveNet.Name,
 			PoolFee:           ui.cfg.PoolFee,

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -9,16 +9,14 @@ import (
 
 	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
-
-	"github.com/decred/dcrpool/pool"
 )
 
 // adminPageData contains all of the necessary information to render the admin
 // template.
 type adminPageData struct {
-	HeaderData    headerData
-	PoolStatsData poolStatsData
-	Connections   map[string][]*pool.ClientInfo
+	HeaderData       headerData
+	PoolStatsData    poolStatsData
+	ConnectedClients map[string][]client
 }
 
 // AdminPage is the handler for "GET /admin". If the current session is
@@ -31,6 +29,8 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
+
+	clients := ui.cache.getClients()
 
 	pageData := adminPageData{
 		HeaderData: headerData{
@@ -47,7 +47,7 @@ func (ui *GUI) AdminPage(w http.ResponseWriter, r *http.Request) {
 			PoolFee:           ui.cfg.PoolFee,
 			SoloPool:          ui.cfg.SoloPool,
 		},
-		Connections: ui.cfg.FetchClientInfo(),
+		ConnectedClients: clients,
 	}
 
 	ui.renderTemplate(w, "admin", pageData)

--- a/gui/assets/public/css/dcrpool.css
+++ b/gui/assets/public/css/dcrpool.css
@@ -8709,7 +8709,7 @@ https://flickity.metafizzy.co
 .icon-warning {
   width: 20px;
   height: 20px;
-  background-image: url(/images/warning-sign.svg);
+  background-image: url('/assets/images/warning-sign.svg');
   background-repeat: no-repeat;
   opacity: 0;
   transition: all 0.25s;
@@ -8868,7 +8868,7 @@ table td {
 .modalbtn {
   width: 24px;
   height: 24px;
-  background: transparent url('/images/dropdown.svg') 0% 0% no-repeat padding-box;
+  background: transparent url('/assets/images/dropdown.svg') 0% 0% no-repeat padding-box;
   opacity: 1;
   cursor: pointer;
 }

--- a/gui/assets/public/css/dcrpool.css
+++ b/gui/assets/public/css/dcrpool.css
@@ -1946,7 +1946,7 @@ textarea.form-control {
 
 .btn {
   display: inline-block;
-  font-weight: 400;
+  font-weight: bold;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -2004,8 +2004,8 @@ fieldset:disabled a.btn {
     border-color: #005cbf; }
     .btn-primary:not(:disabled):not(.disabled):active:focus, .btn-primary:not(:disabled):not(.disabled).active:focus,
     .show > .btn-primary.dropdown-toggle:focus {
-      -webkit-box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);
-              box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5); }
+      -webkit-box-shadow: none;
+              box-shadow: none; }
 
 .btn-secondary {
   color: #fff;
@@ -4342,26 +4342,30 @@ input[type="button"].btn-block {
     background-color: #1b1e21;
     border-color: #1b1e21; }
 
-.close {
+.modal-close {
   float: right;
   font-size: 1.7rem;
   font-weight: 100;
   line-height: 1;
   color: #000;
   text-shadow: 0 1px 0 #fff;
-  opacity: .4; }
-  .close:not(:disabled):not(.disabled) {
-    cursor: pointer; }
-    .close:not(:disabled):not(.disabled):hover, .close:not(:disabled):not(.disabled):focus {
-      color: #000;
-      text-decoration: none;
-      opacity: .65; }
-
-button.close {
   padding: 0;
   background-color: transparent;
   border: 0;
-  -webkit-appearance: none; }
+  -webkit-appearance: none;
+  opacity: .4; }
+.modal-close:not(:disabled):not(.disabled) {
+  cursor: pointer; }
+.modal-close:not(:disabled):not(.disabled):hover,
+.modal-close:not(:disabled):not(.disabled):focus {
+  color: #000;
+  text-decoration: none;
+  opacity: .65; }
+
+.modal-close:active,
+.modal-close:focus {
+  outline: none;
+}
 
 .modal-open {
   overflow: hidden; }
@@ -4440,11 +4444,11 @@ button.close {
   bottom: 0;
   left: 0;
   z-index: 1040;
-  background-color: #000; }
+  background-color: #091440; }
   .modal-backdrop.fade {
     opacity: 0; }
   .modal-backdrop.show {
-    opacity: 0.5; }
+    opacity: 0.3; }
 
 .modal-header {
   display: -webkit-box;
@@ -8334,20 +8338,6 @@ input[type="submit"]:disabled {
             box-shadow: 0 1px 2px 0 rgba(9, 20, 64, 0.21); }
     .modal-blockquote span {
       color: #fd704a; }
-  .modal-close {
-    padding: 0;
-    cursor: pointer;
-    -webkit-appearance: none !important;
-    border: 0;
-    background: transparent; }
-  .modal-close img {
-    vertical-align: super;
-  }
-    .modal-close:focus {
-      outline: none; }
-    @media (max-width: 1199.98px) {
-      .modal-close img {
-        width: 16px; } }
   .modal-header {
     border: 0; }
   .modal-dialog {
@@ -8359,8 +8349,6 @@ input[type="submit"]:disabled {
   .modal-header--long-title .modal-title {
     max-width: 60%;
     text-align: right; }
-  .modal-header--long-title .modal-close {
-    margin: -20px 0 4px 0; }
   .modal-header--long-title img {
     float: right; }
   .modal-header--long-title span {
@@ -8381,7 +8369,7 @@ input[type="submit"]:disabled {
     font-size: 28px;
     line-height: 1.26;
     letter-spacing: normal;
-    color: #48566e; }
+    color: #3D5873; }
     @media (max-width: 767.98px) {
       .modal-title {
         font-size: 18px; } }
@@ -8394,7 +8382,7 @@ input[type="submit"]:disabled {
         max-height: 100vh; } }
     .modal-body p {
       font-size: 16px;
-      color: #48566e; }
+      color: #091440; }
     .modal-body strong {
       color: #091440;
       margin-bottom: 1rem;

--- a/gui/assets/public/css/fonts.css
+++ b/gui/assets/public/css/fonts.css
@@ -1,30 +1,30 @@
 @font-face {
     font-family: "dcrpool-code";
     src:
-        url("/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.ttf.woff2") format("woff2"),
-        url("/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.ttf.woff")  format("woff"),
-        url("/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.ttf")       format("truetype"),
-        url("/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.eot")       format("embedded-opentype");
+        url("/assets/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.ttf.woff2") format("woff2"),
+        url("/assets/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.ttf.woff")  format("woff"),
+        url("/assets/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.ttf")       format("truetype"),
+        url("/assets/css/fonts/SourceCodePro-Regular/SourceCodePro-Regular.eot")       format("embedded-opentype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "dcrpool";
     src:
-        url("/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.ttf.woff2") format("woff2"),
-        url("/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.ttf.woff") format("woff"),
-        url("/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.ttf") format("truetype"),
-        url("/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.eot") format("embedded-opentype");
+        url("/assets/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.ttf.woff2") format("woff2"),
+        url("/assets/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.ttf.woff") format("woff"),
+        url("/assets/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.ttf") format("truetype"),
+        url("/assets/css/fonts/SourceSansPro-Regular/SourceSansPro-Regular.eot") format("embedded-opentype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "dcrpool";
     src:
-        url("/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.ttf.woff2") format("woff2"),
-        url("/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.ttf.woff") format("woff"),
-        url("/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.ttf") format("truetype"),
-        url("/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.eot") format("embedded-opentype");
+        url("/assets/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.ttf.woff2") format("woff2"),
+        url("/assets/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.ttf.woff") format("woff"),
+        url("/assets/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.ttf") format("truetype"),
+        url("/assets/css/fonts/SourceSansPro-Semibold/SourceSansPro-Semibold.eot") format("embedded-opentype");
     font-weight: bold;
     font-display: swap;
 }
@@ -32,10 +32,10 @@
 @font-face {
     font-family: "dcrpool";
     src:
-        url("/css/fonts/SourceSansPro-It/SourceSansPro-It.ttf.woff2") format("woff2"),
-        url("/css/fonts/SourceSansPro-It/SourceSansPro-It.ttf.woff") format("woff"),
-        url("/css/fonts/SourceSansPro-It/SourceSansPro-It.ttf") format("truetype"),
-        url("/css/fonts/SourceSansPro-It/SourceSansPro-It.eot") format("embedded-opentype");
+        url("/assets/css/fonts/SourceSansPro-It/SourceSansPro-It.ttf.woff2") format("woff2"),
+        url("/assets/css/fonts/SourceSansPro-It/SourceSansPro-It.ttf.woff") format("woff"),
+        url("/assets/css/fonts/SourceSansPro-It/SourceSansPro-It.ttf") format("truetype"),
+        url("/assets/css/fonts/SourceSansPro-It/SourceSansPro-It.eot") format("embedded-opentype");
     font-style: italic;
     font-display: swap;
 }
@@ -43,10 +43,10 @@
 @font-face {
     font-family: "dcrpool";
     src:
-        url("/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.ttf.woff2") format("woff2"),
-        url("/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.ttf.woff") format("woff"),
-        url("/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.ttf") format("truetype"),
-        url("/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.eot") format("embedded-opentype");
+        url("/assets/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.ttf.woff2") format("woff2"),
+        url("/assets/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.ttf.woff") format("woff"),
+        url("/assets/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.ttf") format("truetype"),
+        url("/assets/css/fonts/SourceSansPro-SemiboldIt/SourceSansPro-SemiboldIt.eot") format("embedded-opentype");
     font-style: italic;
     font-weight: bold;   
     font-display: swap;

--- a/gui/assets/public/css/pagination.css
+++ b/gui/assets/public/css/pagination.css
@@ -58,8 +58,8 @@
   background-position: center;
 }
 .paginationjs .pagination-arrow-right {
-  background-image: url(/images/right_arrow.svg);
+  background-image: url('/assets/images/right_arrow.svg');
 }
 .paginationjs .pagination-arrow-left {
-  background-image: url(/images/left_arrow.svg);
+  background-image: url('/assets/images/left_arrow.svg');
 }

--- a/gui/assets/public/images/favicon/browserconfig.xml
+++ b/gui/assets/public/images/favicon/browserconfig.xml
@@ -2,10 +2,10 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square70x70logo src="/images/favicon/mstile-70x70.png?v=gT6Mc"/>
-            <square150x150logo src="/images/favicon/mstile-150x150.png?v=gT6Mc"/>
-            <square310x310logo src="/images/favicon/mstile-310x310.png?v=gT6Mc"/>
-            <wide310x150logo src="/images/favicon/mstile-310x150.png?v=gT6Mc"/>
+            <square70x70logo src="/assets/images/favicon/mstile-70x70.png?v=gT6Mc"/>
+            <square150x150logo src="/assets/images/favicon/mstile-150x150.png?v=gT6Mc"/>
+            <square310x310logo src="/assets/images/favicon/mstile-310x310.png?v=gT6Mc"/>
+            <wide310x150logo src="/assets/images/favicon/mstile-310x150.png?v=gT6Mc"/>
             <TileColor>#091440</TileColor>
         </tile>
     </msapplication>

--- a/gui/assets/public/images/favicon/manifest.json
+++ b/gui/assets/public/images/favicon/manifest.json
@@ -3,27 +3,27 @@
     "short_name": "Decred",
     "icons": [
         {
-            "src": "/images/favicon/ic_launcher_mdpi.png?v=vMddPLeYWy",
+            "src": "/assets/images/favicon/ic_launcher_mdpi.png?v=vMddPLeYWy",
             "sizes": "48x48",
             "type": "image/png"
         },
     	{
-            "src": "/images/favicon/ic_launcher_hdpi.png?v=vMddPLeYWy",
+            "src": "/assets/images/favicon/ic_launcher_hdpi.png?v=vMddPLeYWy",
             "sizes": "72x72",
             "type": "image/png"
         },
         {
-            "src": "/images/favicon/ic_launcher_xhdpi.png?v=vMddPLeYWy",
+            "src": "/assets/images/favicon/ic_launcher_xhdpi.png?v=vMddPLeYWy",
             "sizes": "96x96",
             "type": "image/png"
         },
         {
-            "src": "/images/favicon/ic_launcher_xxhdpi.png?v=vMddPLeYWy",
+            "src": "/assets/images/favicon/ic_launcher_xxhdpi.png?v=vMddPLeYWy",
             "sizes": "144x144",
             "type": "image/png"
         },
         {
-            "src": "/images/favicon/ic_launcher_xxxhdpi.png?v=vMddPLeYWy",
+            "src": "/assets/images/favicon/ic_launcher_xxxhdpi.png?v=vMddPLeYWy",
             "sizes": "192x192",
             "type": "image/png"
         }

--- a/gui/assets/public/js/carousel.js
+++ b/gui/assets/public/js/carousel.js
@@ -29,8 +29,8 @@ for (i = 0; i < total; i++) {
     }
 }
 
-$('.carousel-nav').prepend('<li class="carousel-nav__previous"><img src="/images/arrow-prev.svg"></li>');
-$('.carousel-nav').append('<li class="carousel-nav__next"><img src="/images/arrow-next.svg"></li>');
+$('.carousel-nav').prepend('<li class="carousel-nav__previous"><img src="/assets/images/arrow-prev.svg"></li>');
+$('.carousel-nav').append('<li class="carousel-nav__next"><img src="/assets/images/arrow-next.svg"></li>');
 
 var $cellButtons = $cellButtonGroup.find('.carousel-nav__dot');
 

--- a/gui/assets/public/js/modal.js
+++ b/gui/assets/public/js/modal.js
@@ -48,7 +48,7 @@ $("#account-form").on("submit", function (e) {
         type: $(this).attr('method'),
         data: $(this).serialize(),
         success: function() {
-            window.location.replace("/?address="+address);
+            window.location.replace("/account/"+address);
         },
         error: function(response) {
             if (response.status === 400 || response.status === 429) {

--- a/gui/assets/public/js/modal.js
+++ b/gui/assets/public/js/modal.js
@@ -48,7 +48,7 @@ $("#account-form").on("submit", function (e) {
         type: $(this).attr('method'),
         data: $(this).serialize(),
         success: function() {
-            window.location.replace("/account/"+address);
+            window.location.replace("/account?address="+address);
         },
         error: function(response) {
             if (response.status === 400 || response.status === 429) {

--- a/gui/assets/public/js/modal.js
+++ b/gui/assets/public/js/modal.js
@@ -51,11 +51,20 @@ $("#account-form").on("submit", function (e) {
             window.location.replace("/account?address="+address);
         },
         error: function(response) {
-            if (response.status === 400 || response.status === 429) {
-                showError($("#account-form"), response.responseText);
-            } else {
-                showError($("#account-form"), "An error occurred");
-            }
+            switch(response.status) {
+                case 400:
+                    showError($("#account-form"), "Invalid address");
+                    break;
+                case 404:
+                    showError($("#account-form"), "Nothing found for address");
+                    break;
+                case 429:
+                    showError($("#account-form"), "Request limit exceeded");
+                    break;
+                default:
+                    showError($("#account-form"), "An error occurred");
+                    break;
+            };
         },
     });
 });

--- a/gui/assets/public/js/pagination.js
+++ b/gui/assets/public/js/pagination.js
@@ -25,7 +25,7 @@ if ( $('#blocks-page-select').length ) {
 
 if ( $('#blocks-by-account-page-select').length ) {
     $('#blocks-by-account-page-select').pagination({
-        dataSource: "/blocks_by_account?accountID=" + accountID + "&",
+        dataSource: "/account/" + accountID + "/blocks",
         hideWhenLessThanOnePage: true,
         nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
         prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',

--- a/gui/assets/public/js/pagination.js
+++ b/gui/assets/public/js/pagination.js
@@ -47,3 +47,28 @@ if ( $('#blocks-by-account-page-select').length ) {
         }
     });
 };
+
+if ( $('#account-clients-page-select').length ) {
+    $('#account-clients-page-select').pagination({
+        dataSource: "/account/" + accountID + "/clients",
+        hideWhenLessThanOnePage: true,
+        nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
+        prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',
+        locator: "clients",
+        totalNumberLocator: function(response) {
+            return response.count;
+        },
+        callback: function(data) {
+            var html = '';
+
+            if (data.length > 0) {
+                $.each(data, function(_, item){
+                    html += '<tr><td>' + item.miner + '</td><td>' + item.hashrate + '</td></tr>';
+                });
+            } else {
+                html += '<tr><td colspan="100%"><span class="no-data">No connected clients</span></td></tr>';
+            }
+            $('#account-clients-table').html(html);
+        }
+    });
+};

--- a/gui/assets/public/js/pagination.js
+++ b/gui/assets/public/js/pagination.js
@@ -1,25 +1,49 @@
-$('#mined-blocks-page-select').pagination({
-    dataSource: "/mined_blocks",
-    autoHideNext: false,
-    autoHidePrevious: false,
-    hideWhenLessThanOnePage: true,
-    pageSize: 10,
-    nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
-    prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',
-    locator: "blocks",
-    totalNumberLocator: function(response) {
-        return response.count;
-    },
-    callback: function(data) {
-        var html = '';
-
-        if (data.length > 0) {
-            $.each(data, function(index, item){
-                html += '<tr><td><a href="' + item.blockurl + '" rel="noopener noreferrer">' + item.blockheight + '</a></td><td>' + item.miner + '</td><td><span class="dcr-label">' + item.minedby + '</span></td></tr>';
-            });
-        } else {
-            html += '<tr><td colspan="100%"><span class="no-data">No mined blocks</span></td></tr>';
+if ( $('#blocks-page-select').length ) {
+    $('#blocks-page-select').pagination({
+        dataSource: "/blocks",
+        hideWhenLessThanOnePage: true,
+        nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
+        prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',
+        locator: "blocks",
+        totalNumberLocator: function(response) {
+            return response.count;
+        },
+        callback: function(data) {
+            var html = '';
+    
+            if (data.length > 0) {
+                $.each(data, function(_, item){
+                    html += '<tr><td><a href="' + item.blockurl + '" rel="noopener noreferrer">' + item.blockheight + '</a></td><td>' + item.miner + '</td><td><span class="dcr-label">' + item.minedby + '</span></td></tr>';
+                });
+            } else {
+                html += '<tr><td colspan="100%"><span class="no-data">No mined blocks</span></td></tr>';
+            }
+            $('#blocks-table').html(html);
         }
-        $('#mined-blocks-table-body').html(html);
-    }
-})
+    });
+};
+
+if ( $('#blocks-by-account-page-select').length ) {
+    $('#blocks-by-account-page-select').pagination({
+        dataSource: "/blocks_by_account?accountID=" + accountID + "&",
+        hideWhenLessThanOnePage: true,
+        nextText: '<div class="pagination-arrow pagination-arrow-right"></div>',
+        prevText: '<div class="pagination-arrow pagination-arrow-left"></div>',
+        locator: "blocks",
+        totalNumberLocator: function(response) {
+            return response.count;
+        },
+        callback: function(data) {
+            var html = '';
+
+            if (data.length > 0) {
+                $.each(data, function(_, item){
+                    html += '<tr><td><a href="' + item.blockurl + '" rel="noopener noreferrer">' + item.blockheight + '</a></td><td>' + item.confirmed + '</td><td>' + item.miner + '</td></tr>';
+                });
+            } else {
+                html += '<tr><td colspan="100%"><span class="no-data">No mined blocks</span></td></tr>';
+            }
+            $('#blocks-by-account-table').html(html);
+        }
+    });
+};

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -115,29 +115,29 @@
         <div class="col-lg-6 col-12 p-3">
             <div class="block__content">
                 <h1>Connected Clients</h1>
-                <div class="overflow-auto">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Miner</th>
+                            <th>Hash Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody id="account-clients-table">
+                        {{ range .ConnectedClients }}
+                        <tr>
+                            <td>{{.Miner}}</td>
+                            <td>{{.HashRate}}</td>
+                        </tr>
+                        {{else}}
+                        <tr>
+                            <td colspan="100%"><span class="no-data">No connected clients</span></td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
 
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th>Miner</th>
-                                <th>Hash Rate</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {{ range .Clients }}
-                            <tr>
-                                <td>{{.Miner}}</td>
-                                <td>{{hashString .HashRate}}</td>
-                            </tr>
-                            {{else}}
-                            <tr>
-                                <td colspan="100%"><span class="no-data">No connected clients</span></td>
-                            </tr>
-                            {{end}}
-                        </tbody>
-                    </table>
-                </div>
+                <div id="account-clients-page-select" class="page-select"></div>
+
             </div>
         </div>
 

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -146,8 +146,8 @@
 <script>
     var accountID = "{{.AccountID}}";
 </script>
-<script src='/js/modal.js'></script>
-<script src='/js/pagination.js'></script>
+<script src='/assets/js/modal.js'></script>
+<script src='/assets/js/pagination.js'></script>
 
 </body>
 </html>

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -83,31 +83,30 @@
         <div class="col-lg-6 col-12 p-3">
             <div class="block__content">
                 <h1>Blocks Mined</h1>
-                <div class="overflow-auto">
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th>Height</th>
-                                <th>Confirmed</th>
-                                <th>Miner</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {{ range .MinedWork }}
-                            <tr>
-                                <td><a href="{{ .BlockURL}}"
-                                        rel="noopener noreferrer">{{.BlockHeight}}</a></td>
-                                <td>{{.Confirmed}}</td>
-                                <td>{{.Miner}}</td>
-                            </tr>
-                            {{else}}
-                            <tr>
-                                <td colspan="100%"><span class="no-data">No mined work</span></td>
-                            </tr>
-                            {{end}}
-                        </tbody>
-                    </table>
-                </div>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Height</th>
+                            <th>Confirmed</th>
+                            <th>Miner</th>
+                        </tr>
+                    </thead>
+                    <tbody id="blocks-by-account-table">
+                        {{ range .MinedWork }}
+                        <tr>
+                            <td><a href="{{ .BlockURL}}" rel="noopener noreferrer">{{.BlockHeight}}</a></td>
+                            <td>{{.Confirmed}}</td>
+                            <td>{{.Miner}}</td>
+                        </tr>
+                        {{else}}
+                        <tr>
+                            <td colspan="100%"><span class="no-data">No mined blocks</span></td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+
+                <div id="blocks-by-account-page-select" class="page-select"></div>
 
             </div>
         </div>
@@ -144,7 +143,11 @@
 
 </div>
 
+<script>
+    var accountID = "{{.AccountID}}";
+</script>
 <script src='/js/modal.js'></script>
+<script src='/js/pagination.js'></script>
 
 </body>
 </html>

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -1,5 +1,5 @@
 {{define "account"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
 <noscript style="display:inherit;">
     <div class="snackbar snackbar-warning">
@@ -18,7 +18,7 @@
             <div class="col-lg-7 col-12 py-2">
                 <div class="d-flex flex-column">
                     <div class="account-info-title pb-2">Account</div>
-                    <div><span class="dcr-label">{{.AccountStats.AccountID}}</span></div>
+                    <div><span class="dcr-label">{{.AccountID}}</span></div>
                 </div>
             </div>
 
@@ -52,7 +52,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.Payments }}
+                            {{ range .Payments }}
                             <tr>
                                 <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
                                         rel="noopener noreferrer">{{.Height}}</a></td>
@@ -93,7 +93,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.MinedWork }}
+                            {{ range .MinedWork }}
                             <tr>
                                 <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
                                         rel="noopener noreferrer">{{.Height}}</a></td>
@@ -126,7 +126,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{ range .AccountStats.Clients }}
+                            {{ range .Clients }}
                             <tr>
                                 <td>{{.Miner}}</td>
                                 <td>{{hashString .HashRate}}</td>

--- a/gui/assets/templates/account.html
+++ b/gui/assets/templates/account.html
@@ -95,8 +95,8 @@
                         <tbody>
                             {{ range .MinedWork }}
                             <tr>
-                                <td><a href="{{ blockURL $.BlockExplorerURL .Height}}"
-                                        rel="noopener noreferrer">{{.Height}}</a></td>
+                                <td><a href="{{ .BlockURL}}"
+                                        rel="noopener noreferrer">{{.BlockHeight}}</a></td>
                                 <td>{{.Confirmed}}</td>
                                 <td>{{.Miner}}</td>
                             </tr>

--- a/gui/assets/templates/admin.html
+++ b/gui/assets/templates/admin.html
@@ -1,5 +1,5 @@
 {{define "admin"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
 <div class="pool-overview pt-4 pb-3 mb-3">
     <div class="container">
@@ -10,18 +10,18 @@
             
             <div class="row mr-1">
                 <form class="p-2" action="/backup" method="post">
-                    {{.CSRF}}
+                    {{.HeaderData.CSRF}}
                     <button type="submit" class="btn btn-primary" style="padding:6px 6px; font-size: 12px;">Backup</button>
                 </form>
                 
                 <form class="p-2" action="/logout" method="post">
-                    {{.CSRF}}
+                    {{.HeaderData.CSRF}}
                     <button type="submit" class="btn btn-primary" style="padding:6px 6px; font-size: 12px;">Logout</button>
                 </form>
             </div>
         </div>
             
-        {{template "pool-stats" .PoolStats}}
+        {{template "pool-stats" .PoolStatsData}}
 
     </div>
 </div>

--- a/gui/assets/templates/admin.html
+++ b/gui/assets/templates/admin.html
@@ -64,7 +64,7 @@
 
 </div>
 
-<script src='/js/socket.js'></script>
+<script src='/assets/js/socket.js'></script>
 
 </body>
 </html>

--- a/gui/assets/templates/admin.html
+++ b/gui/assets/templates/admin.html
@@ -41,13 +41,13 @@
                             <th>Miner</th>
                             <th>Hash Rate</th>
                         </tr>
-                        {{range $accountID, $clients := .Connections}}
+                        {{range $accountID, $clients := .ConnectedClients}}
                         {{range $client := $clients}}
                         <tr>
                             <td><span class="dcr-label">{{$accountID}}</span></td>
                             <td>{{$client.IP}}</td>
                             <td>{{$client.Miner}}</td>
-                            <td>{{hashString $client.HashRate}}</td>
+                            <td>{{$client.HashRate}}</td>
                         </tr>
                         {{end}}
                         {{else}}

--- a/gui/assets/templates/header.html
+++ b/gui/assets/templates/header.html
@@ -5,48 +5,48 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Designation}} pool</title>
-    <link rel="stylesheet" type="text/css" href="/css/vendor/bootstrap-4.4.1.min.css">
-    <link rel="stylesheet" type="text/css" href="/css/fonts.css">
-    <link rel="stylesheet" type="text/css" href="/css/dcrpool.css">
-    <link rel="stylesheet" type="text/css" href="/css/pagination.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/vendor/bootstrap-4.4.1.min.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/fonts.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/dcrpool.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/pagination.css">
 
-    <script src='/js/vendor/tablesort.min.js'></script>
-    <script src='/js/vendor/tablesort.number.min.js'></script>
+    <script src='/assets/js/vendor/tablesort.min.js'></script>
+    <script src='/assets/js/vendor/tablesort.number.min.js'></script>
 
-    <script src="/js/vendor/jquery-3.4.1.min.js"></script>
-    <script src="/js/vendor/pagination-2.1.5.min.js"></script>
-    <script src="/js/vendor/popper-1.16.0.min.js"></script>
-    <script src="/js/vendor/bootstrap-4.4.1.min.js"></script>
-	<script src="/js/vendor/flickity.pkgd.min.js"></script>
+    <script src="/assets/js/vendor/jquery-3.4.1.min.js"></script>
+    <script src="/assets/js/vendor/pagination-2.1.5.min.js"></script>
+    <script src="/assets/js/vendor/popper-1.16.0.min.js"></script>
+    <script src="/assets/js/vendor/bootstrap-4.4.1.min.js"></script>
+	<script src="/assets/js/vendor/flickity.pkgd.min.js"></script>
     
 
     <!--  Custom favicon  -->
     <!-- Apple PWA -->
-    <link rel="apple-touch-icon" sizes="57x57"   href="/images/favicon/apple-touch-icon-57x57.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="60x60"   href="/images/favicon/apple-touch-icon-60x60.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="72x72"   href="/images/favicon/apple-touch-icon-72x72.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="76x76"   href="/images/favicon/apple-touch-icon-76x76.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="114x114" href="/images/favicon/apple-touch-icon-114x114.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="120x120" href="/images/favicon/apple-touch-icon-120x120.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="144x144" href="/images/favicon/apple-touch-icon-144x144.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-touch-icon-152x152.png?v=gT6Mc">
-    <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon-180x180.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="57x57"   href="/assets/images/favicon/apple-touch-icon-57x57.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="60x60"   href="/assets/images/favicon/apple-touch-icon-60x60.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="72x72"   href="/assets/images/favicon/apple-touch-icon-72x72.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="76x76"   href="/assets/images/favicon/apple-touch-icon-76x76.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favicon/apple-touch-icon-114x114.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favicon/apple-touch-icon-120x120.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favicon/apple-touch-icon-144x144.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favicon/apple-touch-icon-152x152.png?v=gT6Mc">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon/apple-touch-icon-180x180.png?v=gT6Mc">
 
     <!-- Browser -->
-    <link rel="icon" href="/images/favicon/favicon.ico?v=gT6Mc">
-    <link rel="icon" href="/images/favicon/favicon-32x32.png?v=gT6Mc" type="image/png" sizes="32x32">
-    <link rel="icon" href="/images/favicon/favicon-16x16.png?v=gT6Mc" type="image/png" sizes="16x16">
+    <link rel="icon" href="/assets/images/favicon/favicon.ico?v=gT6Mc">
+    <link rel="icon" href="/assets/images/favicon/favicon-32x32.png?v=gT6Mc" type="image/png" sizes="32x32">
+    <link rel="icon" href="/assets/images/favicon/favicon-16x16.png?v=gT6Mc" type="image/png" sizes="16x16">
 
     <!-- Android PWA -->
-    <link rel="manifest" href="/images/favicon/manifest.json?v=gT6Mc">
+    <link rel="manifest" href="/assets/images/favicon/manifest.json?v=gT6Mc">
 
     <!-- Safari -->
-    <link rel="mask-icon" href="/images/favicon/safari-pinned-tab.svg?v=gT6Mc" color="#091440">
+    <link rel="mask-icon" href="/assets/images/favicon/safari-pinned-tab.svg?v=gT6Mc" color="#091440">
 
     <!-- Windows PWA -->
     <meta name="msapplication-TileColor" content="#091440">
-    <meta name="msapplication-TileImage" content="/images/favicon/mstile-144x144.png?v=fi5jKKtbwv">
-    <meta name="msapplication-config"    content="/images/favicon/browserconfig.xml?v=fi5jKKtbwv">
+    <meta name="msapplication-TileImage" content="/assets/images/favicon/mstile-144x144.png?v=fi5jKKtbwv">
+    <meta name="msapplication-config"    content="/assets/images/favicon/browserconfig.xml?v=fi5jKKtbwv">
     <!-- End custom favicon -->
 </head>
 

--- a/gui/assets/templates/header.html
+++ b/gui/assets/templates/header.html
@@ -87,7 +87,7 @@
                         </div>
                         <div class="modal-body">
                             <p>To know your mining account details, enter your mining address.</p>
-                            <form class="modal-form" id="account-form" action="/account_exist" method="get">
+                            <form class="modal-form" id="account-form" action="/account" method="head">
                                 <div class="modal-input">
                                     <input type="text" name="address" required placeholder="Mining Address" spellcheck="false">
                                     <div class="icon-warning"></div>

--- a/gui/assets/templates/header.html
+++ b/gui/assets/templates/header.html
@@ -75,7 +75,7 @@
                 </a>
             </div>
 
-            {{ if not .Admin }}
+            {{ if .ShowMenu }}
             <a class="modalbtn" data-toggle="modal" data-target="#account-modal"></a>
 
             <div class="modal fade" id="account-modal">
@@ -83,13 +83,13 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title">Account Information</h1>
-                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                            <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
                         </div>
                         <div class="modal-body">
                             <p>To know your mining account details, enter your mining address.</p>
-                            <form class="modal-form" id="account-form" action="/account" method="get">
+                            <form class="modal-form" id="account-form" action="/account_exist" method="get">
                                 <div class="modal-input">
-                                    <input type="text" name="address" placeholder="Mining Address" spellcheck="false">
+                                    <input type="text" name="address" required placeholder="Mining Address" spellcheck="false">
                                     <div class="icon-warning"></div>
                                 </div>
                                 <div class="err-message"></div>
@@ -108,7 +108,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h1 class="modal-title">Admin Login</h1>
-                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                            <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
                         </div>
                         <div class="modal-body">
                             <form class="modal-form" id="admin-form" action="/admin" method="post">

--- a/gui/assets/templates/index.html
+++ b/gui/assets/templates/index.html
@@ -55,7 +55,7 @@
                 <div class="carousel-cell">
                     <div class="row m-0">
                         <div class="col-lg-4 col-12 main-carousel__image-container text-center">
-                            <div class="carousel-image" style="background-image:url('/images/carousel_1.svg');">
+                            <div class="carousel-image" style="background-image:url('/assets/images/carousel_1.svg');">
                             </div>
                         </div>
                         <div class="col-lg-8 col-12 py-3 px-4">
@@ -80,7 +80,7 @@
                 <div class="carousel-cell">
                     <div class="row m-0">
                         <div class="col-lg-4 col-12 main-carousel__image-container text-center">
-                            <div class="carousel-image" style="background-image:url('/images/carousel_2.svg');">
+                            <div class="carousel-image" style="background-image:url('/assets/images/carousel_2.svg');">
                             </div>
                         </div>
                         <div class="col-lg-8 col-12 py-3 px-4">
@@ -114,7 +114,7 @@
                 <div class="carousel-cell">
                     <div class="row m-0">
                         <div class="col-lg-4 col-12 main-carousel__image-container text-center">
-                            <div class="carousel-image" style="background-image:url('/images/carousel_3.svg');">
+                            <div class="carousel-image" style="background-image:url('/assets/images/carousel_3.svg');">
                             </div>
                         </div>
                         <div class="col-lg-8 col-12 py-3 px-4">
@@ -198,10 +198,10 @@
     </div>
 </div>
 
-<script src='/js/carousel.js'></script>
-<script src='/js/socket.js'></script>
-<script src='/js/modal.js'></script>
-<script src='/js/pagination.js'></script>
+<script src='/assets/js/carousel.js'></script>
+<script src='/assets/js/socket.js'></script>
+<script src='/assets/js/modal.js'></script>
+<script src='/assets/js/pagination.js'></script>
 
 </body>
 </html>

--- a/gui/assets/templates/index.html
+++ b/gui/assets/templates/index.html
@@ -1,13 +1,29 @@
 {{define "index"}}
-{{template "header" .}}
+{{template "header" .HeaderData}}
 
-{{ with .Error }}
-<div class="snackbar snackbar-error">
-    <div class="snackbar-message">
-        <p>{{.}}</p>
+{{ if .ModalError }}
+<div class="modal fade" id="error-modal">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title">Invalid Address</h1>
+                <button type="button" class="modal-close" data-dismiss="modal">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p>{{ .ModalError }}</p>
+                <div class="d-flex flex-row pt-4 align-items-center">
+                    <button class="btn btn-primary ml-auto" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+        
     </div>
 </div>
-{{end}}
+
+<script>
+    $("#error-modal").modal();
+</script>
+{{ end }}
 
 <noscript style="display:inherit;">
     <div class="snackbar snackbar-warning">
@@ -25,7 +41,7 @@
         <p class="pt-1 pb-2">To mine, point your miner to the pool and set the username as described below in the miner
             configuration section.</p>
         
-        {{template "pool-stats" .PoolStats}}
+        {{template "pool-stats" .PoolStatsData}}
         
     </div>
 </div>
@@ -44,7 +60,7 @@
                         </div>
                         <div class="col-lg-8 col-12 py-3 px-4">
                             <h2>Identify the Miner</h2>
-                            <p>{{.Designation}} pool currently supports:</p>
+                            <p>{{.HeaderData.Designation}} pool currently supports:</p>
                             <div class="d-flex flex-row">
                                 <ul>
                                     <li>Innosilicon&nbsp;D9</li>
@@ -153,7 +169,7 @@
             </div>
         </div>
 
-        {{ if not .PoolStats.SoloPool}}
+        {{ if not .PoolStatsData.SoloPool}}
         <div class="col-lg-6 col-12 p-3">
             <div class="block__content">
                 <h1>Next Reward Payment</h1>

--- a/gui/assets/templates/index.html
+++ b/gui/assets/templates/index.html
@@ -141,20 +141,17 @@
                 <table class="table">
                     <thead>
                         <tr>
-                            <th data-sort-method="number" data-sort-default>Height</th>
-                            <th data-sort-method="none">Miner</th>
-                            <th data-sort-method="none">Mined By</th>
+                            <th>Height</th>
+                            <th>Miner</th>
+                            <th>Mined By</th>
                         </tr>
                     </thead>
-                    <tbody id="mined-blocks-table-body">
+                    <tbody id="blocks-table">
                         {{ range .MinedWork }}
-                        <tr data-row-id="{{ .BlockHeight }}">
-                            <td><a href="{{ .BlockURL }}" rel="noopener noreferrer">{{ .BlockHeight }}</a>
-                            </td>
+                        <tr>
+                            <td><a href="{{ .BlockURL }}" rel="noopener noreferrer">{{ .BlockHeight }}</a></td>
                             <td>{{ .Miner }}</td>
-                            <td>
-                                <span class="dcr-label">{{ .MinedBy }}</span>
-                            </td>
+                            <td><span class="dcr-label">{{ .MinedBy }}</span></td>
                         </tr>
                         {{ else }}
                         <tr>
@@ -164,7 +161,7 @@
                     </tbody>
                 </table>
 
-                <div id="mined-blocks-page-select" class="page-select"></div>
+                <div id="blocks-page-select" class="page-select"></div>
 
             </div>
         </div>

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -128,7 +128,7 @@ func (c *Cache) getPoolHash() string {
 // updateClients will refresh the cached list of connected clients, as well as
 // recalculating the total hashrate for all connected clients.
 func (c *Cache) updateClients(clients []*pool.Client) {
-	clientInfo := make(map[string][]client, 0)
+	clientInfo := make(map[string][]client)
 	poolHashRate := new(big.Rat).SetInt64(0)
 	for _, c := range clients {
 		clientHashRate := c.FetchHashRate()

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -45,18 +45,14 @@ type workQuota struct {
 // GUI, so the formatting does not need to be repeated.
 type Cache struct {
 	blockExplorerURL string
-
-	minedWork    []minedWork
-	minedWorkMtx sync.RWMutex
-
-	workQuotas    []workQuota
-	workQuotasMtx sync.RWMutex
-
-	poolHash    string
-	poolHashMtx sync.RWMutex
-
-	clients    map[string][]client
-	clientsMtx sync.RWMutex
+	minedWork        []minedWork
+	minedWorkMtx     sync.RWMutex
+	workQuotas       []workQuota
+	workQuotasMtx    sync.RWMutex
+	poolHash         string
+	poolHashMtx      sync.RWMutex
+	clients          map[string][]client
+	clientsMtx       sync.RWMutex
 }
 
 // InitCache initialises and returns a cache for use in the GUI.

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gui
+
+import (
+	"math/big"
+	"sync"
+
+	"github.com/decred/dcrpool/pool"
+)
+
+// minedWork represents a block mined by the pool. It is json annotated so it
+// can easily be encoded and sent over a websocket or pagination request.
+type minedWork struct {
+	BlockHeight uint32 `json:"blockheight"`
+	BlockURL    string `json:"blockurl"`
+	MinedBy     string `json:"minedby"`
+	Miner       string `json:"miner"`
+	Confirmed   bool   `json:"confirmed"`
+	// AccountID holds the full ID (not truncated) and so should not be json encoded
+	AccountID string `json:"-"`
+}
+
+// workQuota represents dividend garnered by pool accounts through work
+// contributed. It is json annotated so it can easily be encoded and sent over a
+// websocket or pagination request.
+type workQuota struct {
+	AccountID string `json:"accountid"`
+	Percent   string `json:"percent"`
+}
+
+// Cache stores data which is required for the GUI. Each field has a setter and
+// getter, and they are protected by a mutex so they are safe for concurrent
+// access. Data returned by the getters is already formatted for display in the
+// GUI, so the formatting does not need to be repeated.
+type Cache struct {
+	blockExplorerURL string
+
+	minedWork    []minedWork
+	minedWorkMtx sync.RWMutex
+
+	workQuotas    []workQuota
+	workQuotasMtx sync.RWMutex
+
+	poolHash    string
+	poolHashMtx sync.RWMutex
+}
+
+// InitCache initialises and returns a cache for use in the GUI.
+func InitCache(work []*pool.AcceptedWork, quotas []*pool.Quota, poolHash *big.Rat, blockExplorerURL string) *Cache {
+	cache := Cache{blockExplorerURL: blockExplorerURL}
+	cache.updateMinedWork(work)
+	cache.updateQuotas(quotas)
+	cache.updateHashrate(poolHash)
+	return &cache
+}
+
+func (c *Cache) updateMinedWork(work []*pool.AcceptedWork) {
+	// Parse and format mined work by the pool.
+	workData := make([]minedWork, 0)
+	for _, work := range work {
+		workData = append(workData, minedWork{
+			BlockHeight: work.Height,
+			BlockURL:    blockURL(c.blockExplorerURL, work.Height),
+			MinedBy:     truncateAccountID(work.MinedBy),
+			Miner:       work.Miner,
+			AccountID:   work.MinedBy,
+			Confirmed:   work.Confirmed,
+		})
+	}
+
+	c.minedWorkMtx.Lock()
+	c.minedWork = workData
+	c.minedWorkMtx.Unlock()
+}
+
+func (c *Cache) getMinedWork() []minedWork {
+	c.minedWorkMtx.RLock()
+	defer c.minedWorkMtx.RUnlock()
+	return c.minedWork
+}
+
+func (c *Cache) updateQuotas(quotas []*pool.Quota) {
+	quotaData := make([]workQuota, 0)
+	for _, quota := range quotas {
+		quotaData = append(quotaData, workQuota{
+			AccountID: truncateAccountID(quota.AccountID),
+			Percent:   ratToPercent(quota.Percentage),
+		})
+	}
+
+	c.workQuotasMtx.Lock()
+	c.workQuotas = quotaData
+	c.workQuotasMtx.Unlock()
+}
+
+func (c *Cache) getQuotas() []workQuota {
+	c.workQuotasMtx.RLock()
+	defer c.workQuotasMtx.RUnlock()
+	return c.workQuotas
+}
+
+func (c *Cache) updateHashrate(poolHash *big.Rat) {
+	c.poolHashMtx.Lock()
+	c.poolHash = hashString(poolHash)
+	c.poolHashMtx.Unlock()
+}
+
+func (c *Cache) getPoolHash() string {
+	c.poolHashMtx.RLock()
+	defer c.poolHashMtx.RUnlock()
+	return c.poolHash
+}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -76,8 +76,8 @@ type Config struct {
 	FetchWorkQuotas func() ([]*pool.Quota, error)
 	// BackupDB streams a backup of the database over an http response.
 	BackupDB func(w http.ResponseWriter) error
-	// FetchClientInfo returns details about all connected pool clients.
-	FetchClientInfo func() []*pool.Client
+	// FetchClients returns details about all connected pool clients.
+	FetchClients func() []*pool.Client
 	// AccountExists checks if the provided account id references a pool account.
 	AccountExists func(accountID string) bool
 	// FetchPaymentsForAccount returns a list or payments made to the provided address.
@@ -314,7 +314,7 @@ func (ui *GUI) Run(ctx context.Context) {
 		}
 	}()
 
-	// Initalise the cache
+	// Initalise the cache.
 	work, err := ui.cfg.FetchMinedWork()
 	if err != nil {
 		log.Error(err)
@@ -327,7 +327,7 @@ func (ui *GUI) Run(ctx context.Context) {
 		return
 	}
 
-	clients := ui.cfg.FetchClientInfo()
+	clients := ui.cfg.FetchClients()
 
 	ui.cache = InitCache(work, quotas, clients, ui.cfg.BlockExplorerURL)
 
@@ -361,7 +361,7 @@ func (ui *GUI) Run(ctx context.Context) {
 						ui.cache.updateQuotas(quotas)
 					}
 
-					clients := ui.cfg.FetchClientInfo()
+					clients := ui.cfg.FetchClients()
 					ui.cache.updateClients(clients)
 
 					ticks = 0

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -75,7 +75,7 @@ type Config struct {
 	// based on work contributed per the payment scheme used by the pool.
 	FetchWorkQuotas func() ([]*pool.Quota, error)
 	// FetchClientInfo returns details about all connected pool clients.
-	FetchClientInfo func() map[string][]*pool.ClientInfo
+	FetchClientInfo func() []*pool.Client
 	// BackupDB streams a backup of the database over an http response.
 	BackupDB func(w http.ResponseWriter) error
 	// AccountExists checks if the provided account id references a pool account.

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -71,7 +71,7 @@ type Config struct {
 	// AddPaymentRequest creates a payment request from the provided account
 	// if not already requested.
 	AddPaymentRequest func(addr string) error
-	// FetchMinedWork returns all confirmed blocks mined by the pool.
+	// FetchMinedWork returns all blocks mined by the pool.
 	FetchMinedWork func() ([]*pool.AcceptedWork, error)
 	// FetchWorkQuotas returns the reward distribution to pool accounts
 	// based on work contributed per the payment scheme used by the pool.
@@ -84,8 +84,6 @@ type Config struct {
 	FetchClientInfo func() map[string][]*pool.ClientInfo
 	// AccountExists checks if the provided account id references a pool account.
 	AccountExists func(accountID string) bool
-	// FetchMinedWorkByAccount returns a list of mined work by the provided address.
-	FetchMinedWorkByAccount func(id string) ([]*pool.AcceptedWork, error)
 	// FetchPaymentsForAccount returns a list or payments made to the provided address.
 	FetchPaymentsForAccount func(id string) ([]*pool.Payment, error)
 	// FetchAccountClientInfo returns all clients belonging to the provided
@@ -357,6 +355,8 @@ func (ui *GUI) Run(ctx context.Context) {
 				BlockURL:    blockURL(ui.cfg.BlockExplorerURL, work.Height),
 				MinedBy:     truncateAccountID(work.MinedBy),
 				Miner:       work.Miner,
+				AccountID:   work.MinedBy,
+				Confirmed:   work.Confirmed,
 			})
 		}
 

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -112,7 +112,9 @@ type GUI struct {
 	poolHashMtx   sync.RWMutex
 }
 
-type poolStats struct {
+// poolStatsData contains all of the necessary information to render the
+// pool-stats template.
+type poolStatsData struct {
 	SoloPool          bool
 	PoolFee           float64
 	Network           string
@@ -120,6 +122,14 @@ type poolStats struct {
 	LastWorkHeight    uint32
 	LastPaymentHeight uint32
 	PoolHashRate      string
+}
+
+// headerData contains all of the necessary information to render the
+// header template.
+type headerData struct {
+	CSRF        template.HTML
+	Designation string
+	ShowMenu    bool
 }
 
 // route configures the http router of the user interface.
@@ -140,7 +150,8 @@ func (ui *GUI) route() {
 		http.FileServer(jsDir)))
 
 	ui.router.HandleFunc("/", ui.Homepage).Methods("GET")
-	ui.router.HandleFunc("/account", ui.IsPoolAccount).Methods("GET")
+	ui.router.HandleFunc("/account/{address}", ui.Account).Methods("GET")
+	ui.router.HandleFunc("/account_exist", ui.IsPoolAccount).Methods("GET")
 	ui.router.HandleFunc("/admin", ui.AdminPage).Methods("GET")
 	ui.router.HandleFunc("/admin", ui.AdminLogin).Methods("POST")
 	ui.router.HandleFunc("/backup", ui.DownloadDatabaseBackup).Methods("POST")

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -138,7 +138,7 @@ func (ui *GUI) route() {
 
 	guiRouter.HandleFunc("/", ui.Homepage).Methods("GET")
 	guiRouter.HandleFunc("/account", ui.Account).Methods("GET")
-	guiRouter.HandleFunc("/account_exist", ui.IsPoolAccount).Methods("GET")
+	guiRouter.HandleFunc("/account", ui.IsPoolAccount).Methods("HEAD")
 	guiRouter.HandleFunc("/admin", ui.AdminPage).Methods("GET")
 	guiRouter.HandleFunc("/admin", ui.AdminLogin).Methods("POST")
 	guiRouter.HandleFunc("/backup", ui.DownloadDatabaseBackup).Methods("POST")

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -76,7 +76,7 @@ type Config struct {
 	FetchWorkQuotas func() ([]*pool.Quota, error)
 	// BackupDB streams a backup of the database over an http response.
 	BackupDB func(w http.ResponseWriter) error
-	// FetchClients returns details about all connected pool clients.
+	// FetchClients returns all connected pool clients.
 	FetchClients func() []*pool.Client
 	// AccountExists checks if the provided account id references a pool account.
 	AccountExists func(accountID string) bool

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -156,7 +156,8 @@ func (ui *GUI) route() {
 	ui.router.HandleFunc("/logout", ui.AdminLogout).Methods("POST")
 
 	// Paginated endpoints allow the GUI to request pages of data
-	ui.router.HandleFunc("/mined_blocks", ui.PaginatedMinedBlocks).Methods("GET")
+	ui.router.HandleFunc("/blocks", ui.PaginatedBlocks).Methods("GET")
+	ui.router.HandleFunc("/blocks_by_account", ui.PaginatedBlocksByAccount).Methods("GET")
 
 	// Websocket endpoint allows the GUI to receive updated values
 	ui.router.HandleFunc("/ws", ui.registerWebSocket).Methods("GET")

--- a/gui/index.go
+++ b/gui/index.go
@@ -1,58 +1,35 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package gui
 
 import (
-	"fmt"
-	"html/template"
 	"net/http"
 
 	"github.com/decred/dcrpool/pool"
 	"github.com/gorilla/csrf"
 )
 
-type indexData struct {
-	MinerPorts       map[string]uint32
-	MinedWork        []minedWork
-	PoolDomain       string
-	PoolStats        poolStats
-	WorkQuotas       []workQuota
-	AccountStats     *AccountStats
-	Address          string
-	Admin            bool
-	Error            string
-	BlockExplorerURL string
-	Designation      string
-	CSRF             template.HTML
+// indexPageData contains all of the necessary information to render the index
+// template.
+type indexPageData struct {
+	HeaderData    headerData
+	PoolStatsData poolStatsData
+	MinerPorts    map[string]uint32
+	MinedWork     []minedWork
+	PoolDomain    string
+	WorkQuotas    []workQuota
+	Address       string
+	ModalError    string
 }
 
-// AccountStats is a snapshot of an accounts contribution to the pool. This is
-// comprised of blocks mined by the pool and payments made to the account.
-type AccountStats struct {
-	MinedWork []*pool.AcceptedWork
-	Payments  []*pool.Payment
-	Clients   []*pool.ClientInfo
-	AccountID string
-}
-
-// Homepage is the handler for "GET /". If a valid address parameter is
-// provided, the account.html template is rendered and populated with the
-// relevant account information, otherwise the index.html template is rendered.
-func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
-	session, err := getSession(r, ui.cookieStore)
-	if err != nil {
-		log.Errorf("getSession error: %v", err)
-		http.Error(w, "Session error", http.StatusInternalServerError)
-		return
-	}
-
-	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
-		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
-		return
-	}
-
+// renderIndex renders the index template. It accepts an optional modalError
+// which can be used to include a pop-up error message on the page. This
+// function can be called from any HTTP handler which needs to display an error
+// message. The error message will only be displayed if the browser has
+// Javascript enabled.
+func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
 	// Get the most recently mined blocks (max 10)
 	ui.minedWorkMtx.RLock()
 	lastBlock := 10
@@ -71,82 +48,33 @@ func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
 	poolHash := ui.poolHash
 	ui.poolHashMtx.RUnlock()
 
-	poolStats := poolStats{
-		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
-		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		PaymentMethod:     ui.cfg.PaymentMethod,
-		Network:           ui.cfg.ActiveNet.Name,
-		PoolFee:           ui.cfg.PoolFee,
-		SoloPool:          ui.cfg.SoloPool,
+	data := indexPageData{
+		HeaderData: headerData{
+			CSRF:        csrf.TemplateField(r),
+			Designation: ui.cfg.Designation,
+			ShowMenu:    true,
+		},
+		PoolStatsData: poolStatsData{
+			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
+			LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
+			PoolHashRate:      poolHash,
+			PaymentMethod:     ui.cfg.PaymentMethod,
+			Network:           ui.cfg.ActiveNet.Name,
+			PoolFee:           ui.cfg.PoolFee,
+			SoloPool:          ui.cfg.SoloPool,
+		},
+		WorkQuotas: wQuotas,
+		MinedWork:  mWork,
+		PoolDomain: ui.cfg.Domain,
+		MinerPorts: ui.cfg.MinerPorts,
+		ModalError: modalError,
 	}
 
-	data := indexData{
-		WorkQuotas:       wQuotas,
-		MinedWork:        mWork,
-		PoolDomain:       ui.cfg.Domain,
-		PoolStats:        poolStats,
-		Admin:            false,
-		BlockExplorerURL: ui.cfg.BlockExplorerURL,
-		Designation:      ui.cfg.Designation,
-		MinerPorts:       ui.cfg.MinerPorts,
-		CSRF:             csrf.TemplateField(r),
-	}
-
-	address := r.FormValue("address")
-	if address == "" {
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	// Add address to template data so the input field can be repopulated
-	// with the users input.
-	data.Address = address
-
-	// Generate the account id of the provided address.
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		data.Error = fmt.Sprintf("Unable to generate account ID for address %s", address)
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	if !ui.cfg.AccountExists(accountID) {
-		data.Error = fmt.Sprintf("Nothing found for address %s", address)
-		ui.renderTemplate(w, "index", data)
-		return
-	}
-
-	work, err := ui.cfg.FetchMinedWorkByAccount(accountID)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, "FetchMinedWorkByAddress error: "+err.Error(),
-			http.StatusInternalServerError)
-		return
-	}
-
-	payments, err := ui.cfg.FetchPaymentsForAccount(accountID)
-	if err != nil {
-		log.Error(err)
-		http.Error(w, "FetchPaymentsForAddress error: "+err.Error(),
-			http.StatusInternalServerError)
-		return
-	}
-
-	data.AccountStats = &AccountStats{
-		MinedWork: work,
-		Payments:  payments,
-		Clients:   ui.cfg.FetchAccountClientInfo(accountID),
-		AccountID: accountID,
-	}
-
-	ui.renderTemplate(w, "account", data)
+	ui.renderTemplate(w, "index", data)
 }
 
-// IsPoolAccount is the handler for "GET /account". If the provided address
-// has an account on the server a "200 OK" response is returned, otherwise a
-// "400 Bad Request" is returned.
-func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
+// Homepage is the handler for "GET /". It renders the index template.
+func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
 	session, err := getSession(r, ui.cookieStore)
 	if err != nil {
 		log.Errorf("getSession error: %v", err)
@@ -159,18 +87,5 @@ func (ui *GUI) IsPoolAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	address := r.FormValue("address")
-
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		http.Error(w, "Invalid address", http.StatusBadRequest)
-		return
-	}
-
-	if !ui.cfg.AccountExists(accountID) {
-		http.Error(w, "Nothing found for address", http.StatusBadRequest)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
+	ui.renderIndex(w, r, "")
 }

--- a/gui/index.go
+++ b/gui/index.go
@@ -30,14 +30,18 @@ type indexPageData struct {
 // message. The error message will only be displayed if the browser has
 // Javascript enabled.
 func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
-	// Get the most recently mined blocks (max 10)
+
+	// Get the most recent confirmed mined blocks (max 10)
+	work := make([]minedWork, 0)
 	ui.minedWorkMtx.RLock()
-	lastBlock := 10
-	count := len(ui.minedWork)
-	if count < 10 {
-		lastBlock = count
+	for _, v := range ui.minedWork {
+		if v.Confirmed {
+			work = append(work, v)
+			if len(work) >= 10 {
+				break
+			}
+		}
 	}
-	mWork := ui.minedWork[0:lastBlock]
 	ui.minedWorkMtx.RUnlock()
 
 	ui.workQuotasMtx.RLock()
@@ -64,7 +68,7 @@ func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError st
 			SoloPool:          ui.cfg.SoloPool,
 		},
 		WorkQuotas: wQuotas,
-		MinedWork:  mWork,
+		MinedWork:  work,
 		PoolDomain: ui.cfg.Domain,
 		MinerPorts: ui.cfg.MinerPorts,
 		ModalError: modalError,

--- a/gui/index.go
+++ b/gui/index.go
@@ -7,7 +7,6 @@ package gui
 import (
 	"net/http"
 
-	"github.com/decred/dcrpool/pool"
 	"github.com/gorilla/csrf"
 )
 
@@ -31,7 +30,7 @@ type indexPageData struct {
 // Javascript enabled.
 func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
 
-	// Get the most recent confirmed mined blocks (max 10)
+	// Get the most recent confirmed mined blocks (max 10).
 	allWork := ui.cache.getMinedWork()
 	recentWork := make([]minedWork, 0)
 	for _, v := range allWork {
@@ -70,17 +69,5 @@ func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError st
 
 // Homepage is the handler for "GET /". It renders the index template.
 func (ui *GUI) Homepage(w http.ResponseWriter, r *http.Request) {
-	session, err := getSession(r, ui.cookieStore)
-	if err != nil {
-		log.Errorf("getSession error: %v", err)
-		http.Error(w, "Session error", http.StatusInternalServerError)
-		return
-	}
-
-	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
-		http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
-		return
-	}
-
 	ui.renderIndex(w, r, "")
 }

--- a/gui/middleware.go
+++ b/gui/middleware.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gui
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/decred/dcrpool/pool"
+	"github.com/gorilla/sessions"
+)
+
+const (
+	// sessionKey is the key used to retreive the current session from a request
+	// context.
+	sessionKey ctxKey = iota
+)
+
+type ctxKey int
+
+// sessionMiddleware retrieves a session for the current request and adds it to
+// the request context so it can be used by downstream middlewares/handlers.
+func (ui *GUI) sessionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		session, err := ui.cookieStore.Get(r, "session")
+		if err != nil {
+			// "value is not valid" occurs if the CSRF secret changes. This is
+			// common during development (eg. when using the test harness) but
+			// it should not occur in production.
+			if strings.Contains(err.Error(), "securecookie: the value is not valid") {
+				log.Warnf("getSession error: CSRF secret has changed. Generating new session.")
+			} else {
+				log.Errorf("getSession error: %v", err)
+				http.Error(w, "Session error", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		ctx := context.WithValue(r.Context(), sessionKey, session)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// rateLimitMiddleware returns a "429 Too Many Requests" response if the client
+// has exceeded its allowed limit, otherwise passes the request to the next
+// middleware/handler.
+func (ui *GUI) rateLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		session := r.Context().Value(sessionKey).(*sessions.Session)
+
+		if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+			http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/gui/middleware.go
+++ b/gui/middleware.go
@@ -51,7 +51,7 @@ func (ui *GUI) rateLimitMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session := r.Context().Value(sessionKey).(*sessions.Session)
 
-		if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		if !ui.cfg.WithinLimit(session.ID, pool.GUIClient) {
 			http.Error(w, "Request limit exceeded", http.StatusTooManyRequests)
 			return
 		}

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -17,9 +17,14 @@ type minedWorkPayload struct {
 	Count  int         `json:"count"`
 }
 
-// PaginatedBlocks is the handler for "GET /blocks". It will use
-// parameters pageNumber and pageSize to prepare a json payload describing
-// blocks mined by the pool, as well as the total count of all confirmed blocks.
+type clientsPayload struct {
+	Clients []client `json:"clients"`
+	Count   int      `json:"count"`
+}
+
+// PaginatedBlocks is the handler for "GET /blocks". It uses parameters
+// pageNumber and pageSize to prepare a json payload describing blocks mined by
+// the pool, as well as the total count of all confirmed blocks.
 func (ui *GUI) PaginatedBlocks(w http.ResponseWriter, r *http.Request) {
 
 	// Parse request parameters.
@@ -65,7 +70,7 @@ func (ui *GUI) PaginatedBlocks(w http.ResponseWriter, r *http.Request) {
 }
 
 // PaginatedBlocksByAccount is the handler for "GET /account/{accountID}/blocks".
-// It will use parameters pageNumber, pageSize and accountID to prepare a json
+// It uses parameters pageNumber, pageSize and accountID to prepare a json
 // payload describing blocks mined by the account, as well as the total count of
 // all blocks mined by the account.
 func (ui *GUI) PaginatedBlocksByAccount(w http.ResponseWriter, r *http.Request) {
@@ -108,6 +113,56 @@ func (ui *GUI) PaginatedBlocksByAccount(w http.ResponseWriter, r *http.Request) 
 	payload := minedWorkPayload{
 		Count:  count,
 		Blocks: requestedBlocks,
+	}
+	js, err := json.Marshal(payload)
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Send json response.
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+// PaginatedClientsByAccount is the handler for "GET /account/{accountID}/clients".
+// It uses parameters pageNumber, pageSize and accountID to prepare a json
+// payload describing connected mining clients belonging to the account, as well
+// as the total count of all connected clients.
+func (ui *GUI) PaginatedClientsByAccount(w http.ResponseWriter, r *http.Request) {
+
+	// Parse request parameters.
+	pageNumber, err := strconv.Atoi(r.FormValue("pageNumber"))
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	pageSize, err := strconv.Atoi(r.FormValue("pageSize"))
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	accountID := mux.Vars(r)["accountID"]
+
+	offset := (pageNumber - 1) * pageSize
+	lastClient := offset + pageSize
+
+	// Get all of this accounts clients.
+	allClients := ui.cache.getClients()[accountID]
+
+	count := len(allClients)
+	if lastClient > count {
+		lastClient = count
+	}
+
+	// Prepare json response.
+	payload := clientsPayload{
+		Count:   count,
+		Clients: allClients[offset:lastClient],
 	}
 	js, err := json.Marshal(payload)
 	if err != nil {

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -17,6 +17,9 @@ type minedWork struct {
 	BlockURL    string `json:"blockurl"`
 	MinedBy     string `json:"minedby"`
 	Miner       string `json:"miner"`
+	Confirmed   bool   `json:"confirmed"`
+	// AccountID holds the full ID (not truncated) and so should not be json encoded
+	AccountID string `json:"-"`
 }
 
 type minedWorkPayload struct {

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -27,10 +27,10 @@ type minedWorkPayload struct {
 	Count  int         `json:"count"`
 }
 
-// PaginatedMinedBlocks is the handler for "GET /mined_blocks". It will use
+// PaginatedBlocks is the handler for "GET /blocks". It will use
 // parameters pageNumber and pageSize to prepare a json payload describing
 // blocks mined by the pool, as well as the total count of all confirmed blocks.
-func (ui *GUI) PaginatedMinedBlocks(w http.ResponseWriter, r *http.Request) {
+func (ui *GUI) PaginatedBlocks(w http.ResponseWriter, r *http.Request) {
 	session, err := getSession(r, ui.cookieStore)
 	if err != nil {
 		log.Errorf("getSession error: %v", err)
@@ -68,6 +68,75 @@ func (ui *GUI) PaginatedMinedBlocks(w http.ResponseWriter, r *http.Request) {
 	}
 	requestedBlocks := ui.minedWork[offset:lastBlock]
 	ui.minedWorkMtx.RUnlock()
+
+	// Prepare json response
+	payload := minedWorkPayload{
+		Count:  count,
+		Blocks: requestedBlocks,
+	}
+	js, err := json.Marshal(payload)
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Send json response
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+// PaginatedBlocksByAccount is the handler for "GET /blocks_by_account". It will
+// use parameters pageNumber, pageSize and accountID to prepare a json payload
+// describing blocks mined by the account, as well as the total count of all
+// blocks mined by the account.
+func (ui *GUI) PaginatedBlocksByAccount(w http.ResponseWriter, r *http.Request) {
+	session, err := getSession(r, ui.cookieStore)
+	if err != nil {
+		log.Errorf("getSession error: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !ui.cfg.WithinLimit(session.ID, pool.APIClient) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+
+	// Parse request parameters
+	pageNumber, err := strconv.Atoi(r.FormValue("pageNumber"))
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	pageSize, err := strconv.Atoi(r.FormValue("pageSize"))
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	accountID := r.FormValue("accountID")
+
+	offset := (pageNumber - 1) * pageSize
+	lastBlock := offset + pageSize
+
+	// Get all blocks mined by this account
+	work := make([]minedWork, 0)
+	ui.minedWorkMtx.RLock()
+	for _, v := range ui.minedWork {
+		if v.AccountID == accountID {
+			work = append(work, v)
+		}
+	}
+	ui.minedWorkMtx.RUnlock()
+
+	count := len(work)
+	if lastBlock > count {
+		lastBlock = count
+	}
+	requestedBlocks := work[offset:lastBlock]
 
 	// Prepare json response
 	payload := minedWorkPayload{

--- a/gui/websocket.go
+++ b/gui/websocket.go
@@ -20,13 +20,6 @@ type payload struct {
 	WorkQuotas        []workQuota `json:"workquotas"`
 }
 
-// workQuota represents dividend garnered by pool accounts through work
-// contributed.
-type workQuota struct {
-	AccountID string `json:"accountid"`
-	Percent   string `json:"percent"`
-}
-
 // registerWebSocket is the handler for "GET /ws". It updates the HTTP request
 // to a websocket and adds the caller to a list of connected clients.
 func (ui *GUI) registerWebSocket(w http.ResponseWriter, r *http.Request) {
@@ -42,17 +35,11 @@ func (ui *GUI) registerWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // updateWebSocket sends updates to all connected websocket clients.
 func (ui *GUI) updateWebSocket() {
-	ui.poolHashMtx.RLock()
-	poolHash := ui.poolHash
-	ui.poolHashMtx.RUnlock()
-	ui.workQuotasMtx.RLock()
-	workQuotas := append(ui.workQuotas[:0:0], ui.workQuotas...)
-	ui.workQuotasMtx.RUnlock()
 	msg := payload{
 		LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),
 		LastPaymentHeight: ui.cfg.FetchLastPaymentHeight(),
-		PoolHashRate:      poolHash,
-		WorkQuotas:        workQuotas,
+		PoolHashRate:      ui.cache.getPoolHash(),
+		WorkQuotas:        ui.cache.getQuotas(),
 	}
 	clientsMtx.Lock()
 	for client := range clients {

--- a/pool/acceptedwork_test.go
+++ b/pool/acceptedwork_test.go
@@ -93,27 +93,14 @@ func testAcceptedWork(t *testing.T, db *bolt.DB) {
 			fetchedWork.Height, workC.Height)
 	}
 
-	// Ensure requesting negative or zero most recent accepted work returns
-	// an error.
-	_, err = listMinedWorkByAccount(db, string(id), -1)
-	if err == nil {
-		t.Fatalf("listMinedWorkByAccount: expected negative N error")
-	}
-
-	_, err = listMinedWorkByAccount(db, string(id), 0)
-	if err == nil {
-		t.Fatalf("listMinedWorkByAccount: expected zero N error")
-	}
-
-	// Ensure the accepted work are not listed as mined since they are not
-	// confirmed.
+	// Ensure unconfirmed work is returned
 	minedWork, err := ListMinedWork(db)
 	if err != nil {
 		t.Fatalf("ListMinedWork error: %v", err)
 	}
 
-	if len(minedWork) != 0 {
-		t.Fatalf("expected no mined work")
+	if len(minedWork) != 4 {
+		t.Fatalf("expected unconfirmed work to be returned")
 	}
 
 	// Confirm all accepted work a mined work.
@@ -149,17 +136,6 @@ func testAcceptedWork(t *testing.T, db *bolt.DB) {
 
 	if len(minedWork) != 4 {
 		t.Fatalf("expected %v mined work, got %v", 4, len(minedWork))
-	}
-
-	// Ensure account Y has only one associated mined work.
-	minedWork, err = listMinedWorkByAccount(db, yID, 4)
-	if err != nil {
-		t.Fatalf("ListMinedWork error: %v", err)
-	}
-
-	if len(minedWork) != 1 {
-		t.Fatalf("expected %v mined work for account %v, got %v", 1,
-			yID, len(minedWork))
 	}
 
 	// Ensure mined work cannot be pruned.

--- a/pool/client.go
+++ b/pool/client.go
@@ -888,11 +888,26 @@ func (c *Client) setHashRate(hash *big.Rat) {
 	c.hashRateMtx.Unlock()
 }
 
-// fetchHashRate gets the client's hash rate.
-func (c *Client) fetchHashRate() *big.Rat {
+// FetchHashRate gets the client's hash rate.
+func (c *Client) FetchHashRate() *big.Rat {
 	c.hashRateMtx.Lock()
 	defer c.hashRateMtx.Unlock()
 	return c.hashRate
+}
+
+// FetchIPAddr gets the client's IP address.
+func (c *Client) FetchIPAddr() string {
+	return c.addr.String()
+}
+
+// FetchMinerType gets the client's miner type.
+func (c *Client) FetchMinerType() string {
+	return c.cfg.FetchMiner()
+}
+
+// FetchAccountID gets the client's account ID.
+func (c *Client) FetchAccountID() string {
+	return c.account
 }
 
 func (c *Client) hashMonitor(ctx context.Context) {

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -1033,7 +1033,7 @@ func testClient(t *testing.T, db *bolt.DB) {
 	setMiner(CPU)
 	atomic.StoreInt64(&client.submissions, 50)
 	time.Sleep(time.Millisecond * 1200)
-	hash := client.fetchHashRate()
+	hash := client.FetchHashRate()
 	if hash == ZeroRat {
 		t.Fatal("expected a non-nil client hash rate")
 	}

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -619,18 +619,6 @@ func (h *Hub) FetchMinedWork() ([]*AcceptedWork, error) {
 	return ListMinedWork(h.db)
 }
 
-// FetchPoolHashRate returns the hash rate of the pool.
-func (h *Hub) FetchPoolHashRate() (*big.Rat, map[string][]*ClientInfo) {
-	clientInfo := h.FetchClientInfo()
-	poolHashRate := new(big.Rat).SetInt64(0)
-	for _, clients := range clientInfo {
-		for _, miner := range clients {
-			poolHashRate = poolHashRate.Add(poolHashRate, miner.HashRate)
-		}
-	}
-	return poolHashRate, clientInfo
-}
-
 // Quota details the portion of mining rewrds due an account for work
 // contributed to the pool.
 type Quota struct {

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -562,53 +562,17 @@ func (h *Hub) Run(ctx context.Context) {
 	h.shutdown()
 }
 
-// ClientInfo represents client miner information.
-type ClientInfo struct {
-	Miner    string
-	IP       string
-	HashRate *big.Rat
-}
-
 // FetchClientInfo returns connection details about all pool clients.
-func (h *Hub) FetchClientInfo() map[string][]*ClientInfo {
-	clientInfo := make(map[string][]*ClientInfo)
+func (h *Hub) FetchClientInfo() []*Client {
+	allClients := make([]*Client, 0)
 	for _, endpoint := range h.endpoints {
 		endpoint.clientsMtx.Lock()
 		for _, client := range endpoint.clients {
-			hash := client.fetchHashRate()
-			clientInfo[client.account] = append(clientInfo[client.account],
-				&ClientInfo{
-					Miner:    endpoint.miner,
-					IP:       client.addr.String(),
-					HashRate: hash,
-				})
+			allClients = append(allClients, client)
 		}
 		endpoint.clientsMtx.Unlock()
 	}
-	return clientInfo
-}
-
-// FetchAccountClientInfo returns all clients belonging to the provided
-// account id.
-func (h *Hub) FetchAccountClientInfo(accountID string) []*ClientInfo {
-	info := make([]*ClientInfo, 0)
-	for _, endpoint := range h.endpoints {
-		endpoint.clientsMtx.Lock()
-		for _, client := range endpoint.clients {
-			if client.account == accountID {
-				client.hashRateMtx.RLock()
-				hash := client.hashRate
-				client.hashRateMtx.RUnlock()
-				info = append(info, &ClientInfo{
-					Miner:    endpoint.miner,
-					IP:       client.addr.String(),
-					HashRate: hash,
-				})
-			}
-		}
-		endpoint.clientsMtx.Unlock()
-	}
-	return info
+	return allClients
 }
 
 // FetchMinedWork returns work data associated with all blocks mined by the pool

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -562,17 +562,17 @@ func (h *Hub) Run(ctx context.Context) {
 	h.shutdown()
 }
 
-// FetchClientInfo returns connection details about all pool clients.
-func (h *Hub) FetchClientInfo() []*Client {
-	allClients := make([]*Client, 0)
+// FetchClients returns connection details about all pool clients.
+func (h *Hub) FetchClients() []*Client {
+	clients := make([]*Client, 0)
 	for _, endpoint := range h.endpoints {
 		endpoint.clientsMtx.Lock()
-		for _, client := range endpoint.clients {
-			allClients = append(allClients, client)
+		for _, c := range endpoint.clients {
+			clients = append(clients, c)
 		}
 		endpoint.clientsMtx.Unlock()
 	}
-	return allClients
+	return clients
 }
 
 // FetchMinedWork returns work data associated with all blocks mined by the pool

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -562,7 +562,7 @@ func (h *Hub) Run(ctx context.Context) {
 	h.shutdown()
 }
 
-// FetchClients returns connection details about all pool clients.
+// FetchClients returns all connected pool clients.
 func (h *Hub) FetchClients() []*Client {
 	clients := make([]*Client, 0)
 	for _, endpoint := range h.endpoints {

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -611,7 +611,10 @@ func (h *Hub) FetchAccountClientInfo(accountID string) []*ClientInfo {
 	return info
 }
 
-// FetchMinedWork returns all confirmed blocks mined by the pool.
+// FetchMinedWork returns work data associated with all blocks mined by the pool
+// regardless of whether they are confirmed or not.
+//
+// List is ordered, most recent comes first.
 func (h *Hub) FetchMinedWork() ([]*AcceptedWork, error) {
 	return ListMinedWork(h.db)
 }
@@ -661,13 +664,6 @@ func (h *Hub) FetchWorkQuotas() ([]*Quota, error) {
 		})
 	}
 	return quotas, nil
-}
-
-// FetchMinedWorkByAccount returns a list of mined work by the provided address.
-// List is ordered, most recent comes first.
-func (h *Hub) FetchMinedWorkByAccount(id string) ([]*AcceptedWork, error) {
-	work, err := listMinedWorkByAccount(h.db, id, 10)
-	return work, err
 }
 
 // FetchPaymentsForAccount returns a list or payments made to the provided address.

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -197,9 +197,9 @@ func testHub(t *testing.T, db *bolt.DB) {
 		t.Fatalf("expected 1 client connection from host %s, got %v",
 			host, connections)
 	}
-	cInfo := hub.FetchClientInfo()
+	cInfo := hub.FetchClients()
 	if len(cInfo) != 1 {
-		t.Fatalf("[FetchClientInfo] expected a client info size "+
+		t.Fatalf("[FetchClients] expected a client info size "+
 			"of 1, got %d", len(cInfo))
 	}
 

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -203,20 +203,6 @@ func testHub(t *testing.T, db *bolt.DB) {
 			"of 1, got %d", len(cInfo))
 	}
 
-	// Ensure there are no connected clients for test accounts
-	aInfo := hub.FetchAccountClientInfo(xID)
-	if len(aInfo) != 0 {
-		t.Fatalf("[FetchClientInfo] expected a client info size of 0"+
-			" for account x, got %d", len(cInfo))
-	}
-
-	// Ensure connected clients do not have an associated account.
-	aInfo = hub.FetchAccountClientInfo("")
-	if len(aInfo) != 1 {
-		t.Fatalf("[FetchClientInfo] expected a client info size "+
-			"of 1 for clients with no associated account, got %d", len(cInfo))
-	}
-
 	// Empty the share bucket.
 	err = emptyBucket(db, shareBkt)
 	if err != nil {

--- a/pool/limiter.go
+++ b/pool/limiter.go
@@ -13,7 +13,7 @@ import (
 
 // Client types.
 const (
-	APIClient = iota
+	GUIClient = iota
 	PoolClient
 )
 
@@ -26,12 +26,13 @@ const (
 	// clientBurst is the maximum token usage allowed per second,
 	// for pool clients.
 	clientBurst = 5
-	// apiTokenRate is the token refill rate for the api request bucket,
+	// guiTokenRate is the token refill rate for the gui request bucket,
 	// per second.
-	apiTokenRate = 3
-	// apiBurst is the maximum token usage allowed per second,
-	// for api clients.
-	apiBurst = 3
+	guiTokenRate = 3
+	// guiBurst is the maximum token usage allowed per second, for gui clients.
+	// This needs to be >= 5 because a single page can make multiple requests,
+	// eg. pagination, establishing a websocket, AJAX form submissions.
+	guiBurst = 5
 )
 
 // RateLimiter keeps connected clients within their allocated request rates.
@@ -52,8 +53,8 @@ func NewRateLimiter() *RateLimiter {
 func (r *RateLimiter) addRequestLimiter(ip string, clientType int) (*rate.Limiter, error) {
 	var limiter *rate.Limiter
 	switch clientType {
-	case APIClient:
-		limiter = rate.NewLimiter(apiTokenRate, apiBurst)
+	case GUIClient:
+		limiter = rate.NewLimiter(guiTokenRate, guiBurst)
 	case PoolClient:
 		limiter = rate.NewLimiter(clientTokenRate, clientBurst)
 	default:

--- a/pool/limiter_test.go
+++ b/pool/limiter_test.go
@@ -4,20 +4,20 @@ import "testing"
 
 func testLimiter(t *testing.T) {
 	limiter := NewRateLimiter()
-	apiLimiterIP := "127.0.0.1"
+	guiLimiterIP := "127.0.0.1"
 
-	// Ensure the api limiter is within range.
-	if !limiter.withinLimit(apiLimiterIP, APIClient) {
+	// Ensure the gui limiter is within range.
+	if !limiter.withinLimit(guiLimiterIP, GUIClient) {
 		t.Fatal("expected limiter to be within limit")
 	}
 
-	// Exhaust the api limiter range.
-	for limiter.withinLimit(apiLimiterIP, APIClient) {
+	// Exhaust the gui limiter range.
+	for limiter.withinLimit(guiLimiterIP, GUIClient) {
 		continue
 	}
 
-	// Fetch the api limiter.
-	lmt := limiter.fetchLimiter(apiLimiterIP)
+	// Fetch the gui limiter.
+	lmt := limiter.fetchLimiter(guiLimiterIP)
 	if lmt == nil {
 		t.Fatalf("expected a non-nil limiter")
 	}
@@ -55,11 +55,11 @@ func testLimiter(t *testing.T) {
 	}
 
 	// Remove limiters.
-	limiter.removeLimiter(apiLimiterIP)
+	limiter.removeLimiter(guiLimiterIP)
 	limiter.removeLimiter(poolLimiterIP)
 
 	// Ensure the limiters have been removed.
-	lmt = limiter.fetchLimiter(apiLimiterIP)
+	lmt = limiter.fetchLimiter(guiLimiterIP)
 	if lmt != nil {
 		t.Fatalf("expected a nil limiter")
 	}


### PR DESCRIPTION
As discussed on Matrix, bundling changes from #173 and #174 into a new PR with some additional changes.

### New style errors

This PR implements the new error modals as defined by @MariaPleshkova in https://xd.adobe.com/view/a814493c-193a-4dfc-5735-0e6d459a6924-de25/. These errors are displayed when an invalid URL is visited, for example `/account?address=NotARealAddress`. When you are searching for an account using the AJAX form, the errors should be displayed as before, this PR does not change those.

**Note:** This PR does not change the Javascript warning - that will need some extra thought because it cannot be implemented as a modal - drawing a modal depends on Javascript.

### Cache

`Cache` has been introduced, which acts as a data buffer between hub and gui. Cache has setter functions which are used by the hub, and getter functions which are used by gui. It holds pre-formatted data which is ready to be served directly to gui without needing to lock any mutexes in the hub or hit the database. This facilitates implementing #167 because now the hub is able to push data into the cache when it knows the data has changed, whereas the previous model had the gui pulling data from the hub on a timer, with no knowledge of whether the underlying data had changed or not.

### Pagination

Pagination has been added for both the Mined Blocks and the Connected Clients tables on the account page.

### Rate Limiting

Rate limiting moved to a middleware which removes a lot of duplicated code.

As a result, rate limiting has been added to some places it was previously missing:
- `/ws` the websocket route
- `/logout` for admin logout

The limit has been increased from 3 to 5 for GUI clients. This is because some of the pages are now making extra requests (pagination, establishing a websocket, AJAX form submissions) and the limit of 3 was causing issues.
