### PR TITLE
pool: update client last work time test.

### DIFF
--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -538,6 +538,15 @@ func testClient(t *testing.T, db *bolt.DB) {
 	}
 	client.cfg.ActiveNet = chaincfg.SimNetParams()
 
+	// Ensure the last work time of the CPU client was updated
+	// on receiving work.
+	lastWorkTime := atomic.LoadInt64(&client.lastWorkTime)
+	if lastWorkTime == 0 {
+		t.Fatalf("expected last work time for %s connection "+
+			"to be more than zero, got %d", client.id,
+			client.lastWorkTime)
+	}
+
 	// Send a work notification to an Innosilicon D9 client.
 	setMiner(InnosiliconD9)
 	client.ch <- r

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -390,23 +390,6 @@ func testHub(t *testing.T, db *bolt.DB) {
 		"8000000100000000000005a0"
 	hub.processWork(workE)
 
-	// Wait for work distribution.
-	time.Sleep(time.Millisecond * 500)
-
-	// Ensure all connected clients received work.
-	for _, endpoint := range hub.endpoints {
-		endpoint.clientsMtx.Lock()
-		for _, client := range endpoint.clients {
-			lastWorkTime := atomic.LoadInt64(&client.lastWorkTime)
-			if lastWorkTime == 0 {
-				t.Fatalf("expected last work time for %s connection "+
-					"to be more than zero, got %d", client.id,
-					client.lastWorkTime)
-			}
-		}
-		endpoint.clientsMtx.Unlock()
-	}
-
 	// Get a block and publish a bogus transaction by confirming the
 	// mined accepted work.
 	hub.chainState.setCurrentWork(workE)


### PR DESCRIPTION
This should resolve the intermittent failures of the previous last work time test by waiting for the work notification at client side before continuing with tests.