### PR TITLE
multi: utilize tx confimation notifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ mining rewards of the pool. The addresses generated from it should be the mining
 addresses (`--miningaddr`) set for the mining node. It is important to set 
 multiple mining addresses for the mining node in production to make it 
 difficult for third-parties wanting to track coinbases mined by the pool and 
-ultimately determine the cummulative value of coinbases mined. 
+ultimately determine the cumulative value of coinbases mined. 
 
 The fee account's purpose is to receive pool fees of the mining pool. It is 
 important to set multiple pool fee addresses to the mining pool in production to 
 make it difficult for third-parties wanting to track pool fees collected by 
-the pool and ultimately determine the cummulative value accrued by pool operators. 
+the pool and ultimately determine the cumulative value accrued by pool operators. 
 With multiple pool fee addresses set, the mining pool picks one at random for 
 every payout made. The addresses generated from the fee account should be 
 set as the pool fee addresses (`--poolfeeaddrs`) of the mining pool.

--- a/README.md
+++ b/README.md
@@ -133,10 +133,19 @@ In mining pool mode the ideal wallet setup is to have two wallet accounts,
 the pool account and the fee account, for the mining pool. This account structure 
 separates revenue earned from pool operations from mining rewards gotten on 
 behalf of participating clients. The pool account's purpose is to receive 
-mining rewards of the pool. The address generated from it should be the mining 
-address (`--miningaddr`) of the mining node. The fee account's purpose is to 
-receive pool fees of the mining pool. The address generated from it should be 
-the address set as the pool fee address (`--poolfeeaddrs`) of the mining pool.
+mining rewards of the pool. The addresses generated from it should be the mining 
+addresses (`--miningaddr`) set for the mining node. It is important to set 
+multiple mining addresses for the mining node in production to make it 
+difficult for third-parties wanting to track coinbases mined by the pool and 
+ultimately determine the cummulative value of coinbases mined. 
+
+The fee account's purpose is to receive pool fees of the mining pool. It is 
+important to set multiple pool fee addresses to the mining pool in production to 
+make it difficult for third-parties wanting to track pool fees collected by 
+the pool and ultimately determine the cummulative value accrued by pool operators. 
+With multiple pool fee addresses set, the mining pool picks one at random for 
+every payout made. The addresses generated from the fee account should be 
+set as the pool fee addresses (`--poolfeeaddrs`) of the mining pool.
 
 ## Testing
 

--- a/dcrpool.go
+++ b/dcrpool.go
@@ -153,12 +153,19 @@ func newPool(cfg *config) (*miningPool, error) {
 			AccountNumber:         cfg.WalletAccount,
 			RequiredConfirmations: 1,
 		}
-		_, err = walletConn.Balance(context.TODO(), req)
+		_, err = walletConn.Balance(p.ctx, req)
 		if err != nil {
 			return nil, err
 		}
 
 		p.hub.SetWalletConnection(walletConn, grpc.Close)
+
+		confNotifs, err := walletConn.ConfirmationNotifications(p.ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		p.hub.SetTxConfNotifClient(confNotifs)
 	}
 
 	err = p.hub.FetchWork(p.ctx)

--- a/pool/acceptedwork.go
+++ b/pool/acceptedwork.go
@@ -62,7 +62,7 @@ func NewAcceptedWork(blockHash string, prevHash string, height uint32,
 		Height:    height,
 		MinedBy:   minedBy,
 		Miner:     miner,
-		CreatedOn: time.Now().Unix(),
+		CreatedOn: time.Now().UnixNano(),
 	}
 }
 

--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -30,7 +30,7 @@ type ChainStateConfig struct {
 	PayDividends func(context.Context, uint32) error
 	// GeneratePayments creates payments for participating accounts in pool
 	// mining mode based on the configured payment scheme.
-	GeneratePayments func(uint32, *PaymentSource, dcrutil.Amount) error
+	GeneratePayments func(uint32, *PaymentSource, dcrutil.Amount, int64) error
 	// GetBlock fetches the block associated with the provided block hash.
 	GetBlock func(context.Context, *chainhash.Hash) (*wire.MsgBlock, error)
 	// GetBlockConfirmations fetches the block confirmations with the provided
@@ -420,7 +420,8 @@ func (cs *ChainState) handleChainUpdates(ctx context.Context) {
 					Coinbase:  block.Transactions[0].TxHash().String(),
 				}
 				amt := dcrutil.Amount(block.Transactions[0].TxOut[2].Value)
-				err = cs.cfg.GeneratePayments(block.Header.Height, source, amt)
+				err = cs.cfg.GeneratePayments(block.Header.Height, source,
+					amt, work.CreatedOn)
 				if err != nil {
 					// Errors generated creating payments are fatal since it is
 					// required to distribute payments to participating miners.

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -41,7 +41,7 @@ func testChainState(t *testing.T, db *bolt.DB) {
 	payDividends := func(context.Context, uint32) error {
 		return nil
 	}
-	generatePayments := func(uint32, *PaymentSource, dcrutil.Amount) error {
+	generatePayments := func(uint32, *PaymentSource, dcrutil.Amount, int64) error {
 		return nil
 	}
 	getBlock := func(context.Context, *chainhash.Hash) (*wire.MsgBlock, error) {

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -617,7 +617,7 @@ func (h *Hub) FetchWorkQuotas() ([]*Quota, error) {
 	var percentages map[string]*big.Rat
 	var err error
 	if h.cfg.PaymentMethod == PPS {
-		percentages, err = h.paymentMgr.PPSSharePercentages()
+		percentages, err = h.paymentMgr.PPSSharePercentages(time.Now().UnixNano())
 	}
 	if h.cfg.PaymentMethod == PPLNS {
 		percentages, err = h.paymentMgr.PPLNSSharePercentages()

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -548,6 +548,9 @@ func (h *Hub) shutdown() {
 	if h.nodeConn != nil {
 		h.nodeConn.Shutdown()
 	}
+	if h.notifClient != nil {
+		_ = h.notifClient.CloseSend()
+	}
 	h.db.Close()
 }
 

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -100,10 +100,6 @@ func (t *tWalletConnection) SignTransaction(context.Context, *walletrpc.SignTran
 	}, nil
 }
 
-func (t *tWalletConnection) BestBlock(ctx context.Context, in *walletrpc.BestBlockRequest, opts ...grpc.CallOption) (*walletrpc.BestBlockResponse, error) {
-	return nil, nil
-}
-
 func (t *tWalletConnection) PublishTransaction(context.Context, *walletrpc.PublishTransactionRequest, ...grpc.CallOption) (*walletrpc.PublishTransactionResponse, error) {
 	txHash, err := hex.DecodeString("d2a667e0f1643c3deb2de87ef9af3252679459f62" +
 		"5451a351b1510b5090abe23")

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -748,7 +748,7 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32) error {
 	// The fee address is being picked at random from the set of pool fee
 	// addresses to make it difficult for third-parties wanting to track
 	// pool fees collected by the pool and ultimately determine the
-	// cummulative value accrued by pool operators.
+	// cumulative value accrued by pool operators.
 	feeAddr := pm.cfg.PoolFeeAddrs[rand.Intn(len(pm.cfg.PoolFeeAddrs))]
 
 	// Create the payout transaction.

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -747,8 +747,13 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32) error {
 		return nil
 	}
 
-	// Create the payout transaction.
+	// The fee address is being picked at random from the set of pool fee
+	// addresses to make it difficult for third-parties wanting to track
+	// pool fees collected by the pool and ultimately determine the
+	// cummulative value accrued by pool operators.
 	feeAddr := pm.cfg.PoolFeeAddrs[rand.Intn(len(pm.cfg.PoolFeeAddrs))]
+
+	// Create the payout transaction.
 	inputs := make([]chainjson.TransactionInput, 0)
 	outputs := make(map[string]dcrutil.Amount)
 	var tIn dcrutil.Amount


### PR DESCRIPTION
This uses tx confirmation notifications from the wallet to confirm the coinbases sourced by payments are spendable before attempting to spend them. The readme now  better explains why multiple pool fee address and multiple mining addresses are important to set in production.

Resolves #222 and #218.