### PR TITLE
gui: update Innosilicon D9 firmware link.

### DIFF
--- a/gui/assets/templates/index.html
+++ b/gui/assets/templates/index.html
@@ -72,7 +72,7 @@
                                     <li>Whatsminer&nbsp;D1</li>
                                 </ul>
                             </div>
-                            <p>For Innosilicon D9 the pool only supports <a href="https://drive.google.com/open?id=1wofB_OUDkB2gxz_IS7wM8Br6ogKdYDmY">D9_20180602_094459.swu</a> 
+                            <p>For Innosilicon D9 the pool only supports <a href="https://github.com/decred/dcrpool/releases/download/v1.1.0-rc1/D9_20180602_094459.swu">D9_20180602_094459.swu</a> 
                                 firmware, ensure the D9 has the supported firmware before connecting.</p>
                         </div>
                     </div>


### PR DESCRIPTION
This removes the google hosted D9 firmware link in favour of the github hosted option.

Resolves #170.