### PR TITLE
dcrpool: align rpcuser configuration with rpcuser help message 

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ const (
 	defaultDBFilename            = "dcrpool.kv"
 	defaultTLSCertFilename       = "dcrpool.cert"
 	defaultTLSKeyFilename        = "dcrpool.key"
+	defaultRPCUser               = "dcrp"
 	defaultDcrdRPCHost           = "127.0.0.1"
 	defaultWalletGRPCHost        = "127.0.0.1"
 	defaultMaxGenTime            = time.Second * 15
@@ -503,11 +504,9 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Ensure the dcrd rpc username is set.
+	// Set the RPCUser
 	if cfg.RPCUser == "" {
-		str := "%s: the rpcuser option is not set"
-		err := fmt.Errorf(str, funcName)
-		return nil, nil, err
+		cfg.RPCUser = defaultRPCUser
 	}
 
 	// Ensure the dcrd rpc password is set.


### PR DESCRIPTION
rpcuser help message states that the default user is drpc this corrects that