### PR TITLE
multi: extend read timeouts in tests.

### DIFF
--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -121,7 +121,7 @@ func testClient(t *testing.T, db *bolt.DB) {
 			return true
 		},
 		HashCalcThreshold: 1,
-		ClientTimeout:     time.Millisecond * 1300,
+		ClientTimeout:     time.Millisecond * 5000,
 		SignalCache: func(_ CacheUpdateEvent) {
 			// Do nothing.
 		},
@@ -1406,7 +1406,7 @@ func testClient(t *testing.T, db *bolt.DB) {
 	}
 
 	// Trigger a client timeout by waiting.
-	time.Sleep(time.Millisecond * 1500)
+	time.Sleep(time.Millisecond * 5300)
 
 	// Empty the job bucket.
 	err = emptyBucket(db, jobBkt)

--- a/v1.1.0_release_notes.md
+++ b/v1.1.0_release_notes.md
@@ -7,11 +7,9 @@ changes made are:
 
 ## Bug Fixes.
  The notable bug fixes in this release include:
-   1. Data access issues related to using raw db values outside 
-   of their associated database transactions have been resolved.
+   1. Data access issues related to using raw db values outside of their associated database transactions have been resolved.
 
-   1. Race conditions associated with listing websocket clients and 
-   updating the GUI have been resolved.
+   1. Race conditions associated with listing websocket clients and updating the GUI have been resolved.
 
    1. Panics associated with the cpu miner in the testing harness have been resolved.
 
@@ -48,12 +46,9 @@ The notable infrastructure and interface improvements include:
 
  1. Mined work, reward quota, pending and archived payment requests by the GUI are now paginated. 
 
- 1. The pool now utiilizes transaction confirmation notification streams to 
- ensure coinbases are spendable before the pool utilizes them in payout transaction.
+ 1. The pool now utiilizes transaction confirmation notification streams to ensure coinbases are spendable before the pool utilizes them in payout transaction.
 
- 1. The allowed pool fee range has been updated to between 0.2% and 5%, 
- bounds inclusive. 
+ 1. The allowed pool fee range has been updated to between 0.2% and 5%, bounds inclusive. 
 
-1. Deprecated `--minpayment` & `--maxtxfeereserve` in favour of 
-an improved payment process which sources tx fees from the receiving account and does not generate change.
+1. Deprecated `--minpayment` & `--maxtxfeereserve` in favour of an improved payment process which sources tx fees from the receiving account and does not generate change.
 


### PR DESCRIPTION
This extends read timeouts in client tests to prevent read timeouts on slow machines. This also fixes some formatting issues with the release notes.