### PR TITLE
Remove quotes from generic font-family names

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.26.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/gui/assets/public/css/fonts.css
+++ b/gui/assets/public/css/fonts.css
@@ -53,11 +53,9 @@
 }
 
 html, body {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrpool", "Verdana", "sans-serif" !important;
+    font-family: "dcrpool", "Verdana", sans-serif;
 }
 
 pre, code {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrpool-code", "Courier New", "monospace" !important;
+    font-family: "dcrpool-code", "Courier New", monospace;
 }


### PR DESCRIPTION
Discovered in decred/dcrdocs#1103, generic font-family names should not have quotes: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

Also taken the opportunity to update build deps.