### PR TITLE
pool: update client subscription state before responding.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -333,10 +333,11 @@ func (c *Client) handleSubscribeRequest(req *Request, allowed bool) error {
 		resp = SubscribeResponse(*req.ID, nid, c.extraNonce1, ExtraNonce2Size, nil)
 	}
 
-	c.ch <- resp
 	c.subscribedMtx.Lock()
 	c.subscribed = true
 	c.subscribedMtx.Unlock()
+
+	c.ch <- resp
 
 	return nil
 }


### PR DESCRIPTION
This fixes a bug where the subscription state would be out of sync with the client because the response was getting sent before the state was updated.