### PR TITLE
Remove duplicated fetchBucket funcs.

### DIFF
--- a/pool/acceptedwork.go
+++ b/pool/acceptedwork.go
@@ -60,30 +60,12 @@ func NewAcceptedWork(blockHash string, prevHash string, height uint32,
 	}
 }
 
-// fetchWorkBucket is a helper function for getting the work bucket.
-func fetchWorkBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
-	const funcName = "fetchWorkBucket"
-	pbkt := tx.Bucket(poolBkt)
-	if pbkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(poolBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	bkt := pbkt.Bucket(workBkt)
-	if bkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(workBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	return bkt, nil
-}
-
 // FetchAcceptedWork fetches the accepted work referenced by the provided id.
 func FetchAcceptedWork(db *bolt.DB, id []byte) (*AcceptedWork, error) {
 	const funcName = "FetchAcceptedWork"
 	var work AcceptedWork
 	err := db.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchWorkBucket(tx)
+		bkt, err := fetchBucket(tx, workBkt)
 		if err != nil {
 			return err
 		}
@@ -111,7 +93,7 @@ func FetchAcceptedWork(db *bolt.DB, id []byte) (*AcceptedWork, error) {
 func (work *AcceptedWork) Persist(db *bolt.DB) error {
 	const funcName = "AcceptedWork.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchWorkBucket(tx)
+		bkt, err := fetchBucket(tx, workBkt)
 		if err != nil {
 			return err
 		}
@@ -145,7 +127,7 @@ func (work *AcceptedWork) Persist(db *bolt.DB) error {
 func (work *AcceptedWork) Update(db *bolt.DB) error {
 	const funcName = "AcceptedWork.Update"
 	return db.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchWorkBucket(tx)
+		bkt, err := fetchBucket(tx, workBkt)
 		if err != nil {
 			return err
 		}
@@ -186,7 +168,7 @@ func ListMinedWork(db *bolt.DB) ([]*AcceptedWork, error) {
 	const funcName = "ListMinedWork"
 	minedWork := make([]*AcceptedWork, 0)
 	err := db.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchWorkBucket(tx)
+		bkt, err := fetchBucket(tx, workBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/acceptedwork_test.go
+++ b/pool/acceptedwork_test.go
@@ -22,7 +22,7 @@ func listMinedWorkByAccount(db *bolt.DB, accountID string) ([]*AcceptedWork, err
 	minedWork := make([]*AcceptedWork, 0)
 
 	err := db.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchWorkBucket(tx)
+		bkt, err := fetchBucket(tx, workBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/account.go
+++ b/pool/account.go
@@ -38,30 +38,12 @@ func NewAccount(address string) *Account {
 	}
 }
 
-// fetchAccountBucket is a helper function for getting the account bucket.
-func fetchAccountBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
-	const funcName = "fetchAccountBucket"
-	pbkt := tx.Bucket(poolBkt)
-	if pbkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(poolBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	bkt := pbkt.Bucket(accountBkt)
-	if bkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(accountBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	return bkt, nil
-}
-
 // FetchAccount fetches the account referenced by the provided id.
 func FetchAccount(db *bolt.DB, id []byte) (*Account, error) {
 	const funcName = "FetchAccount"
 	var account Account
 	err := db.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchAccountBucket(tx)
+		bkt, err := fetchBucket(tx, accountBkt)
 		if err != nil {
 			return err
 		}
@@ -90,7 +72,7 @@ func FetchAccount(db *bolt.DB, id []byte) (*Account, error) {
 func (acc *Account) Persist(db *bolt.DB) error {
 	const funcName = "Account.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchAccountBucket(tx)
+		bkt, err := fetchBucket(tx, accountBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -108,7 +108,7 @@ func (cs *ChainState) fetchCurrentWork() string {
 func (cs *ChainState) pruneAcceptedWork(ctx context.Context, height uint32) error {
 	toDelete := make([]*AcceptedWork, 0)
 	err := cs.cfg.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchWorkBucket(tx)
+		bkt, err := fetchBucket(tx, workBkt)
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func (cs *ChainState) pruneAcceptedWork(ctx context.Context, height uint32) erro
 func (cs *ChainState) prunePayments(ctx context.Context, height uint32) error {
 	toDelete := make([]*Payment, 0)
 	err := cs.cfg.DB.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchPaymentBucket(tx)
+		bkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ func (cs *ChainState) prunePayments(ctx context.Context, height uint32) error {
 // pruneJobs removes all jobs with heights less than the provided height.
 func (cs *ChainState) pruneJobs(height uint32) error {
 	err := cs.cfg.DB.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchJobBucket(tx)
+		bkt, err := fetchBucket(tx, jobBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/db.go
+++ b/pool/db.go
@@ -300,3 +300,21 @@ func emptyBucket(db *bolt.DB, bucket []byte) error {
 		return nil
 	})
 }
+
+// fetchBucket is a helper function for getting the requested bucket.
+func fetchBucket(tx *bolt.Tx, bucketID []byte) (*bolt.Bucket, error) {
+	const funcName = "fetchBucket"
+	pbkt := tx.Bucket(poolBkt)
+	if pbkt == nil {
+		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
+			string(poolBkt))
+		return nil, dbError(ErrBucketNotFound, desc)
+	}
+	bkt := pbkt.Bucket(bucketID)
+	if bkt == nil {
+		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
+			string(bucketID))
+		return nil, dbError(ErrBucketNotFound, desc)
+	}
+	return bkt, nil
+}

--- a/pool/db_test.go
+++ b/pool/db_test.go
@@ -74,41 +74,14 @@ func testFetchBucketHelpers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Ensure fetch bucket helpers return an error when the
+	// Ensure fetch bucket helper returns an error when the
 	// pool bucket cannot be found.
 	err = db.View(func(tx *bolt.Tx) error {
-		_, err := fetchWorkBucket(tx)
-		if err == nil {
-			return expectedNotFoundErr
-		}
-		_, err = fetchAccountBucket(tx)
-		if err == nil {
-			return expectedNotFoundErr
-		}
-		_, err = fetchWorkBucket(tx)
-		if err == nil {
-			return expectedNotFoundErr
-		}
-		_, err = fetchJobBucket(tx)
-		if err == nil {
-			return expectedNotFoundErr
-		}
-		_, err = fetchPaymentBucket(tx)
-		if err == nil {
-			return expectedNotFoundErr
-		}
-		_, err = fetchPaymentArchiveBucket(tx)
-		if err == nil {
-			return expectedNotFoundErr
-		}
-		_, err = fetchShareBucket(tx)
-		if err == nil {
-			return expectedNotFoundErr
-		}
-		return nil
+		_, err := fetchBucket(tx, workBkt)
+		return err
 	})
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, ErrBucketNotFound) {
+		t.Fatalf("expected bucket not found error, got %v", err)
 	}
 
 	err = deleteEntry(db, paymentBkt, []byte("k"))
@@ -150,44 +123,14 @@ func testFetchBucketHelpers(t *testing.T) {
 		t.Fatalf("db update error: %v", err)
 	}
 
-	expectedNestedNotFoundErr := fmt.Errorf("expected nested bucket not found error")
-
-	// Ensure fetch bucket helpers return an error if the
+	// Ensure fetch bucket helper returns an error if the
 	// required nested bucket cannot be found.
 	err = db.View(func(tx *bolt.Tx) error {
-		_, err := fetchWorkBucket(tx)
-		if err == nil {
-			return expectedNestedNotFoundErr
-		}
-		_, err = fetchAccountBucket(tx)
-		if err == nil {
-			return expectedNestedNotFoundErr
-		}
-		_, err = fetchWorkBucket(tx)
-		if err == nil {
-			return expectedNestedNotFoundErr
-		}
-		_, err = fetchJobBucket(tx)
-		if err == nil {
-			return expectedNestedNotFoundErr
-		}
-		_, err = fetchPaymentBucket(tx)
-		if err == nil {
-			return expectedNestedNotFoundErr
-		}
-		_, err = fetchPaymentArchiveBucket(tx)
-		if err == nil {
-			return expectedNestedNotFoundErr
-		}
-		_, err = fetchShareBucket(tx)
-		if err == nil {
-			return expectedNestedNotFoundErr
-		}
-
-		return nil
+		_, err := fetchBucket(tx, workBkt)
+		return err
 	})
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, ErrBucketNotFound) {
+		t.Fatalf("expected bucket not found error, got %v", err)
 	}
 
 }

--- a/pool/job.go
+++ b/pool/job.go
@@ -47,30 +47,12 @@ func NewJob(header string, height uint32) *Job {
 	}
 }
 
-// fetchJobBucket is a helper function for getting the job bucket.
-func fetchJobBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
-	const funcName = "fetchJobBucket"
-	pbkt := tx.Bucket(poolBkt)
-	if pbkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(poolBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	bkt := pbkt.Bucket(jobBkt)
-	if bkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(jobBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	return bkt, nil
-}
-
 // FetchJob fetches the job referenced by the provided id.
 func FetchJob(db *bolt.DB, id []byte) (*Job, error) {
 	const funcName = "FetchJob"
 	var job Job
 	err := db.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchJobBucket(tx)
+		bkt, err := fetchBucket(tx, jobBkt)
 		if err != nil {
 			return err
 		}
@@ -99,7 +81,7 @@ func FetchJob(db *bolt.DB, id []byte) (*Job, error) {
 func (job *Job) Persist(db *bolt.DB) error {
 	const funcName = "Job.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchJobBucket(tx)
+		bkt, err := fetchBucket(tx, jobBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/payment.go
+++ b/pool/payment.go
@@ -58,49 +58,12 @@ func paymentID(height uint32, createdOnNano int64, account string) []byte {
 	return buf.Bytes()
 }
 
-// fetchPaymentBucket is a helper function for getting the payment bucket.
-func fetchPaymentBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
-	const funcName = "fetchPaymentBucket"
-	pbkt := tx.Bucket(poolBkt)
-	if pbkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(poolBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	bkt := pbkt.Bucket(paymentBkt)
-	if bkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(paymentBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	return bkt, nil
-}
-
-// fetchPaymentArchiveBucket is a helper function for getting the
-// payment archive bucket.
-func fetchPaymentArchiveBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
-	const funcName = "fetchPaymentArchiveBucket"
-	pbkt := tx.Bucket(poolBkt)
-	if pbkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(poolBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	bkt := pbkt.Bucket(paymentArchiveBkt)
-	if bkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(paymentArchiveBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	return bkt, nil
-}
-
 // FetchPayment fetches the payment referenced by the provided id.
 func FetchPayment(db *bolt.DB, id []byte) (*Payment, error) {
 	const funcName = "FetchPayment"
 	var payment Payment
 	err := db.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchPaymentBucket(tx)
+		bkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}
@@ -128,7 +91,7 @@ func FetchPayment(db *bolt.DB, id []byte) (*Payment, error) {
 func (pmt *Payment) Persist(db *bolt.DB) error {
 	const funcName = "Payment.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchPaymentBucket(tx)
+		bkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}
@@ -165,11 +128,11 @@ func (pmt *Payment) Delete(db *bolt.DB) error {
 func (pmt *Payment) Archive(db *bolt.DB) error {
 	const funcName = "Payment.Archive"
 	return db.Update(func(tx *bolt.Tx) error {
-		pbkt, err := fetchPaymentBucket(tx)
+		pbkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}
-		abkt, err := fetchPaymentArchiveBucket(tx)
+		abkt, err := fetchBucket(tx, paymentArchiveBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -273,7 +273,7 @@ func (pm *PaymentMgr) persistLastPaymentPaidOn(tx *bolt.Tx) error {
 func (pm *PaymentMgr) pruneShares(tx *bolt.Tx, minNano int64) error {
 	funcName := "pruneShares"
 	minB := nanoToBigEndianBytes(minNano)
-	bkt, err := fetchShareBucket(tx)
+	bkt, err := fetchBucket(tx, shareBkt)
 	if err != nil {
 		return err
 	}
@@ -401,7 +401,7 @@ func (pm *PaymentMgr) PPSEligibleShares(max []byte) ([]*Share, error) {
 	funcName := "PPSEligibleShares"
 	eligibleShares := make([]*Share, 0)
 	err := pm.cfg.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchShareBucket(tx)
+		bkt, err := fetchBucket(tx, shareBkt)
 		if err != nil {
 			return err
 		}
@@ -459,7 +459,7 @@ func (pm *PaymentMgr) PPLNSEligibleShares(min []byte) ([]*Share, error) {
 	funcName := "PPLNSEligibleShares"
 	eligibleShares := make([]*Share, 0)
 	err := pm.cfg.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchShareBucket(tx)
+		bkt, err := fetchBucket(tx, shareBkt)
 		if err != nil {
 			return err
 		}
@@ -651,7 +651,7 @@ func (pm *PaymentMgr) pendingPayments() ([]*Payment, error) {
 	funcName := "pendingPayments"
 	payments := make([]*Payment, 0)
 	err := pm.cfg.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchPaymentBucket(tx)
+		bkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}
@@ -681,7 +681,7 @@ func (pm *PaymentMgr) pendingPaymentsAtHeight(height uint32) ([]*Payment, error)
 	funcName := "pendingPaymentsAtHeight"
 	payments := make([]*Payment, 0)
 	err := pm.cfg.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchPaymentBucket(tx)
+		bkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}
@@ -724,7 +724,7 @@ func (pm *PaymentMgr) pendingPaymentsForBlockHash(blockHash string) (uint32, err
 	funcName := "pendingPaymentsForBlockHash"
 	var count uint32
 	err := pm.cfg.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchPaymentBucket(tx)
+		bkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}
@@ -758,7 +758,7 @@ func (pm *PaymentMgr) archivedPayments() ([]*Payment, error) {
 	funcName := "archivedPayments"
 	pmts := make([]*Payment, 0)
 	err := pm.cfg.DB.View(func(tx *bolt.Tx) error {
-		abkt, err := fetchPaymentArchiveBucket(tx)
+		abkt, err := fetchBucket(tx, paymentArchiveBkt)
 		if err != nil {
 			return err
 		}
@@ -788,7 +788,7 @@ func (pm *PaymentMgr) maturePendingPayments(height uint32) (map[string][]*Paymen
 	funcName := "maturePendingPayments"
 	payments := make([]*Payment, 0)
 	err := pm.cfg.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchPaymentBucket(tx)
+		bkt, err := fetchBucket(tx, paymentBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -62,7 +62,7 @@ func (txB *txBroadcasterImpl) PublishTransaction(ctx context.Context, req *walle
 func fetchShare(db *bolt.DB, id []byte) (*Share, error) {
 	var share Share
 	err := db.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchShareBucket(tx)
+		bkt, err := fetchBucket(tx, shareBkt)
 		if err != nil {
 			return err
 		}

--- a/pool/share.go
+++ b/pool/share.go
@@ -53,29 +53,11 @@ func NewShare(account string, weight *big.Rat) *Share {
 	}
 }
 
-// fetchShareBucket is a helper function for getting the share bucket.
-func fetchShareBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
-	const funcName = "fetchShareBucket"
-	pbkt := tx.Bucket(poolBkt)
-	if pbkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(poolBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	bkt := pbkt.Bucket(shareBkt)
-	if bkt == nil {
-		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
-			string(shareBkt))
-		return nil, dbError(ErrBucketNotFound, desc)
-	}
-	return bkt, nil
-}
-
 // Persist saves a share to the database.
 func (s *Share) Persist(db *bolt.DB) error {
 	const funcName = "Share.Persist"
 	return db.Update(func(tx *bolt.Tx) error {
-		bkt, err := fetchShareBucket(tx)
+		bkt, err := fetchBucket(tx, shareBkt)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Replace multiple duplicated funcs with a single generic func which takes bucket ID as an arg.
- Update tests to check for correct error type.

Part of #257