### PR TITLE
gui: Only display confirmed blocks on the homepage

### DIFF
--- a/gui/account.go
+++ b/gui/account.go
@@ -15,11 +15,11 @@ import (
 // account template.
 type accountPageData struct {
 	HeaderData       headerData
-	MinedWork        []minedWork
-	ArchivedPayments []archivedPayment
-	PendingPayments  []pendingPayment
+	MinedWork        *[]minedWork
+	ArchivedPayments *[]archivedPayment
+	PendingPayments  *[]pendingPayment
 	PaymentRequested bool
-	ConnectedClients []client
+	ConnectedClients *[]client
 	AccountID        string
 	Address          string
 	BlockExplorerURL string
@@ -48,35 +48,17 @@ func (ui *GUI) account(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the most recently mined blocks by this account (max 10).
-	allWork := ui.cache.getMinedWork()
-	recentWork := make([]minedWork, 0)
-	for _, v := range allWork {
-		if v.AccountID == accountID {
-			recentWork = append(recentWork, v)
-			if len(recentWork) >= 10 {
-				break
-			}
-		}
-	}
+	// Get the 10 most recently mined blocks by this account.
+	_, recentWork := ui.cache.getMinedWorkByAccount(0, 9, accountID)
 
-	// Get this accounts pending payments (max 10).
-	pendingPmts := ui.cache.getPendingPayments()[accountID]
-	if len(pendingPmts) > 10 {
-		pendingPmts = pendingPmts[0:10]
-	}
+	// Get the 10 most recent pending payments for this account.
+	_, pendingPmts := ui.cache.getPendingPayments(0, 9, accountID)
 
-	// Get this accounts archived payments (max 10).
-	archivedPmts := ui.cache.getArchivedPayments()[accountID]
-	if len(archivedPmts) > 10 {
-		archivedPmts = archivedPmts[0:10]
-	}
+	// Get the 10 most recent archived payments for this account.
+	_, archivedPmts := ui.cache.getArchivedPayments(0, 9, accountID)
 
-	// Get this accounts connected clients (max 10).
-	clients := ui.cache.getClients()[accountID]
-	if len(clients) > 10 {
-		clients = clients[0:10]
-	}
+	// Get 10 of this accounts connected clients.
+	_, clients := ui.cache.getClientsForAccount(0, 9, accountID)
 
 	data := &accountPageData{
 		HeaderData: headerData{

--- a/gui/account.go
+++ b/gui/account.go
@@ -15,11 +15,11 @@ import (
 // account template.
 type accountPageData struct {
 	HeaderData       headerData
-	MinedWork        *[]minedWork
-	ArchivedPayments *[]archivedPayment
-	PendingPayments  *[]pendingPayment
+	MinedWork        []minedWork
+	ArchivedPayments []archivedPayment
+	PendingPayments  []pendingPayment
 	PaymentRequested bool
-	ConnectedClients *[]client
+	ConnectedClients []client
 	AccountID        string
 	Address          string
 	BlockExplorerURL string

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -125,7 +125,7 @@ func (c *Cache) updateMinedWork(work []*pool.AcceptedWork) {
 
 // getConfirmedMinedWork retrieves the cached list of confirmed blocks mined by
 // the pool.
-func (c *Cache) getConfirmedMinedWork(first, last int) (int, *[]minedWork) {
+func (c *Cache) getConfirmedMinedWork(first, last int) (int, []minedWork) {
 	c.minedWorkMtx.RLock()
 	defer c.minedWorkMtx.RUnlock()
 
@@ -139,12 +139,12 @@ func (c *Cache) getConfirmedMinedWork(first, last int) (int, *[]minedWork) {
 	count := len(allWork)
 	requestedWork := allWork[first:min(last, count)]
 
-	return count, &requestedWork
+	return count, requestedWork
 }
 
 // getMinedWorkByAccount retrieves the cached list of blocks mined by
 // an account. Returns both confirmed and unconfirmed blocks.
-func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, *[]minedWork) {
+func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, []minedWork) {
 	c.minedWorkMtx.RLock()
 	defer c.minedWorkMtx.RUnlock()
 
@@ -158,7 +158,7 @@ func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, *
 	count := len(allWork)
 	requestedWork := allWork[first:min(last, count)]
 
-	return count, &requestedWork
+	return count, requestedWork
 }
 
 // updateRewardQuotas uses a list of work quotas to refresh the cached list of
@@ -184,14 +184,14 @@ func (c *Cache) updateRewardQuotas(quotas []*pool.Quota) {
 }
 
 // getRewardQuotas retrieves the cached list of pending reward payment quotas.
-func (c *Cache) getRewardQuotas(first, last int) (int, *[]rewardQuota) {
+func (c *Cache) getRewardQuotas(first, last int) (int, []rewardQuota) {
 	c.rewardQuotasMtx.RLock()
 	defer c.rewardQuotasMtx.RUnlock()
 
 	count := len(c.rewardQuotas)
 	requestedQuotas := c.rewardQuotas[first:min(last, count)]
 
-	return count, &requestedQuotas
+	return count, requestedQuotas
 }
 
 // getPoolHash retrieves the total hashrate of all connected mining clients.
@@ -228,7 +228,7 @@ func (c *Cache) updateClients(clients []*pool.Client) {
 
 // getClientsForAccount retrieves the cached list of connected clients for a
 // given account ID.
-func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, *[]client) {
+func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, []client) {
 	c.clientsMtx.RLock()
 	defer c.clientsMtx.RUnlock()
 
@@ -237,7 +237,7 @@ func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, *[
 	count := len(accountClients)
 	requestedClients := accountClients[first:min(last, count)]
 
-	return count, &requestedClients
+	return count, requestedClients
 }
 
 // getClients retrieves the cached list of all clients connected to the pool.
@@ -298,7 +298,7 @@ func (c *Cache) updatePayments(pendingPmts []*pool.Payment, archivedPmts []*pool
 
 // getPendingPayments retrieves the cached list of unpaid payments for a given
 // account ID.
-func (c *Cache) getPendingPayments(first, last int, accountID string) (int, *[]pendingPayment) {
+func (c *Cache) getPendingPayments(first, last int, accountID string) (int, []pendingPayment) {
 	c.pendingPaymentsMtx.RLock()
 	defer c.pendingPaymentsMtx.RUnlock()
 
@@ -307,12 +307,12 @@ func (c *Cache) getPendingPayments(first, last int, accountID string) (int, *[]p
 	count := len(accountPayments)
 	requestedPayments := accountPayments[first:min(last, count)]
 
-	return count, &requestedPayments
+	return count, requestedPayments
 }
 
 // getArchivedPayments retrieves the cached list of paid payments for a given
 // account ID.
-func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, *[]archivedPayment) {
+func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, []archivedPayment) {
 	c.archivedPaymentsMtx.RLock()
 	defer c.archivedPaymentsMtx.RUnlock()
 
@@ -321,5 +321,5 @@ func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, *[]
 	count := len(accountPayments)
 	requestedPayments := accountPayments[first:min(last, count)]
 
-	return count, &requestedPayments
+	return count, requestedPayments
 }

--- a/gui/index.go
+++ b/gui/index.go
@@ -16,8 +16,8 @@ type indexPageData struct {
 	HeaderData    headerData
 	PoolStatsData poolStatsData
 	MinerPorts    map[string]uint32
-	MinedWork     *[]minedWork
-	RewardQuotas  *[]rewardQuota
+	MinedWork     []minedWork
+	RewardQuotas  []rewardQuota
 	Address       string
 	ModalError    string
 }

--- a/gui/index.go
+++ b/gui/index.go
@@ -16,8 +16,8 @@ type indexPageData struct {
 	HeaderData    headerData
 	PoolStatsData poolStatsData
 	MinerPorts    map[string]uint32
-	MinedWork     []minedWork
-	RewardQuotas  []rewardQuota
+	MinedWork     *[]minedWork
+	RewardQuotas  *[]rewardQuota
 	Address       string
 	ModalError    string
 }
@@ -29,23 +29,11 @@ type indexPageData struct {
 // Javascript enabled.
 func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
 
-	// Get the most recent confirmed mined blocks (max 10).
-	allWork := ui.cache.getMinedWork()
-	recentWork := make([]minedWork, 0)
-	for _, v := range allWork {
-		if v.Confirmed {
-			recentWork = append(recentWork, v)
-			if len(recentWork) >= 10 {
-				break
-			}
-		}
-	}
+	// Get the 10 most recent confirmed mined blocks.
+	_, confirmedWork := ui.cache.getConfirmedMinedWork(0, 9)
 
-	// Get the next reward payment percentages (max 10).
-	rewardQuotas := ui.cache.getRewardQuotas()
-	if len(rewardQuotas) > 10 {
-		rewardQuotas = rewardQuotas[0:10]
-	}
+	// Get the first 10 next reward payment percentages.
+	_, rewardQuotas := ui.cache.getRewardQuotas(0, 9)
 
 	data := indexPageData{
 		HeaderData: headerData{
@@ -63,7 +51,7 @@ func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError st
 			SoloPool:          ui.cfg.SoloPool,
 		},
 		RewardQuotas: rewardQuotas,
-		MinedWork:    recentWork,
+		MinedWork:    confirmedWork,
 		MinerPorts:   ui.cfg.MinerPorts,
 		ModalError:   modalError,
 	}

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -60,8 +60,8 @@ func sendJSONResponse(w http.ResponseWriter, payload interface{}) {
 }
 
 // paginatedBlocks is the handler for "GET /blocks". It uses parameters
-// pageNumber and pageSize to prepare a json payload describing blocks mined by
-// the pool, as well as the total count of all confirmed blocks.
+// pageNumber and pageSize to prepare a json payload describing confirmed blocks
+// mined by the pool, as well as the total count of all confirmed blocks.
 func (ui *GUI) paginatedBlocks(w http.ResponseWriter, r *http.Request) {
 	first, last, err := getPaginationParams(r)
 	if err != nil {
@@ -71,12 +71,19 @@ func (ui *GUI) paginatedBlocks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	allWork := ui.cache.getMinedWork()
-	count := len(allWork)
+	confirmedWork := make([]minedWork, 0)
+	for _, v := range allWork {
+		if v.Confirmed {
+			confirmedWork = append(confirmedWork, v)
+		}
+	}
+
+	count := len(confirmedWork)
 	last = min(last, count)
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
-		Data:  allWork[first:last],
+		Data:  confirmedWork[first:last],
 	})
 }
 

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -17,14 +17,6 @@ type paginationPayload struct {
 	Count int         `json:"count"`
 }
 
-// min returns the smallest of the two provided integers.
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // getPaginationParams parses the request parameters to find pageNumber and
 // pageSize which are required for all paginated data requests. Returns first
 // and last, the indices of the first and last items to return.
@@ -70,20 +62,11 @@ func (ui *GUI) paginatedBlocks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	allWork := ui.cache.getMinedWork()
-	confirmedWork := make([]minedWork, 0)
-	for _, v := range allWork {
-		if v.Confirmed {
-			confirmedWork = append(confirmedWork, v)
-		}
-	}
-
-	count := len(confirmedWork)
-	last = min(last, count)
+	count, confirmedWork := ui.cache.getConfirmedMinedWork(first, last)
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
-		Data:  confirmedWork[first:last],
+		Data:  confirmedWork,
 	})
 }
 
@@ -99,13 +82,11 @@ func (ui *GUI) paginatedRewardQuotas(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	allRewardQuotas := ui.cache.getRewardQuotas()
-	count := len(allRewardQuotas)
-	last = min(last, count)
+	count, quotas := ui.cache.getRewardQuotas(first, last)
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
-		Data:  allRewardQuotas[first:last],
+		Data:  quotas,
 	})
 }
 
@@ -123,21 +104,11 @@ func (ui *GUI) paginatedBlocksByAccount(w http.ResponseWriter, r *http.Request) 
 
 	accountID := mux.Vars(r)["accountID"]
 
-	// Get all blocks mined by this account.
-	work := make([]minedWork, 0)
-	allWork := ui.cache.getMinedWork()
-	for _, v := range allWork {
-		if v.AccountID == accountID {
-			work = append(work, v)
-		}
-	}
-
-	count := len(work)
-	last = min(last, count)
+	count, work := ui.cache.getMinedWorkByAccount(first, last, accountID)
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
-		Data:  work[first:last],
+		Data:  work,
 	})
 }
 
@@ -155,14 +126,11 @@ func (ui *GUI) paginatedClientsByAccount(w http.ResponseWriter, r *http.Request)
 
 	accountID := mux.Vars(r)["accountID"]
 
-	allClients := ui.cache.getClients()[accountID]
-
-	count := len(allClients)
-	last = min(last, count)
+	count, clients := ui.cache.getClientsForAccount(first, last, accountID)
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
-		Data:  allClients[first:last],
+		Data:  clients,
 	})
 }
 
@@ -180,14 +148,11 @@ func (ui *GUI) paginatedPendingPaymentsByAccount(w http.ResponseWriter, r *http.
 
 	accountID := mux.Vars(r)["accountID"]
 
-	allPayments := ui.cache.getPendingPayments()[accountID]
-
-	count := len(allPayments)
-	last = min(last, count)
+	count, payments := ui.cache.getPendingPayments(first, last, accountID)
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
-		Data:  allPayments[first:last],
+		Data:  payments,
 	})
 }
 
@@ -205,13 +170,10 @@ func (ui *GUI) paginatedArchivedPaymentsByAccount(w http.ResponseWriter, r *http
 
 	accountID := mux.Vars(r)["accountID"]
 
-	allPayments := ui.cache.getArchivedPayments()[accountID]
-
-	count := len(allPayments)
-	last = min(last, count)
+	count, payments := ui.cache.getArchivedPayments(first, last, accountID)
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
-		Data:  allPayments[first:last],
+		Data:  payments,
 	})
 }


### PR DESCRIPTION
Homepage was showing some unconfirmed blocks due to the pagination endpoint not filtering correctly.

This PR has been updated to also include some improvements to the cache. The cache now performs all filtering and paging of data, rather than the calling code needing to do it. This is slightly more memory efficient, and also reduces duplication and simplifies calling code.