### PR TITLE
Fix pagination panics

### DIFF
--- a/gui/account.go
+++ b/gui/account.go
@@ -49,16 +49,16 @@ func (ui *GUI) account(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the 10 most recently mined blocks by this account.
-	_, recentWork := ui.cache.getMinedWorkByAccount(0, 9, accountID)
+	_, recentWork, _ := ui.cache.getMinedWorkByAccount(0, 9, accountID)
 
 	// Get the 10 most recent pending payments for this account.
-	_, pendingPmts := ui.cache.getPendingPayments(0, 9, accountID)
+	_, pendingPmts, _ := ui.cache.getPendingPayments(0, 9, accountID)
 
 	// Get the 10 most recent archived payments for this account.
-	_, archivedPmts := ui.cache.getArchivedPayments(0, 9, accountID)
+	_, archivedPmts, _ := ui.cache.getArchivedPayments(0, 9, accountID)
 
 	// Get 10 of this accounts connected clients.
-	_, clients := ui.cache.getClientsForAccount(0, 9, accountID)
+	_, clients, _ := ui.cache.getClientsForAccount(0, 9, accountID)
 
 	data := &accountPageData{
 		HeaderData: headerData{

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -138,7 +138,7 @@ func (c *Cache) getConfirmedMinedWork(first, last int) (int, []minedWork, error)
 
 	count := len(allWork)
 
-	if last >= count+(last-first) {
+	if first >= count {
 		return 0, allWork[0:0], fmt.Errorf("Blocks request is out of range. Maximum %v, Requested %v", count, last)
 	}
 
@@ -162,7 +162,7 @@ func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, [
 
 	count := len(allWork)
 
-	if last >= count+(last-first) {
+	if first >= count {
 		return 0, allWork[0:0], fmt.Errorf("Blocks by account request is out of range. Maximum %v, Requested %v", count, last)
 	}
 
@@ -200,7 +200,7 @@ func (c *Cache) getRewardQuotas(first, last int) (int, []rewardQuota, error) {
 
 	count := len(c.rewardQuotas)
 
-	if last >= count+(last-first) {
+	if first >= count {
 		return 0, c.rewardQuotas[0:0], fmt.Errorf("Reward Quotas request is out of range. Maximum %v, Requested %v", count, last)
 	}
 
@@ -251,7 +251,7 @@ func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, []
 
 	count := len(accountClients)
 
-	if last >= count+(last-first) {
+	if first >= count {
 		return 0, accountClients[0:0], fmt.Errorf("Clients by account request is out of range. Maximum %v, Requested %v", count, last)
 	}
 
@@ -326,7 +326,7 @@ func (c *Cache) getPendingPayments(first, last int, accountID string) (int, []pe
 
 	count := len(accountPayments)
 
-	if last >= count+(last-first) {
+	if first >= count {
 		return 0, accountPayments[0:0], fmt.Errorf("Pending payments by account request is out of range. Maximum %v, Requested %v", count, last)
 	}
 
@@ -345,7 +345,7 @@ func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, []a
 
 	count := len(accountPayments)
 
-	if last >= count+(last-first) {
+	if first >= count {
 		return 0, accountPayments[0:0], fmt.Errorf("Archived payments by account request is out of range. Maximum %v, Requested %v", count, last)
 	}
 

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -139,7 +139,7 @@ func (c *Cache) getConfirmedMinedWork(first, last int) (int, []minedWork, error)
 	count := len(allWork)
 
 	if first >= count {
-		return 0, allWork[0:0], fmt.Errorf("Blocks request is out of range. Maximum %v, Requested %v", count, last)
+		return 0, allWork[0:0], fmt.Errorf("Blocks request is out of range. Maximum %v, Requested %v", count, first)
 	}
 
 	requestedWork := allWork[first:min(last, count)]
@@ -163,7 +163,7 @@ func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, [
 	count := len(allWork)
 
 	if first >= count {
-		return 0, allWork[0:0], fmt.Errorf("Blocks by account request is out of range. Maximum %v, Requested %v", count, last)
+		return 0, allWork[0:0], fmt.Errorf("Blocks by account request is out of range. Maximum %v, Requested %v", count, first)
 	}
 
 	requestedWork := allWork[first:min(last, count)]
@@ -201,7 +201,7 @@ func (c *Cache) getRewardQuotas(first, last int) (int, []rewardQuota, error) {
 	count := len(c.rewardQuotas)
 
 	if first >= count {
-		return 0, c.rewardQuotas[0:0], fmt.Errorf("Reward Quotas request is out of range. Maximum %v, Requested %v", count, last)
+		return 0, c.rewardQuotas[0:0], fmt.Errorf("Reward Quotas request is out of range. Maximum %v, Requested %v", count, first)
 	}
 
 	requestedQuotas := c.rewardQuotas[first:min(last, count)]
@@ -252,7 +252,7 @@ func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, []
 	count := len(accountClients)
 
 	if first >= count {
-		return 0, accountClients[0:0], fmt.Errorf("Clients by account request is out of range. Maximum %v, Requested %v", count, last)
+		return 0, accountClients[0:0], fmt.Errorf("Clients by account request is out of range. Maximum %v, Requested %v", count, first)
 	}
 
 	requestedClients := accountClients[first:min(last, count)]
@@ -327,7 +327,7 @@ func (c *Cache) getPendingPayments(first, last int, accountID string) (int, []pe
 	count := len(accountPayments)
 
 	if first >= count {
-		return 0, accountPayments[0:0], fmt.Errorf("Pending payments by account request is out of range. Maximum %v, Requested %v", count, last)
+		return 0, accountPayments[0:0], fmt.Errorf("Pending payments by account request is out of range. Maximum %v, Requested %v", count, first)
 	}
 
 	requestedPayments := accountPayments[first:min(last, count)]
@@ -346,7 +346,7 @@ func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, []a
 	count := len(accountPayments)
 
 	if first >= count {
-		return 0, accountPayments[0:0], fmt.Errorf("Archived payments by account request is out of range. Maximum %v, Requested %v", count, last)
+		return 0, accountPayments[0:0], fmt.Errorf("Archived payments by account request is out of range. Maximum %v, Requested %v", count, first)
 	}
 
 	requestedPayments := accountPayments[first:min(last, count)]

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -125,7 +125,7 @@ func (c *Cache) updateMinedWork(work []*pool.AcceptedWork) {
 
 // getConfirmedMinedWork retrieves the cached list of confirmed blocks mined by
 // the pool.
-func (c *Cache) getConfirmedMinedWork(first, last int) (int, []minedWork) {
+func (c *Cache) getConfirmedMinedWork(first, last int) (int, []minedWork, error) {
 	c.minedWorkMtx.RLock()
 	defer c.minedWorkMtx.RUnlock()
 
@@ -137,14 +137,19 @@ func (c *Cache) getConfirmedMinedWork(first, last int) (int, []minedWork) {
 	}
 
 	count := len(allWork)
+
+	if last >= count+(last-first) {
+		return 0, allWork[0:0], fmt.Errorf("Blocks request is out of range. Maximum %v, Requested %v", count, last)
+	}
+
 	requestedWork := allWork[first:min(last, count)]
 
-	return count, requestedWork
+	return count, requestedWork, nil
 }
 
 // getMinedWorkByAccount retrieves the cached list of blocks mined by
 // an account. Returns both confirmed and unconfirmed blocks.
-func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, []minedWork) {
+func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, []minedWork, error) {
 	c.minedWorkMtx.RLock()
 	defer c.minedWorkMtx.RUnlock()
 
@@ -156,9 +161,14 @@ func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, [
 	}
 
 	count := len(allWork)
+
+	if last >= count+(last-first) {
+		return 0, allWork[0:0], fmt.Errorf("Blocks by account request is out of range. Maximum %v, Requested %v", count, last)
+	}
+
 	requestedWork := allWork[first:min(last, count)]
 
-	return count, requestedWork
+	return count, requestedWork, nil
 }
 
 // updateRewardQuotas uses a list of work quotas to refresh the cached list of
@@ -184,14 +194,19 @@ func (c *Cache) updateRewardQuotas(quotas []*pool.Quota) {
 }
 
 // getRewardQuotas retrieves the cached list of pending reward payment quotas.
-func (c *Cache) getRewardQuotas(first, last int) (int, []rewardQuota) {
+func (c *Cache) getRewardQuotas(first, last int) (int, []rewardQuota, error) {
 	c.rewardQuotasMtx.RLock()
 	defer c.rewardQuotasMtx.RUnlock()
 
 	count := len(c.rewardQuotas)
+
+	if last >= count+(last-first) {
+		return 0, c.rewardQuotas[0:0], fmt.Errorf("Reward Quotas request is out of range. Maximum %v, Requested %v", count, last)
+	}
+
 	requestedQuotas := c.rewardQuotas[first:min(last, count)]
 
-	return count, requestedQuotas
+	return count, requestedQuotas, nil
 }
 
 // getPoolHash retrieves the total hashrate of all connected mining clients.
@@ -228,16 +243,21 @@ func (c *Cache) updateClients(clients []*pool.Client) {
 
 // getClientsForAccount retrieves the cached list of connected clients for a
 // given account ID.
-func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, []client) {
+func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, []client, error) {
 	c.clientsMtx.RLock()
 	defer c.clientsMtx.RUnlock()
 
 	accountClients := c.clients[accountID]
 
 	count := len(accountClients)
+
+	if last >= count+(last-first) {
+		return 0, accountClients[0:0], fmt.Errorf("Clients by account request is out of range. Maximum %v, Requested %v", count, last)
+	}
+
 	requestedClients := accountClients[first:min(last, count)]
 
-	return count, requestedClients
+	return count, requestedClients, nil
 }
 
 // getClients retrieves the cached list of all clients connected to the pool.
@@ -298,28 +318,38 @@ func (c *Cache) updatePayments(pendingPmts []*pool.Payment, archivedPmts []*pool
 
 // getPendingPayments retrieves the cached list of unpaid payments for a given
 // account ID.
-func (c *Cache) getPendingPayments(first, last int, accountID string) (int, []pendingPayment) {
+func (c *Cache) getPendingPayments(first, last int, accountID string) (int, []pendingPayment, error) {
 	c.pendingPaymentsMtx.RLock()
 	defer c.pendingPaymentsMtx.RUnlock()
 
 	accountPayments := c.pendingPayments[accountID]
 
 	count := len(accountPayments)
+
+	if last >= count+(last-first) {
+		return 0, accountPayments[0:0], fmt.Errorf("Pending payments by account request is out of range. Maximum %v, Requested %v", count, last)
+	}
+
 	requestedPayments := accountPayments[first:min(last, count)]
 
-	return count, requestedPayments
+	return count, requestedPayments, nil
 }
 
 // getArchivedPayments retrieves the cached list of paid payments for a given
 // account ID.
-func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, []archivedPayment) {
+func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, []archivedPayment, error) {
 	c.archivedPaymentsMtx.RLock()
 	defer c.archivedPaymentsMtx.RUnlock()
 
 	accountPayments := c.archivedPayments[accountID]
 
 	count := len(accountPayments)
+
+	if last >= count+(last-first) {
+		return 0, accountPayments[0:0], fmt.Errorf("Archived payments by account request is out of range. Maximum %v, Requested %v", count, last)
+	}
+
 	requestedPayments := accountPayments[first:min(last, count)]
 
-	return count, requestedPayments
+	return count, requestedPayments, nil
 }

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -139,7 +139,7 @@ func (c *Cache) getConfirmedMinedWork(first, last int) (int, []minedWork, error)
 	count := len(allWork)
 
 	if first >= count {
-		return 0, allWork[0:0], fmt.Errorf("Blocks request is out of range. Maximum %v, Requested %v", count, first)
+		return 0, allWork[0:0], fmt.Errorf("blocks request is out of range. maximum %v, requested %v", count, first)
 	}
 
 	requestedWork := allWork[first:min(last, count)]
@@ -163,7 +163,7 @@ func (c *Cache) getMinedWorkByAccount(first, last int, accountID string) (int, [
 	count := len(allWork)
 
 	if first >= count {
-		return 0, allWork[0:0], fmt.Errorf("Blocks by account request is out of range. Maximum %v, Requested %v", count, first)
+		return 0, allWork[0:0], fmt.Errorf("blocks by account request is out of range. maximum %v, requested %v", count, first)
 	}
 
 	requestedWork := allWork[first:min(last, count)]
@@ -201,7 +201,7 @@ func (c *Cache) getRewardQuotas(first, last int) (int, []rewardQuota, error) {
 	count := len(c.rewardQuotas)
 
 	if first >= count {
-		return 0, c.rewardQuotas[0:0], fmt.Errorf("Reward Quotas request is out of range. Maximum %v, Requested %v", count, first)
+		return 0, c.rewardQuotas[0:0], fmt.Errorf("reward quotas request is out of range. maximum %v, requested %v", count, first)
 	}
 
 	requestedQuotas := c.rewardQuotas[first:min(last, count)]
@@ -252,7 +252,7 @@ func (c *Cache) getClientsForAccount(first, last int, accountID string) (int, []
 	count := len(accountClients)
 
 	if first >= count {
-		return 0, accountClients[0:0], fmt.Errorf("Clients by account request is out of range. Maximum %v, Requested %v", count, first)
+		return 0, accountClients[0:0], fmt.Errorf("clients by account request is out of range. maximum %v, requested %v", count, first)
 	}
 
 	requestedClients := accountClients[first:min(last, count)]
@@ -327,7 +327,7 @@ func (c *Cache) getPendingPayments(first, last int, accountID string) (int, []pe
 	count := len(accountPayments)
 
 	if first >= count {
-		return 0, accountPayments[0:0], fmt.Errorf("Pending payments by account request is out of range. Maximum %v, Requested %v", count, first)
+		return 0, accountPayments[0:0], fmt.Errorf("pending payments by account request is out of range. maximum %v, requested %v", count, first)
 	}
 
 	requestedPayments := accountPayments[first:min(last, count)]
@@ -346,7 +346,7 @@ func (c *Cache) getArchivedPayments(first, last int, accountID string) (int, []a
 	count := len(accountPayments)
 
 	if first >= count {
-		return 0, accountPayments[0:0], fmt.Errorf("Archived payments by account request is out of range. Maximum %v, Requested %v", count, first)
+		return 0, accountPayments[0:0], fmt.Errorf("archived payments by account request is out of range. maximum %v, requested %v", count, first)
 	}
 
 	requestedPayments := accountPayments[first:min(last, count)]

--- a/gui/index.go
+++ b/gui/index.go
@@ -30,10 +30,10 @@ type indexPageData struct {
 func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError string) {
 
 	// Get the 10 most recent confirmed mined blocks.
-	_, confirmedWork := ui.cache.getConfirmedMinedWork(0, 9)
+	_, confirmedWork, _ := ui.cache.getConfirmedMinedWork(0, 9)
 
 	// Get the first 10 next reward payment percentages.
-	_, rewardQuotas := ui.cache.getRewardQuotas(0, 9)
+	_, rewardQuotas, _ := ui.cache.getRewardQuotas(0, 9)
 
 	data := indexPageData{
 		HeaderData: headerData{

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -6,6 +6,7 @@ package gui
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -28,6 +29,10 @@ func getPaginationParams(r *http.Request) (first, last int, err error) {
 	pageSize, err := strconv.Atoi(r.FormValue("pageSize"))
 	if err != nil {
 		return 0, 0, err
+	}
+
+	if pageNumber < 1 || pageSize < 1 {
+		return 0, 0, errors.New("Invalid number given for pageNumber or PageSize")
 	}
 
 	first = (pageNumber - 1) * pageSize
@@ -62,7 +67,13 @@ func (ui *GUI) paginatedBlocks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	count, confirmedWork := ui.cache.getConfirmedMinedWork(first, last)
+	count, confirmedWork, err := ui.cache.getConfirmedMinedWork(first, last)
+
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
@@ -82,7 +93,13 @@ func (ui *GUI) paginatedRewardQuotas(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	count, quotas := ui.cache.getRewardQuotas(first, last)
+	count, quotas, err := ui.cache.getRewardQuotas(first, last)
+
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
@@ -104,7 +121,13 @@ func (ui *GUI) paginatedBlocksByAccount(w http.ResponseWriter, r *http.Request) 
 
 	accountID := mux.Vars(r)["accountID"]
 
-	count, work := ui.cache.getMinedWorkByAccount(first, last, accountID)
+	count, work, err := ui.cache.getMinedWorkByAccount(first, last, accountID)
+
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
@@ -126,7 +149,13 @@ func (ui *GUI) paginatedClientsByAccount(w http.ResponseWriter, r *http.Request)
 
 	accountID := mux.Vars(r)["accountID"]
 
-	count, clients := ui.cache.getClientsForAccount(first, last, accountID)
+	count, clients, err := ui.cache.getClientsForAccount(first, last, accountID)
+
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
@@ -148,7 +177,13 @@ func (ui *GUI) paginatedPendingPaymentsByAccount(w http.ResponseWriter, r *http.
 
 	accountID := mux.Vars(r)["accountID"]
 
-	count, payments := ui.cache.getPendingPayments(first, last, accountID)
+	count, payments, err := ui.cache.getPendingPayments(first, last, accountID)
+
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,
@@ -170,7 +205,13 @@ func (ui *GUI) paginatedArchivedPaymentsByAccount(w http.ResponseWriter, r *http
 
 	accountID := mux.Vars(r)["accountID"]
 
-	count, payments := ui.cache.getArchivedPayments(first, last, accountID)
+	count, payments, err := ui.cache.getArchivedPayments(first, last, accountID)
+
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	sendJSONResponse(w, paginationPayload{
 		Count: count,

--- a/gui/pagination.go
+++ b/gui/pagination.go
@@ -32,7 +32,7 @@ func getPaginationParams(r *http.Request) (first, last int, err error) {
 	}
 
 	if pageNumber < 1 || pageSize < 1 {
-		return 0, 0, errors.New("Invalid number given for pageNumber or pageSize")
+		return 0, 0, errors.New("invalid number given for pagenumber or pagesize")
 	}
 
 	first = (pageNumber - 1) * pageSize
@@ -68,7 +68,6 @@ func (ui *GUI) paginatedBlocks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	count, confirmedWork, err := ui.cache.getConfirmedMinedWork(first, last)
-
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -94,7 +93,6 @@ func (ui *GUI) paginatedRewardQuotas(w http.ResponseWriter, r *http.Request) {
 	}
 
 	count, quotas, err := ui.cache.getRewardQuotas(first, last)
-
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -122,7 +120,6 @@ func (ui *GUI) paginatedBlocksByAccount(w http.ResponseWriter, r *http.Request) 
 	accountID := mux.Vars(r)["accountID"]
 
 	count, work, err := ui.cache.getMinedWorkByAccount(first, last, accountID)
-
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -150,7 +147,6 @@ func (ui *GUI) paginatedClientsByAccount(w http.ResponseWriter, r *http.Request)
 	accountID := mux.Vars(r)["accountID"]
 
 	count, clients, err := ui.cache.getClientsForAccount(first, last, accountID)
-
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -178,7 +174,6 @@ func (ui *GUI) paginatedPendingPaymentsByAccount(w http.ResponseWriter, r *http.
 	accountID := mux.Vars(r)["accountID"]
 
 	count, payments, err := ui.cache.getPendingPayments(first, last, accountID)
-
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -206,7 +201,6 @@ func (ui *GUI) paginatedArchivedPaymentsByAccount(w http.ResponseWriter, r *http
 	accountID := mux.Vars(r)["accountID"]
 
 	count, payments, err := ui.cache.getArchivedPayments(first, last, accountID)
-
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
There were a number of panics in pagination. 

1. If pagenumber or pagesize was 0 or negative.


```
 https://localhost:8080/blocks?pageSize=-1&pageNumber=1
 https://localhost:8080/blocks?pageSize=1&pageNumber=-1
```

2. If requested pagesize and pagenumber exceeded  work count. 

if count is 236 

then
 
```
 https://localhost:8080/blocks?pageSize=1&pageNumber=237
 https://localhost:8080/blocks?pageSize=2&pageNumber=119

etc
```

This PR fixes these issues. 