### PR TITLE
Add dcrctl install instructions for harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ miner for testing.
 
 To run the mining harness:  
 
+Install [dcrctl](https://github.com/decred/dcrctl) 
+
+```sh
+GO111MODULE=on go get decred.org/dcrctl
+```
+then
+
 ```sh
 cd dcrpool/cmd/miner 
 go install


### PR DESCRIPTION
harness needs dcrctl to work. Since dcrctl has it own repo now it needs to be installed separately from dcrd.