### PR TITLE
multi: account for DCP0006 upgrade.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200608124004-b2f67c2dc475
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.1-0.20200503044000-76f6906e50e5
 	github.com/decred/dcrd/rpcclient/v6 v6.0.0-20200623174822-e2d77e4e7efe
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/csrf v1.7.0
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/decred/dcrd/txscript/v3 v3.0.0-20200608124004-b2f67c2dc475 h1:tfngeUk
 github.com/decred/dcrd/txscript/v3 v3.0.0-20200608124004-b2f67c2dc475/go.mod h1:vrm3R/AesmA9slTf0rFcwhD0SduAJAWxocyaWVi8dM0=
 github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
 github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -38,7 +38,7 @@ func testChainState(t *testing.T, db *bolt.DB) {
 		t.Fatalf("unexpected serialization error: %v", err)
 	}
 
-	payDividends := func(context.Context, uint32) error {
+	payDividends := func(context.Context, uint32, bool) error {
 		return nil
 	}
 	generatePayments := func(uint32, *PaymentSource, dcrutil.Amount, int64) error {


### PR DESCRIPTION
This updates picking the coinbase output from a tx base on the whether the treasury agenda is active or not.

Fixes #251.