### PR TITLE
Load fonts.css last

### DIFF
--- a/gui/assets/templates/header.html
+++ b/gui/assets/templates/header.html
@@ -6,9 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Designation}} pool</title>
     <link rel="stylesheet" type="text/css" href="/assets/css/vendor/bootstrap-4.4.1.min.css">
-    <link rel="stylesheet" type="text/css" href="/assets/css/fonts.css">
     <link rel="stylesheet" type="text/css" href="/assets/css/dcrpool.css">
     <link rel="stylesheet" type="text/css" href="/assets/css/pagination.css">
+    <!-- fonts.css should be last to ensure dcr fonts take precedence. -->
+    <link rel="stylesheet" type="text/css" href="/assets/css/fonts.css">
 
     <script src="/assets/js/vendor/jquery-3.4.1.min.js"></script>
     <script src="/assets/js/vendor/pagination-2.1.5.min.js"></script>


### PR DESCRIPTION
fonts.css should be loaded last to ensure dcr fonts take precedence over fonts in other css files