### PR TITLE
Remove CreatedOn timestamp from payments

### DIFF
--- a/gui/assets/public/js/admin-pagination.js
+++ b/gui/assets/public/js/admin-pagination.js
@@ -11,7 +11,7 @@ if ($('#pending-payments-page-select').length) {
             var html = '';
             if (data.length > 0) {
                 $.each(data, function (_, item) {
-                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td>' +  item.createdon + '</td><td>' +  item.amount + '</td></tr>';
+                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td>' +  item.estimatedpaymentheight + '</td><td>' +  item.amount + '</td></tr>';
                 });
             } else {
                 html += '<tr><td colspan="100%"><span class="no-data">No pending payments</span></td></tr>';
@@ -28,7 +28,7 @@ if ($('#archived-payments-page-select').length) {
             var html = '';
             if (data.length > 0) {
                 $.each(data, function (_, item) {
-                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td><a href="' +  item.paidheighturl + '" rel="noopener noreferrer">' +  item.paidheight + '</a></td><td>' +  item.createdon + '</td><td>' +  item.amount + '</td><td><a href="' +  item.txurl + '" rel="noopener noreferrer">' +  item.txid + '</a></td></tr>';
+                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td><a href="' +  item.paidheighturl + '" rel="noopener noreferrer">' +  item.paidheight + '</a></td><td>' +  item.amount + '</td><td><a href="' +  item.txurl + '" rel="noopener noreferrer">' +  item.txid + '</a></td></tr>';
                 });
             } else {
                 html += '<tr><td colspan="100%"><span class="no-data">No received payments</span></td></tr>';

--- a/gui/assets/public/js/pagination.js
+++ b/gui/assets/public/js/pagination.js
@@ -79,7 +79,7 @@ if ($('#pending-payments-page-select').length) {
             var html = '';
             if (data.length > 0) {
                 $.each(data, function (_, item) {
-                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td>' +  item.createdon + '</td><td>' +  item.amount + '</td></tr>';
+                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td>' +  item.estimatedpaymentheight + '</td><td>' +  item.amount + '</td></tr>';
                 });
             } else {
                 html += '<tr><td colspan="100%"><span class="no-data">No pending payments</span></td></tr>';
@@ -96,7 +96,7 @@ if ($('#archived-payments-page-select').length) {
             var html = '';
             if (data.length > 0) {
                 $.each(data, function (_, item) {
-                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td><a href="' +  item.paidheighturl + '" rel="noopener noreferrer">' +  item.paidheight + '</a></td><td>' +  item.createdon + '</td><td>' +  item.amount + '</td><td><a href="' +  item.txurl + '" rel="noopener noreferrer">' +  item.txid + '</a></td></tr>';
+                    html += '<tr><td><a href="' +  item.workheighturl + '" rel="noopener noreferrer">' +  item.workheight + '</a></td><td><a href="' +  item.paidheighturl + '" rel="noopener noreferrer">' +  item.paidheight + '</a></td><td>' +  item.amount + '</td><td><a href="' +  item.txurl + '" rel="noopener noreferrer">' +  item.txid + '</a></td></tr>';
                 });
             } else {
                 html += '<tr><td colspan="100%"><span class="no-data">No received payments</span></td></tr>';

--- a/gui/assets/templates/payments.html
+++ b/gui/assets/templates/payments.html
@@ -1,8 +1,8 @@
 {{define "payments"}}
     
-    {{ if .PendingPayments }}
     <div class="row">
-        <div class="col-12 p-3">
+        {{ if .PendingPayments }}
+        <div class="col-xl p-3">
             <div class="block__content">
 
                 <div class="d-flex flex-wrap">
@@ -17,7 +17,7 @@
                     <thead>
                         <tr>
                             <th>Work Height</th>
-                            <th>Created On</th>
+                            <th>Est. Payment Height</th>
                             <th>Amount</th>
                         </tr>
                     </thead>
@@ -26,7 +26,7 @@
                         <tr>
                             <td><a href="{{ .WorkHeightURL }}"
                                     rel="noopener noreferrer">{{ .WorkHeight }}</a></td>
-                            <td>{{ .CreatedOn }}</td>
+                            <td>{{ .EstimatedPaymentHeight }}</td>
                             <td>{{ .Amount }}</td>
                         </tr>
                         {{end}}
@@ -37,11 +37,9 @@
 
             </div>
         </div>
-    </div>
-    {{end}}
+        {{end}}
 
-    <div class="row">
-        <div class="col-12 p-3">
+        <div class="col-xl p-3">
             <div class="block__content">
 
                 <div class="d-flex flex-wrap">
@@ -57,7 +55,6 @@
                         <tr>
                             <th>Work Height</th>
                             <th>Payment Height</th>
-                            <th>Created On</th>
                             <th>Amount</th>
                             <th>Tx ID</th>
                         </tr>
@@ -69,7 +66,6 @@
                                     rel="noopener noreferrer">{{ .WorkHeight }}</a></td>
                             <td><a href="{{ .PaidHeightURL }}"
                                     rel="noopener noreferrer">{{ .PaidHeight }}</a></td>
-                            <td>{{ .CreatedOn }}</td>
                             <td>{{ .Amount }}</td>
                             <td><a href="{{ .TxURL }}"
                                     rel="noopener noreferrer">{{ .TxID }}</a>

--- a/gui/assets/templates/payments.html
+++ b/gui/assets/templates/payments.html
@@ -5,10 +5,10 @@
         <div class="col-xl p-3">
             <div class="block__content">
 
-                <div class="d-flex flex-wrap">
-                    <h1 class="mr-auto text-nowrap">Pending Payments</h1>
+                <div class="d-flex flex-wrap align-items-baseline">
+                    <h1 class="mr-auto text-nowrap pr-4">Pending Payments</h1>
                     
-                    <h2 class="row mr-1">
+                    <h2>
                         Total:&nbsp;{{ .PendingPaymentsTotal }}
                     </h2>
                 </div>
@@ -42,10 +42,10 @@
         <div class="col-xl p-3">
             <div class="block__content">
 
-                <div class="d-flex flex-wrap">
-                    <h1 class="mr-auto text-nowrap">Payments Received</h1>
+                <div class="d-flex flex-wrap align-items-baseline">
+                    <h1 class="mr-auto text-nowrap pr-4">Payments Received</h1>
                     
-                    <h2 class="row mr-1">
+                    <h2>
                         Total:&nbsp;{{ .ArchivedPaymentsTotal }}
                     </h2>
                 </div>

--- a/gui/cache.go
+++ b/gui/cache.go
@@ -45,10 +45,10 @@ type rewardQuota struct {
 // pendingPayment represents an unpaid reward payment. It is json annotated so
 // it can easily be encoded and sent over a websocket or pagination request.
 type pendingPayment struct {
-	WorkHeight    string `json:"workheight"`
-	WorkHeightURL string `json:"workheighturl"`
-	Amount        string `json:"amount"`
-	CreatedOn     string `json:"createdon"`
+	WorkHeight             string `json:"workheight"`
+	WorkHeightURL          string `json:"workheighturl"`
+	Amount                 string `json:"amount"`
+	EstimatedPaymentHeight string `json:"estimatedpaymentheight"`
 }
 
 // archivedPayment represents a paid reward payment. It is json annotated so it
@@ -57,7 +57,6 @@ type archivedPayment struct {
 	WorkHeight    string `json:"workheight"`
 	WorkHeightURL string `json:"workheighturl"`
 	Amount        string `json:"amount"`
-	CreatedOn     string `json:"createdon"`
 	PaidHeight    string `json:"paidheight"`
 	PaidHeightURL string `json:"paidheighturl"`
 	TxURL         string `json:"txurl"`
@@ -290,10 +289,10 @@ func (c *Cache) updatePayments(pendingPmts []*pool.Payment, archivedPmts []*pool
 		accountID := p.Account
 		pendingPayments[accountID] = append(pendingPayments[accountID],
 			&pendingPayment{
-				WorkHeight:    fmt.Sprint(p.Height),
-				WorkHeightURL: blockURL(c.blockExplorerURL, p.Height),
-				Amount:        amount(p.Amount),
-				CreatedOn:     formatUnixTime(p.CreatedOn),
+				WorkHeight:             fmt.Sprint(p.Height),
+				WorkHeightURL:          blockURL(c.blockExplorerURL, p.Height),
+				Amount:                 amount(p.Amount),
+				EstimatedPaymentHeight: fmt.Sprint(p.EstimatedMaturity + 1),
 			},
 		)
 		if _, ok := pendingPaymentTotals[accountID]; !ok {
@@ -321,7 +320,6 @@ func (c *Cache) updatePayments(pendingPmts []*pool.Payment, archivedPmts []*pool
 				WorkHeight:    fmt.Sprint(p.Height),
 				WorkHeightURL: blockURL(c.blockExplorerURL, p.Height),
 				Amount:        amount(p.Amount),
-				CreatedOn:     formatUnixTime(p.CreatedOn),
 				PaidHeight:    fmt.Sprint(p.PaidOnHeight),
 				PaidHeightURL: blockURL(c.blockExplorerURL, p.PaidOnHeight),
 				TxURL:         txURL(c.blockExplorerURL, p.TransactionID),


### PR DESCRIPTION
- List "Estimated Payment Height" for pending payments instead of CreatedOn.
- Display payment tables side-by-side on large screens. Maintain vertical stacking on smaller screens + mobile.
- Fix payment totals alignment issues

![Screenshot from 2020-10-06 11-36-25](https://user-images.githubusercontent.com/6762864/95191124-3640c480-07c8-11eb-926e-c4c55bb0f6e5.png)
