### PR TITLE
Use existing account if one exists

### DIFF
--- a/gui/account.go
+++ b/gui/account.go
@@ -36,11 +36,7 @@ func (ui *GUI) account(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate the account id of the provided address.
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		ui.renderIndex(w, r, "Unable to generate account ID for address")
-		return
-	}
+	accountID := pool.AccountID(address)
 
 	if !ui.cfg.AccountExists(accountID) {
 		ui.renderIndex(w, r, "Nothing found for address")
@@ -84,11 +80,8 @@ func (ui *GUI) isPoolAccount(w http.ResponseWriter, r *http.Request) {
 
 	address := r.FormValue("address")
 
-	accountID, err := pool.AccountID(address, ui.cfg.ActiveNet)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
+	// Generate the account ID of the provided address.
+	accountID := pool.AccountID(address)
 
 	if !ui.cfg.AccountExists(accountID) {
 		w.WriteHeader(http.StatusNotFound)

--- a/pool/acceptedwork.go
+++ b/pool/acceptedwork.go
@@ -107,9 +107,9 @@ func FetchAcceptedWork(db *bolt.DB, id []byte) (*AcceptedWork, error) {
 	return &work, err
 }
 
-// Create persists the accepted work to the database.
-func (work *AcceptedWork) Create(db *bolt.DB) error {
-	const funcName = "AcceptedWork.Create"
+// Persist saves the accepted work to the database.
+func (work *AcceptedWork) Persist(db *bolt.DB) error {
+	const funcName = "AcceptedWork.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
 		bkt, err := fetchWorkBucket(tx)
 		if err != nil {

--- a/pool/acceptedwork_test.go
+++ b/pool/acceptedwork_test.go
@@ -11,7 +11,7 @@ import (
 func persistAcceptedWork(db *bolt.DB, blockHash string, prevHash string,
 	height uint32, minedBy string, miner string) (*AcceptedWork, error) {
 	acceptedWork := NewAcceptedWork(blockHash, prevHash, height, minedBy, miner)
-	err := acceptedWork.Create(db)
+	err := acceptedWork.Persist(db)
 	if err != nil {
 		return nil, err
 	}
@@ -94,9 +94,9 @@ func testAcceptedWork(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure creating an already existing accepted work returns an error.
-	err = workD.Create(db)
+	err = workD.Persist(db)
 	if err == nil {
-		t.Fatal("Create: expected a duplicate accepted work error")
+		t.Fatal("Persist: expected a duplicate accepted work error")
 	}
 
 	// Ensure fetching a non existent accepted work returns an error.

--- a/pool/account.go
+++ b/pool/account.go
@@ -86,9 +86,9 @@ func FetchAccount(db *bolt.DB, id []byte) (*Account, error) {
 	return &account, err
 }
 
-// Create persists the account to the database.
-func (acc *Account) Create(db *bolt.DB) error {
-	const funcName = "Account.Create"
+// Persist saves the account to the database.
+func (acc *Account) Persist(db *bolt.DB) error {
+	const funcName = "Account.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
 		bkt, err := fetchAccountBucket(tx)
 		if err != nil {

--- a/pool/account_test.go
+++ b/pool/account_test.go
@@ -9,7 +9,7 @@ import (
 
 func persistAccount(db *bolt.DB, address string) (*Account, error) {
 	acc := NewAccount(address)
-	err := acc.Create(db)
+	err := acc.Persist(db)
 	if err != nil {
 		return nil, err
 	}

--- a/pool/account_test.go
+++ b/pool/account_test.go
@@ -1,36 +1,39 @@
 package pool
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
-	"github.com/decred/dcrd/chaincfg/v3"
 	bolt "go.etcd.io/bbolt"
 )
 
-func persistAccount(db *bolt.DB, address string, activeNet *chaincfg.Params) (*Account, error) {
-	acc, err := NewAccount(address, activeNet)
+func persistAccount(db *bolt.DB, address string) (*Account, error) {
+	acc := NewAccount(address)
+	err := acc.Create(db)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create account: %v", err)
-	}
-	err = acc.Create(db)
-	if err != nil {
-		return nil, fmt.Errorf("unable to persist account: %v", err)
+		return nil, err
 	}
 	return acc, nil
 }
 
 func testAccount(t *testing.T, db *bolt.DB) {
-	accountA, err := persistAccount(db, "Ssj6Sd54j11JM8qpenCwfwnKD73dsjm68ru",
-		chaincfg.SimNetParams())
+	simnetAddrA := "Ssj6Sd54j11JM8qpenCwfwnKD73dsjm68ru"
+	simnetAddrB := "SssPc1UNr8czcP3W9hfAgpmLRa3zJPDhfSy"
+
+	// Create some valid accounts.
+	accountA, err := persistAccount(db, simnetAddrA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accountB, err := persistAccount(db, simnetAddrB)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	accountB, err := persistAccount(db, "SssPc1UNr8czcP3W9hfAgpmLRa3zJPDhfSy",
-		chaincfg.SimNetParams())
-	if err != nil {
-		t.Fatal(err)
+	// Creating the same account twice should fail.
+	_, err = persistAccount(db, simnetAddrA)
+	if !errors.Is(err, ErrValueFound) {
+		t.Fatal("expected value found error")
 	}
 
 	// Fetch an account with its id.
@@ -60,9 +63,14 @@ func testAccount(t *testing.T, db *bolt.DB) {
 		t.Fatalf("delete accountB error: %v ", err)
 	}
 
-	// Ensure the account have been deleted.
+	// Ensure the accounts have both been deleted.
 	_, err = FetchAccount(db, []byte(accountA.UUID))
-	if err == nil {
-		t.Fatal("expected no account found error")
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatal("expected value not found error")
+	}
+
+	_, err = FetchAccount(db, []byte(accountB.UUID))
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatal("expected value not found error")
 	}
 }

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -262,7 +262,7 @@ func testChainState(t *testing.T, db *bolt.DB) {
 		"00007979602e13db87f6c760bbf27c137f4112b9e1988724bd245fb0bb7d1283",
 		"00006fb4ee4609e90196cfa41df2f1129a64553f935f21e6940b38e7e26e7dff",
 		42, xID, CPU)
-	err = work.Create(cs.cfg.DB)
+	err = work.Persist(cs.cfg.DB)
 	if err != nil {
 		t.Fatalf("unable to persist accepted work %v", err)
 	}
@@ -276,7 +276,7 @@ func testChainState(t *testing.T, db *bolt.DB) {
 		"00000000000000000000000000000000000000000000000000000000000" +
 		"00000000000008000000100000000000005a0"
 	job := NewJob(workE, 42)
-	err = job.Create(cs.cfg.DB)
+	err = job.Persist(cs.cfg.DB)
 	if err != nil {
 		log.Errorf("failed to persist job %v", err)
 		return

--- a/pool/client.go
+++ b/pool/client.go
@@ -179,7 +179,7 @@ func (c *Client) claimWeightedShare() error {
 	}
 	weight := ShareWeights[c.cfg.FetchMiner()]
 	share := NewShare(c.account, weight)
-	return share.Create(c.cfg.DB)
+	return share.Persist(c.cfg.DB)
 }
 
 // handleAuthorizeRequest processes authorize request messages received.
@@ -230,7 +230,7 @@ func (c *Client) handleAuthorizeRequest(req *Request, allowed bool) error {
 
 		// Create the account if it does not already exist.
 		account := NewAccount(address)
-		err = account.Create(c.cfg.DB)
+		err = account.Persist(c.cfg.DB)
 		if err != nil {
 			// Do not error if the account already exists.
 			if !errors.Is(err, ErrValueFound) {
@@ -461,7 +461,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 	// by the mining node.
 	work := NewAcceptedWork(hash.String(), header.PrevBlock.String(),
 		header.Height, c.account, c.cfg.FetchMiner())
-	err = work.Create(c.cfg.DB)
+	err = work.Persist(c.cfg.DB)
 	if err != nil {
 		// If the submitted accepted work already exists, ignore the
 		// submission.
@@ -606,7 +606,7 @@ func (c *Client) updateWork() {
 
 	// Create a job for the timestamp-rolled current work.
 	job := NewJob(updatedWorkE, height)
-	err = job.Create(c.cfg.DB)
+	err = job.Persist(c.cfg.DB)
 	if err != nil {
 		log.Error(err)
 		return

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -530,7 +530,7 @@ func testClient(t *testing.T, db *bolt.DB) {
 		"000000000000000000000000000000000000000000000800000010" +
 		"0000000000005a0"
 	job := NewJob(workE, 41)
-	err = job.Create(client.cfg.DB)
+	err = job.Persist(client.cfg.DB)
 	if err != nil {
 		t.Fatalf("failed to persist job %v", err)
 	}
@@ -815,7 +815,7 @@ func testClient(t *testing.T, db *bolt.DB) {
 		"0000000000000000000000000000000000000000000000800000010000000000" +
 		"0005a0"
 	job = NewJob(workE, 46)
-	err = job.Create(client.cfg.DB)
+	err = job.Persist(client.cfg.DB)
 	if err != nil {
 		t.Fatalf("failed to persist job %v", err)
 	}

--- a/pool/db_test.go
+++ b/pool/db_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/decred/dcrd/chaincfg/v3"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -284,14 +283,12 @@ func testInitDB(t *testing.T) {
 
 func testDatabase(t *testing.T, db *bolt.DB) {
 	// Persist some accounts.
-	accountA, err := persistAccount(db, "Ssj6Sd54j11JM8qpenCwfwnKD73dsjm68ru",
-		chaincfg.SimNetParams())
+	accountA, err := persistAccount(db, "Ssj6Sd54j11JM8qpenCwfwnKD73dsjm68ru")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = persistAccount(db, "SssPc1UNr8czcP3W9hfAgpmLRa3zJPDhfSy",
-		chaincfg.SimNetParams())
+	_, err = persistAccount(db, "SssPc1UNr8czcP3W9hfAgpmLRa3zJPDhfSy")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,11 +333,11 @@ func testDatabase(t *testing.T, db *bolt.DB) {
 	}
 
 	// Recreate account X and Y.
-	_, err = persistAccount(db, xAddr, chaincfg.SimNetParams())
+	_, err = persistAccount(db, xAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = persistAccount(db, yAddr, chaincfg.SimNetParams())
+	_, err = persistAccount(db, yAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -421,7 +421,7 @@ func (h *Hub) processWork(headerE string) {
 	nTime := headerE[272:280]
 	genTx2 := headerE[352:360]
 	job := NewJob(headerE, height)
-	err = job.Create(h.db)
+	err = job.Persist(h.db)
 	if err != nil {
 		log.Error(err)
 		return

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -340,9 +340,9 @@ func testHub(t *testing.T, db *bolt.DB) {
 		"193c4b8fd02aaed33ab9c5418ace9bec4047f61f923767bceb5a51c6e368bfa6",
 		CPU)
 
-	err = work.Create(db)
+	err = work.Persist(db)
 	if err != nil {
-		t.Fatalf("[Create] unexpected error: %v", err)
+		t.Fatalf("[Persist] unexpected error: %v", err)
 	}
 
 	port := uint32(5030)

--- a/pool/job.go
+++ b/pool/job.go
@@ -95,9 +95,9 @@ func FetchJob(db *bolt.DB, id []byte) (*Job, error) {
 	return &job, err
 }
 
-// Create persists the job to the database.
-func (job *Job) Create(db *bolt.DB) error {
-	const funcName = "Job.Create"
+// Persist saves the job to the database.
+func (job *Job) Persist(db *bolt.DB) error {
+	const funcName = "Job.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
 		bkt, err := fetchJobBucket(tx)
 		if err != nil {

--- a/pool/job_test.go
+++ b/pool/job_test.go
@@ -9,7 +9,7 @@ import (
 
 func persistJob(db *bolt.DB, header string, height uint32) (*Job, error) {
 	job := NewJob(header, height)
-	err := job.Create(db)
+	err := job.Persist(db)
 	if err != nil {
 		return nil, fmt.Errorf("unable to persist job: %v", err)
 	}

--- a/pool/payment.go
+++ b/pool/payment.go
@@ -124,9 +124,9 @@ func FetchPayment(db *bolt.DB, id []byte) (*Payment, error) {
 	return &payment, err
 }
 
-// Create persists a payment to the database.
-func (pmt *Payment) Create(db *bolt.DB) error {
-	const funcName = "Payment.Create"
+// Persist saves a payment to the database.
+func (pmt *Payment) Persist(db *bolt.DB) error {
+	const funcName = "Payment.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
 		bkt, err := fetchPaymentBucket(tx)
 		if err != nil {
@@ -151,7 +151,7 @@ func (pmt *Payment) Create(db *bolt.DB) error {
 
 // Update persists the updated payment to the database.
 func (pmt *Payment) Update(db *bolt.DB) error {
-	return pmt.Create(db)
+	return pmt.Persist(db)
 }
 
 // Delete purges the referenced payment from the database. Note that

--- a/pool/payment_test.go
+++ b/pool/payment_test.go
@@ -16,7 +16,7 @@ import (
 func persistPayment(db *bolt.DB, account string, source *PaymentSource,
 	amount dcrutil.Amount, height uint32, estMaturity uint32) (*Payment, error) {
 	pmt := NewPayment(account, source, amount, height, estMaturity)
-	err := pmt.Create(db)
+	err := pmt.Persist(db)
 	if err != nil {
 		return nil, fmt.Errorf("unable to persist payment: %v", err)
 	}

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -489,7 +489,7 @@ func (pm *PaymentMgr) payPerShare(source *PaymentSource, amt dcrutil.Amount, hei
 		return err
 	}
 	for _, payment := range payments {
-		err := payment.Create(pm.cfg.DB)
+		err := payment.Persist(pm.cfg.DB)
 		if err != nil {
 			return err
 		}
@@ -520,7 +520,7 @@ func (pm *PaymentMgr) payPerLastNShares(source *PaymentSource, amt dcrutil.Amoun
 		return err
 	}
 	for _, payment := range payments {
-		err := payment.Create(pm.cfg.DB)
+		err := payment.Persist(pm.cfg.DB)
 		if err != nil {
 			return err
 		}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -42,19 +42,14 @@ func setupDB() (*bolt.DB, error) {
 		return nil, err
 	}
 
-	xID, err = AccountID(xAddr, chaincfg.SimNetParams())
+	xID = AccountID(xAddr)
+	yID = AccountID(yAddr)
+
+	_, err = persistAccount(db, xAddr)
 	if err != nil {
 		return nil, err
 	}
-	yID, err = AccountID(yAddr, chaincfg.SimNetParams())
-	if err != nil {
-		return nil, err
-	}
-	_, err = persistAccount(db, xAddr, chaincfg.SimNetParams())
-	if err != nil {
-		return nil, err
-	}
-	_, err = persistAccount(db, yAddr, chaincfg.SimNetParams())
+	_, err = persistAccount(db, yAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/pool/share.go
+++ b/pool/share.go
@@ -71,9 +71,9 @@ func fetchShareBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	return bkt, nil
 }
 
-// Create persists a share to the database.
-func (s *Share) Create(db *bolt.DB) error {
-	const funcName = "Share.Create"
+// Persist saves a share to the database.
+func (s *Share) Persist(db *bolt.DB) error {
+	const funcName = "Share.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
 		bkt, err := fetchShareBucket(tx)
 		if err != nil {

--- a/pool/share_test.go
+++ b/pool/share_test.go
@@ -21,7 +21,7 @@ func persistShare(db *bolt.DB, account string, weight *big.Rat, createdOnNano in
 		Account: account,
 		Weight:  weight,
 	}
-	err := share.Create(db)
+	err := share.Persist(db)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is currently an issue introduced by #245 where a disconnected miner is not able to reconnect because of an "account already exists" error:

```
2020-09-17 10:39:07.242 [DBG] POOL: Mining client connected. id=a42490b0/cpu, addr=127.0.0.1:36458
2020-09-17 10:39:07.263 [ERR] POOL: Account.Create: account 7f36b2c979067add6ce030176e0bdc75ac65798842f339aed8ad22d6cdda584c already exists
2020-09-17 10:39:07.283 [ERR] POOL: a42490b0/cpu: EOF
```

This PR fixes the issue by introducing and using a new func `CreateOrFetchAccount`. `CreateOrFetchAccount` will retrieve an account if one exists, or create one if not.

The check for address decoding is also moved into `CreateOrFetchAccount`. We only need to check for address validity once before inserting an account into the database, we don't need to do it every single time we just want to create an account ID.