### PR TITLE
Fix harness to not expose profile

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -69,7 +69,7 @@ user=m$i
 address=${CLIENT_ADDRS[$i]}
 pool=127.0.0.1:5550
 maxprocs=$MINER_MAX_PROCS
-profile=:$PROFILE_PORT
+profile=$PROFILE_PORT
 EOF
 done
 

--- a/harness.sh
+++ b/harness.sh
@@ -105,7 +105,7 @@ lastnperiod=${LAST_N_PERIOD}
 adminpass=${ADMIN_PASS}
 guidir=${GUI_DIR}
 designation=${SESSION}
-profile=:6060
+profile=6060
 EOF
 
 cat > "${NODES_ROOT}/mwallet/dcrmwctl.conf" <<EOF


### PR DESCRIPTION
The ":" while defining port made the profile service accessible on all interfaces. Now it only contains port number hence it defaults to localhost. 