### PR TITLE
Various harness updates

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.13, 1.14]
+        go: [1.14, 1.15]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ provides pool administrators database backup functionality when needed.
 
 Building or updating from source requires the following build dependencies:
 
-- **Go 1.13 or later**
+- **Go 1.14 or later**
 
   Installation instructions can be found here: <https://golang.org/doc/install>.
   It is recommended to add `$GOPATH/bin` to your `PATH` at this point.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ every payout made. The addresses generated from the fee account should be
 set as the pool fee addresses (`--poolfeeaddrs`) of the mining pool.
 
 ## Pool Fees
+
 In mining pool mode pool fees collected by the pool operator are for 
 maintaining a connection to the decred network for the delivery of work 
 to mining clients, the submission of solved work by mining clients to the 
@@ -155,6 +156,7 @@ network and processing of block rewards based on work contributed by
 participting accounts.
 
 ## Transaction fees
+
 Every mature group of payments plus the pool fees collected completely 
 exhaust the referenced coinbases being sourced from by payments. For this 
 reason payout transactions by the pool create no change. It is implicit 
@@ -166,25 +168,8 @@ the overall value of payouts being made by the transaction.
 
 ## Testing
 
-The project has [a configurable tmux mining harness](harness.sh) and a cpu 
-miner for testing.
-
-To run the mining harness:  
-
-Install [dcrctl](https://github.com/decred/dcrctl)
-
-```sh
-GO111MODULE=on go get decred.org/dcrctl
-```
-
-then
-
-```sh
-cd dcrpool/cmd/miner
-go install
-cd ../..
-./harness.sh
-```
+The project has a configurable tmux mining harness and a CPU miner for testing
+on simnet. Further documentation can be found in [harness.sh](./harness.sh).
 
 ## Should I be running dcrpool?
 

--- a/harness.sh
+++ b/harness.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
+#
+# Copyright (c) 2020 The Decred developers
+# Use of this source code is governed by an ISC
+# license that can be found in the LICENSE file.
+#
 # Tmux script that sets up a simnet mining harness.
+#
+# To use the script simply run `./harness.sh` from the repo root.
+#
+# The script makes a few assumptions about the system it is running on:
+# - tmux is installed
+# - dcrd, dcrwallet, dcrctl, miner and dcrpool are available on $PATH
+# - /tmp directory exists
+
 set -e
-SESSION="harness"
-NODES_ROOT=~/harness
+
+TMUX_SESSION="dcrpool-harness"
+HARNESS_ROOT=/tmp/dcrpool-harness
 RPC_USER="user"
 RPC_PASS="pass"
 MASTER_WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e1402eac"
@@ -14,7 +28,7 @@ MAX_GEN_TIME=20s
 MINER_MAX_PROCS=1
 PAYMENT_METHOD="pplns"
 LAST_N_PERIOD=5m
-GUI_DIR="${NODES_ROOT}/gui"
+GUI_DIR="${HARNESS_ROOT}/gui"
 CPU_MINING_ADDR="SsiuwSRYvH7pqWmRxFJWR8Vmqc3AWsjmK2Y"
 POOL_MINING_ADDR="SspUvSyDGSzvPz2NfdZ5LW15uq6rmuGZyhL"
 PFEE_ADDR="SsVPfV8yoMu7AvF5fGjxTGmQ57pGkaY6n8z"
@@ -45,24 +59,24 @@ CLIENT_ADDRS=(
 # addresses above - currently 20.
 NUMBER_OF_CLIENTS=2
 
-if [ -d "${NODES_ROOT}" ]; then
-  rm -R "${NODES_ROOT}"
+if [ -d "${HARNESS_ROOT}" ]; then
+  rm -R "${HARNESS_ROOT}"
 fi
 
 echo "Writing node config files"
-mkdir -p "${NODES_ROOT}/master"
-mkdir -p "${NODES_ROOT}/vnode"
-mkdir -p "${NODES_ROOT}/mwallet"
-mkdir -p "${NODES_ROOT}/vwallet"
-mkdir -p "${NODES_ROOT}/pool"
-mkdir -p "${NODES_ROOT}/gui"
+mkdir -p "${HARNESS_ROOT}/master"
+mkdir -p "${HARNESS_ROOT}/vnode"
+mkdir -p "${HARNESS_ROOT}/mwallet"
+mkdir -p "${HARNESS_ROOT}/vwallet"
+mkdir -p "${HARNESS_ROOT}/pool"
+mkdir -p "${HARNESS_ROOT}/gui"
 
 cp -r gui/assets ${GUI_DIR}/assets
 
 for ((i = 0; i < $NUMBER_OF_CLIENTS; i++)); do
 PROFILE_PORT=$(($i + 6061))
-mkdir -p "${NODES_ROOT}/c$i"
-cat > "${NODES_ROOT}/c$i/client.conf" <<EOF
+mkdir -p "${HARNESS_ROOT}/c$i"
+cat > "${HARNESS_ROOT}/c$i/client.conf" <<EOF
 debuglevel=trace
 activenet=simnet
 user=m$i
@@ -73,27 +87,27 @@ profile=$PROFILE_PORT
 EOF
 done
 
-cat > "${NODES_ROOT}/master/dcrmctl.conf" <<EOF
+cat > "${HARNESS_ROOT}/master/dcrmctl.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
-rpccert=${NODES_ROOT}/master/rpc.cert
+rpccert=${HARNESS_ROOT}/master/rpc.cert
 rpcserver=127.0.0.1:19556
 EOF
 
-cat > "${NODES_ROOT}/vnode/dcrvctl.conf" <<EOF
+cat > "${HARNESS_ROOT}/vnode/dcrvctl.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
-rpccert=${NODES_ROOT}/vnode/rpc.cert
+rpccert=${HARNESS_ROOT}/vnode/rpc.cert
 rpcserver=127.0.0.1:19560
 EOF
 
-cat > "${NODES_ROOT}/pool/pool.conf" <<EOF
+cat > "${HARNESS_ROOT}/pool/pool.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
 dcrdrpchost=127.0.0.1:19556
-dcrdrpccert=${NODES_ROOT}/master/rpc.cert
+dcrdrpccert=${HARNESS_ROOT}/master/rpc.cert
 walletgrpchost=127.0.0.1:19558
-walletrpccert=${NODES_ROOT}/mwallet/rpc.cert
+walletrpccert=${HARNESS_ROOT}/mwallet/rpc.cert
 debuglevel=trace
 maxgentime=${MAX_GEN_TIME}
 solopool=${SOLO_POOL}
@@ -108,37 +122,37 @@ designation=${SESSION}
 profile=6060
 EOF
 
-cat > "${NODES_ROOT}/mwallet/dcrmwctl.conf" <<EOF
+cat > "${HARNESS_ROOT}/mwallet/dcrmwctl.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
-rpccert=${NODES_ROOT}/mwallet/rpc.cert
+rpccert=${HARNESS_ROOT}/mwallet/rpc.cert
 rpcserver=127.0.0.1:19557
 EOF
 
-cat > "${NODES_ROOT}/vwallet/dcrvwctl.conf" <<EOF
+cat > "${HARNESS_ROOT}/vwallet/dcrvwctl.conf" <<EOF
 rpcuser=${RPC_USER}
 rpcpass=${RPC_PASS}
-rpccert=${NODES_ROOT}/vwallet/rpc.cert
+rpccert=${HARNESS_ROOT}/vwallet/rpc.cert
 rpcserver=127.0.0.1:19562
 EOF
 
-cat > "${NODES_ROOT}/mwallet/mwallet.conf" <<EOF
+cat > "${HARNESS_ROOT}/mwallet/mwallet.conf" <<EOF
 username=${RPC_USER}
 password=${RPC_PASS}
-cafile=${NODES_ROOT}/master/rpc.cert
-logdir=${NODES_ROOT}/mwallet/log
-appdata=${NODES_ROOT}/mwallet
+cafile=${HARNESS_ROOT}/master/rpc.cert
+logdir=${HARNESS_ROOT}/mwallet/log
+appdata=${HARNESS_ROOT}/mwallet
 simnet=1
 pass=${WALLET_PASS}
 accountgaplimit=25
 EOF
 
-cat > "${NODES_ROOT}/vwallet/vwallet.conf" <<EOF
+cat > "${HARNESS_ROOT}/vwallet/vwallet.conf" <<EOF
 username=${RPC_USER}
 password=${RPC_PASS}
-cafile=${NODES_ROOT}/vnode/rpc.cert
-logdir=${NODES_ROOT}/vwallet/log
-appdata=${NODES_ROOT}/vwallet
+cafile=${HARNESS_ROOT}/vnode/rpc.cert
+logdir=${HARNESS_ROOT}/vwallet/log
+appdata=${HARNESS_ROOT}/vwallet
 simnet=1
 enablevoting=1
 enableticketbuyer=1
@@ -149,22 +163,22 @@ grpclisten=127.0.0.1:19561
 rpclisten=127.0.0.1:19562
 EOF
 
-cd ${NODES_ROOT} && tmux new-session -d -s $SESSION
+cd ${HARNESS_ROOT} && tmux new-session -d -s $TMUX_SESSION
 
 ################################################################################
 # Setup the master node.
 ################################################################################
-cat > "${NODES_ROOT}/master/ctl" <<EOF
+cat > "${HARNESS_ROOT}/master/ctl" <<EOF
 #!/bin/sh
 dcrctl -C dcrmctl.conf \$*
 EOF
-chmod +x "${NODES_ROOT}/master/ctl"
+chmod +x "${HARNESS_ROOT}/master/ctl"
 
-tmux rename-window -t $SESSION 'master'
-tmux send-keys "cd ${NODES_ROOT}/master" C-m
+tmux rename-window -t $TMUX_SESSION 'master'
+tmux send-keys "cd ${HARNESS_ROOT}/master" C-m
 
 echo "Starting simnet master node"
-tmux send-keys "dcrd --appdata=${NODES_ROOT}/master \
+tmux send-keys "dcrd --appdata=${HARNESS_ROOT}/master \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --miningaddr=${POOL_MINING_ADDR} \
 --txindex \
@@ -174,7 +188,7 @@ tmux send-keys "dcrd --appdata=${NODES_ROOT}/master \
 ################################################################################
 # Setup the master node's dcrctl (mctl).
 ################################################################################
-cat > "${NODES_ROOT}/master/mine" <<EOF
+cat > "${HARNESS_ROOT}/master/mine" <<EOF
 #!/bin/sh
   NUM=1
   case \$1 in
@@ -186,10 +200,10 @@ cat > "${NODES_ROOT}/master/mine" <<EOF
     sleep 0.5
   done
 EOF
-chmod +x "${NODES_ROOT}/master/mine"
+chmod +x "${HARNESS_ROOT}/master/mine"
 
-tmux new-window -t $SESSION -n 'mctl'
-tmux send-keys "cd ${NODES_ROOT}/master" C-m
+tmux new-window -t $TMUX_SESSION -n 'mctl'
+tmux send-keys "cd ${HARNESS_ROOT}/master" C-m
 
 sleep 3
 # mine some blocks to start the chain.
@@ -202,14 +216,14 @@ tmux send-keys "./ctl livetickets"
 ################################################################################
 # Setup the pool wallet.
 ################################################################################
-cat > "${NODES_ROOT}/mwallet/ctl" <<EOF
+cat > "${HARNESS_ROOT}/mwallet/ctl" <<EOF
 #!/bin/sh
 dcrctl -C dcrmwctl.conf --wallet \$*
 EOF
-chmod +x "${NODES_ROOT}/mwallet/ctl"
+chmod +x "${HARNESS_ROOT}/mwallet/ctl"
 
-tmux new-window -t $SESSION -n 'mwallet'
-tmux send-keys "cd ${NODES_ROOT}/mwallet" C-m
+tmux new-window -t $TMUX_SESSION -n 'mwallet'
+tmux send-keys "cd ${HARNESS_ROOT}/mwallet" C-m
 tmux send-keys "dcrwallet -C mwallet.conf --create" C-m
 echo "Creating simnet master wallet"
 sleep 1
@@ -225,8 +239,8 @@ sleep 10
 # The consensus daemon must be synced for account generation to 
 # work as expected.
 echo "Setting up pool wallet accounts"
-tmux new-window -t $SESSION -n 'mwctl'
-tmux send-keys "cd ${NODES_ROOT}/mwallet" C-m
+tmux new-window -t $TMUX_SESSION -n 'mwctl'
+tmux send-keys "cd ${HARNESS_ROOT}/mwallet" C-m
 tmux send-keys "./ctl createnewaccount pfee" C-m
 tmux send-keys "./ctl getnewaddress pfee" C-m
 
@@ -242,18 +256,18 @@ tmux send-keys "./ctl getbalance"
 ################################################################################
 # Setup the voting node.
 ################################################################################
-cat > "${NODES_ROOT}/vnode/ctl" <<EOF
+cat > "${HARNESS_ROOT}/vnode/ctl" <<EOF
 #!/bin/sh
 dcrctl -C dcrvctl.conf \$*
 EOF
-chmod +x "${NODES_ROOT}/vnode/ctl"
+chmod +x "${HARNESS_ROOT}/vnode/ctl"
 
-tmux new-window -t $SESSION -n 'vnode'
-tmux send-keys "cd ${NODES_ROOT}/vnode" C-m
+tmux new-window -t $TMUX_SESSION -n 'vnode'
+tmux send-keys "cd ${HARNESS_ROOT}/vnode" C-m
 
 echo "Starting simnet voting node"
 
-tmux send-keys "dcrd --appdata=${NODES_ROOT}/vnode \
+tmux send-keys "dcrd --appdata=${HARNESS_ROOT}/vnode \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --connect=127.0.0.1:18555 \
 --listen=127.0.0.1:19559 --rpclisten=127.0.0.1:19560 \
@@ -266,7 +280,7 @@ tmux send-keys "dcrd --appdata=${NODES_ROOT}/vnode \
 # Setup the voting node's dcrctl (vctl).
 ################################################################################
 sleep 3
-cat > "${NODES_ROOT}/vnode/mine" <<EOF
+cat > "${HARNESS_ROOT}/vnode/mine" <<EOF
 #!/bin/sh
   NUM=1
   case \$1 in
@@ -278,10 +292,10 @@ cat > "${NODES_ROOT}/vnode/mine" <<EOF
     sleep 0.5
   done
 EOF
-chmod +x "${NODES_ROOT}/vnode/mine"
+chmod +x "${HARNESS_ROOT}/vnode/mine"
 
-tmux new-window -t $SESSION -n 'vctl'
-tmux send-keys "cd ${NODES_ROOT}/vnode" C-m
+tmux new-window -t $TMUX_SESSION -n 'vctl'
+tmux send-keys "cd ${HARNESS_ROOT}/vnode" C-m
 
 tmux send-keys "./mine 30" C-m
 sleep 10
@@ -290,13 +304,13 @@ echo "Mined 30 blocks, at stake enabled height (SEH)"
 ################################################################################
 # Setup the voting wallet.
 ################################################################################
-cat > "${NODES_ROOT}/vwallet/ctl" <<EOF
+cat > "${HARNESS_ROOT}/vwallet/ctl" <<EOF
 #!/bin/sh
 dcrctl -C dcrvwctl.conf --wallet \$*
 EOF
-chmod +x "${NODES_ROOT}/vwallet/ctl"
+chmod +x "${HARNESS_ROOT}/vwallet/ctl"
 
-cat > "${NODES_ROOT}/vwallet/tickets" <<EOF
+cat > "${HARNESS_ROOT}/vwallet/tickets" <<EOF
 #!/bin/sh
 NUM=1
 case \$1 in
@@ -305,10 +319,10 @@ case \$1 in
 esac
 ./ctl purchaseticket default 999999 1 \`./ctl getnewaddress\` \$NUM
 EOF
-chmod +x "${NODES_ROOT}/vwallet/tickets"
+chmod +x "${HARNESS_ROOT}/vwallet/tickets"
 
-tmux new-window -t $SESSION -n 'vwallet'
-tmux send-keys "cd ${NODES_ROOT}/vwallet" C-m
+tmux new-window -t $TMUX_SESSION -n 'vwallet'
+tmux send-keys "cd ${HARNESS_ROOT}/vwallet" C-m
 tmux send-keys "dcrwallet -C vwallet.conf --create" C-m
 echo "Creating simnet voting wallet"
 sleep 1
@@ -321,17 +335,17 @@ tmux send-keys "dcrwallet -C vwallet.conf --debuglevel=debug" C-m
 # Setup the voting wallet's dcrctl (vwctl).
 ################################################################################
 sleep 1
-tmux new-window -t $SESSION -n 'vwctl'
-tmux send-keys "cd ${NODES_ROOT}/vwallet" C-m
+tmux new-window -t $TMUX_SESSION -n 'vwctl'
+tmux send-keys "cd ${HARNESS_ROOT}/vwallet" C-m
 
 ################################################################################
 # Setup dcrpool.
 ################################################################################
 echo "Starting dcrpool"
 sleep 5
-tmux new-window -t $SESSION -n 'pool'
-tmux send-keys "cd ${NODES_ROOT}/pool" C-m
-tmux send-keys "dcrpool --configfile=pool.conf --homedir=${NODES_ROOT}/pool" C-m
+tmux new-window -t $TMUX_SESSION -n 'pool'
+tmux send-keys "cd ${HARNESS_ROOT}/pool" C-m
+tmux send-keys "dcrpool --configfile=pool.conf --homedir=${HARNESS_ROOT}/pool" C-m
 
 ################################################################################
 # Setup the mining clients.
@@ -339,9 +353,9 @@ tmux send-keys "dcrpool --configfile=pool.conf --homedir=${NODES_ROOT}/pool" C-m
 for ((i = 0; i < $NUMBER_OF_CLIENTS; i++)); do
   echo "Starting mining client $i"
   sleep 1
-  tmux new-window -t $SESSION -n c$i
-  tmux send-keys "cd ${NODES_ROOT}/c$i" C-m
-  tmux send-keys "miner --configfile=client.conf --homedir=${NODES_ROOT}/c$i" C-m
+  tmux new-window -t $TMUX_SESSION -n c$i
+  tmux send-keys "cd ${HARNESS_ROOT}/c$i" C-m
+  tmux send-keys "miner --configfile=client.conf --homedir=${HARNESS_ROOT}/c$i" C-m
 done
 
-tmux attach-session -t $SESSION
+tmux attach-session -t $TMUX_SESSION

--- a/harness.sh
+++ b/harness.sh
@@ -29,30 +29,38 @@ MINER_MAX_PROCS=1
 PAYMENT_METHOD="pplns"
 LAST_N_PERIOD=5m
 GUI_DIR="${HARNESS_ROOT}/gui"
-CPU_MINING_ADDR="SsiuwSRYvH7pqWmRxFJWR8Vmqc3AWsjmK2Y"
-POOL_MINING_ADDR="SspUvSyDGSzvPz2NfdZ5LW15uq6rmuGZyhL"
-PFEE_ADDR="SsVPfV8yoMu7AvF5fGjxTGmQ57pGkaY6n8z"
+# CPU_MINING_ADDR is the mining address printed during creation of vwallet.
+# Initial block rewards from `generate` are sent here so vwallet can buy tickets.
+CPU_MINING_ADDR="SsaJxXSymEGroxAiUY9u1mRq1DDWLxn5WhB"
+# POOL_MINING_ADDR is the mining address printed during creation of mwallet.
+# Block rewards from pool mining are sent here before being distributed to participants.
+POOL_MINING_ADDR="SsXciQNTo3HuV5tX3yy4hXndRWgLMRVC7Ah"
+# PFEE_ADDR is from mwallet, pfee account.
+# Pool fees are collected here.
+PFEE_ADDR="SsYcrXcBfUA1TAYiMhYRTkHupEapH7QWNU6"
+# CLIENT_ADDRS are from mwallet, accounts c0, c1, etc.
+# Client reward payments are sent to these addresses.
 CLIENT_ADDRS=(
-  "SsZckVrqHRBtvhJA5UqLZ3MDXpZHi5mK6uU"
-  "Ssn23a3rJaCUxjqXiVSNwU6FxV45sLkiFpz"
-  "SsgGu2Fz3c2YeoRKZMeXNQBJ324J8uFe2ku"
-  "Ssj65eTTHTvyEyQJBPuqUuueLouf5yMtmJL"
-  "SsZKVJQnN3Hm3A1Ga3WTTZMRceeGTZgsMTQ"
-  "SsivBg41hYAxGf4FDK8swGoxmJMTk8kqaks"
-  "Ssi34kZ7HN9WNHkofWsjKajoYwiAdryfr89"
-  "SsnEdBRWU5zVfo6rQxVkyVikCF2X3p5mVrW"
-  "SskZsGb78uyvkzCF7aqHYa24oWWHLF3XEKe"
-  "SsaJoAxcB3bTGoavzpymrx1q2wa6nkna35g"
-  "SsUpkNXC5824166ASdw72BFE8zeF4i4XaDp"
-  "SsZbyZp62wrEiZQ3iLyfUgpTg4KzNUNmzVP"
-  "SsaYJ3DYpaxquCd2cdD6Zba8p6jTnBFVjck"
-  "SsZpjNR3ZfrRzKGMtRZixoRb2uii43qE2QE"
-  "SsWTW7sgp5Pb1Hede5imKDUP5ymYZTXkzkX"
-  "SssRDNnKvD2bfKvKfC3p8b5UGR78nivxG56"
-  "Ssmc27WaSfizoyvhy6GSht5XtC9DYswKyTD"
-  "SsV83wxme92uY6tDKWxnGer5GBKXDHpknDo"
-  "Sse8V9WrWLSHS5t4WEr2Cy92FGRsxGwXTfo"
-  "SssSxnc6rixXPowbxcdrXg6PccAHFCe4x6K"
+  "SscVdtfaNS1iCLceaT8Sqwd8hGoia8XDifR"
+  "SsjUjmw8oGCg63C2MQPygFGZPh2Mbq3iaHM"
+  "SsbpP2WFUWtnzm4GbiLUTVYWgpGiFDb6M8G"
+  "SsVDptDDFQrfq7YZoDU3F1i6qNGgRo59FXG"
+  "SsViw2X9sY74GfXjYm5ieWLZv3vNmmtZGXB"
+  "SshjubSN3mXx6NTRiGnYZ2p9bU3ZKvMkd3f"
+  "Ssj1cwFpr7JM1KqW9cePAXM6nXVYz7BHveC"
+  "SsUgTPPZzQPQLq9MDYQKDXiAJjK4F5aQMjV"
+  "Ssh37A184b5pequfjwZGSZrPyrAFJETg7c4"
+  "Ssa9aqaHJYsPLyLRAz47j5uSJDmsSDkaSPU"
+  "Ssjti72KzbRACaMQcjrXHEUHn374dm4hbn6"
+  "SsUmjGtniYZxWQVkRUbN2Q65ou8poUMAFm8"
+  "SsjqAzmWmPPKG7kk9LDs9ZNfi2y9HjkVXU6"
+  "SsVwnUEBVSne61pqnxEU9WXh3HKeUemjHgU"
+  "SsZpWMDW6UN8AZkKfW99RWG4imY93Bnu8X2"
+  "SsqzmU32q7DWU8Pvqrhj7BLRZ4iy6wa6wTB"
+  "SsWJKGHaEmTjN9AUrTPoLWbumBJGqZnGvz6"
+  "SsbAAMn7b3Ei8rN4qq1CWZvgfytCHoSBq7c"
+  "SsnL7yGMaASzaDVb3VVsVutWGzAMT8hHFvR"
+  "SsjSDtCo8E6ztfib23kZSACFjW8Dfkv3obq"
 )
 
 # Number of mining clients to create. Maximum is determined by number of client

--- a/harness.sh
+++ b/harness.sh
@@ -224,12 +224,14 @@ chmod +x "${HARNESS_ROOT}/mwallet/ctl"
 
 tmux new-window -t $TMUX_SESSION -n 'mwallet'
 tmux send-keys "cd ${HARNESS_ROOT}/mwallet" C-m
-tmux send-keys "dcrwallet -C mwallet.conf --create" C-m
 echo "Creating simnet master wallet"
+tmux send-keys "dcrwallet -C mwallet.conf --create <<EOF
+y
+n
+y
+${MASTER_WALLET_SEED}
+EOF" C-m
 sleep 1
-tmux send-keys "${WALLET_PASS}" C-m "${WALLET_PASS}" C-m "n" C-m "y" C-m
-sleep 1
-tmux send-keys "${MASTER_WALLET_SEED}" C-m C-m
 tmux send-keys "dcrwallet -C mwallet.conf " C-m # --debuglevel=warn
 
 # ################################################################################
@@ -323,12 +325,14 @@ chmod +x "${HARNESS_ROOT}/vwallet/tickets"
 
 tmux new-window -t $TMUX_SESSION -n 'vwallet'
 tmux send-keys "cd ${HARNESS_ROOT}/vwallet" C-m
-tmux send-keys "dcrwallet -C vwallet.conf --create" C-m
 echo "Creating simnet voting wallet"
+tmux send-keys "dcrwallet -C vwallet.conf --create <<EOF
+y
+n
+y
+${VOTING_WALLET_SEED}
+EOF" C-m
 sleep 1
-tmux send-keys "${WALLET_PASS}" C-m "${WALLET_PASS}" C-m "n" C-m "y" C-m
-sleep 1
-tmux send-keys "${VOTING_WALLET_SEED}" C-m C-m
 tmux send-keys "dcrwallet -C vwallet.conf --debuglevel=debug" C-m
 
 ################################################################################


### PR DESCRIPTION
- Add more detailed docs to the harness, remove details from project README
- Rename some vars in the harness to be more accurate:
  - `NODES_ROOT` becomes `HARNESS_ROOT`
  - `SESSION` becomes `TMUX_SESSION`
- tmux session is now `dcrpool-harness` rather than simply `harness`
- Create harness directory in `/tmp` rather than user home dir
- Create wallets with stdin rather than using tmux send-keys & sleep (decred/dcrwallet#1807)

Also including the update to go 1.15