### PR TITLE
Handle database IDs as strings where possible.

### DIFF
--- a/pool/account.go
+++ b/pool/account.go
@@ -57,7 +57,7 @@ func fetchAccountBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 }
 
 // FetchAccount fetches the account referenced by the provided id.
-func FetchAccount(db *bolt.DB, id []byte) (*Account, error) {
+func FetchAccount(db *bolt.DB, id string) (*Account, error) {
 	const funcName = "FetchAccount"
 	var account Account
 	err := db.View(func(tx *bolt.Tx) error {
@@ -66,10 +66,9 @@ func FetchAccount(db *bolt.DB, id []byte) (*Account, error) {
 			return err
 		}
 
-		v := bkt.Get(id)
+		v := bkt.Get([]byte(id))
 		if v == nil {
-			desc := fmt.Sprintf("%s: no account found for id %s", funcName,
-				string(id))
+			desc := fmt.Sprintf("%s: no account found for id %s", funcName, id)
 			return dbError(ErrValueNotFound, desc)
 		}
 		err = json.Unmarshal(v, &account)
@@ -124,5 +123,5 @@ func (acc *Account) Persist(db *bolt.DB) error {
 
 // Delete purges the referenced account from the database.
 func (acc *Account) Delete(db *bolt.DB) error {
-	return deleteEntry(db, accountBkt, []byte(acc.UUID))
+	return deleteEntry(db, accountBkt, acc.UUID)
 }

--- a/pool/account_test.go
+++ b/pool/account_test.go
@@ -37,7 +37,7 @@ func testAccount(t *testing.T, db *bolt.DB) {
 	}
 
 	// Fetch an account with its id.
-	fetchedAccount, err := FetchAccount(db, []byte(accountA.UUID))
+	fetchedAccount, err := FetchAccount(db, accountA.UUID)
 	if err != nil {
 		t.Fatalf("FetchAccount error: %v", err)
 	}
@@ -64,12 +64,12 @@ func testAccount(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure the accounts have both been deleted.
-	_, err = FetchAccount(db, []byte(accountA.UUID))
+	_, err = FetchAccount(db, accountA.UUID)
 	if !errors.Is(err, ErrValueNotFound) {
 		t.Fatal("expected value not found error")
 	}
 
-	_, err = FetchAccount(db, []byte(accountB.UUID))
+	_, err = FetchAccount(db, accountB.UUID)
 	if !errors.Is(err, ErrValueNotFound) {
 		t.Fatal("expected value not found error")
 	}

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -123,11 +123,11 @@ func testChainState(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure job A has been pruned with job B remaining.
-	_, err = FetchJob(db, []byte(jobA.UUID))
+	_, err = FetchJob(db, jobA.UUID)
 	if err == nil {
 		t.Fatal("expected a value not found error")
 	}
-	_, err = FetchJob(db, []byte(jobB.UUID))
+	_, err = FetchJob(db, jobB.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error fetching job B: %v", err)
 	}
@@ -168,11 +168,11 @@ func testChainState(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure work A did not get pruned but work B did.
-	_, err = FetchAcceptedWork(db, []byte(workA.UUID))
+	_, err = FetchAcceptedWork(db, workA.UUID)
 	if err != nil {
 		t.Fatalf("expected a valid accepted work, got: %v", err)
 	}
-	_, err = FetchAcceptedWork(db, []byte(workB.UUID))
+	_, err = FetchAcceptedWork(db, workB.UUID)
 	if err == nil {
 		t.Fatal("expected a no value found error")
 	}
@@ -338,7 +338,7 @@ func testChainState(t *testing.T, db *bolt.DB) {
 	<-confMsg.Done
 
 	// Ensure the accepted work is now confirmed mined.
-	confirmedWork, err := FetchAcceptedWork(cs.cfg.DB, []byte(work.UUID))
+	confirmedWork, err := FetchAcceptedWork(cs.cfg.DB, work.UUID)
 	if err != nil {
 		t.Fatalf("unable to confirm accepted work: %v", err)
 	}
@@ -361,7 +361,7 @@ func testChainState(t *testing.T, db *bolt.DB) {
 	<-discMinedMsg.Done
 
 	// Ensure the mined work is no longer confirmed mined.
-	discMinedWork, err := FetchAcceptedWork(cs.cfg.DB, []byte(work.UUID))
+	discMinedWork, err := FetchAcceptedWork(cs.cfg.DB, work.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/pool/client.go
+++ b/pool/client.go
@@ -356,7 +356,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 		c.ch <- resp
 		return err
 	}
-	job, err := FetchJob(c.cfg.DB, []byte(jobID))
+	job, err := FetchJob(c.cfg.DB, jobID)
 	if err != nil {
 		sErr := NewStratumError(Unknown, err)
 		resp := SubmitWorkResponse(*req.ID, false, sErr)

--- a/pool/db.go
+++ b/pool/db.go
@@ -6,7 +6,6 @@ package pool
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -253,7 +252,7 @@ func InitDB(dbFile string, isSoloPool bool) (*bolt.DB, error) {
 
 // deleteEntry removes the specified key and its associated value from
 // the provided bucket.
-func deleteEntry(db *bolt.DB, bucket, key []byte) error {
+func deleteEntry(db *bolt.DB, bucket []byte, key string) error {
 	const funcName = "deleteEntry"
 	return db.Update(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(poolBkt)
@@ -264,11 +263,10 @@ func deleteEntry(db *bolt.DB, bucket, key []byte) error {
 		}
 		b := pbkt.Bucket(bucket)
 
-		err := b.Delete(key)
+		err := b.Delete([]byte(key))
 		if err != nil {
 			desc := fmt.Sprintf("%s: unable to delete entry with "+
-				"key %s from bucket %s", funcName, hex.EncodeToString(key),
-				string(poolBkt))
+				"key %s from bucket %s", funcName, key, string(poolBkt))
 			return dbError(ErrDeleteEntry, desc)
 		}
 		return nil

--- a/pool/db_test.go
+++ b/pool/db_test.go
@@ -111,7 +111,7 @@ func testFetchBucketHelpers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = deleteEntry(db, paymentBkt, []byte("k"))
+	err = deleteEntry(db, paymentBkt, "k")
 	if err == nil {
 		t.Fatal(expectedNotFoundErr)
 	}
@@ -294,13 +294,13 @@ func testDatabase(t *testing.T, db *bolt.DB) {
 	}
 
 	// delete the created account.
-	err = deleteEntry(db, accountBkt, []byte(accountA.UUID))
+	err = deleteEntry(db, accountBkt, accountA.UUID)
 	if err != nil {
 		t.Fatalf("emptyBucket error: %v", err)
 	}
 
 	// Ensure the accountA has been removed.
-	_, err = FetchAccount(db, []byte(accountA.UUID))
+	_, err = FetchAccount(db, accountA.UUID)
 	if !errors.Is(err, ErrValueNotFound) {
 		t.Fatalf("expected no value found error: %v", err)
 	}
@@ -312,11 +312,11 @@ func testDatabase(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure the account X and Y have been removed.
-	_, err = FetchAccount(db, []byte(xID))
+	_, err = FetchAccount(db, xID)
 	if err == nil {
 		t.Fatalf("expected no value found error for %s", xID)
 	}
-	_, err = FetchAccount(db, []byte(yID))
+	_, err = FetchAccount(db, yID)
 	if err == nil {
 		t.Fatalf("expected no value found error for %s", yID)
 	}

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -642,7 +642,7 @@ func (h *Hub) FetchWorkQuotas() ([]*Quota, error) {
 
 // AccountExists checks if the provided account id references a pool account.
 func (h *Hub) AccountExists(accountID string) bool {
-	_, err := FetchAccount(h.db, []byte(accountID))
+	_, err := FetchAccount(h.db, accountID)
 	if err != nil {
 		log.Tracef("Unable to fetch account for id: %s", accountID)
 		return false

--- a/pool/job.go
+++ b/pool/job.go
@@ -66,7 +66,7 @@ func fetchJobBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 }
 
 // FetchJob fetches the job referenced by the provided id.
-func FetchJob(db *bolt.DB, id []byte) (*Job, error) {
+func FetchJob(db *bolt.DB, id string) (*Job, error) {
 	const funcName = "FetchJob"
 	var job Job
 	err := db.View(func(tx *bolt.Tx) error {
@@ -75,10 +75,9 @@ func FetchJob(db *bolt.DB, id []byte) (*Job, error) {
 			return err
 		}
 
-		v := bkt.Get(id)
+		v := bkt.Get([]byte(id))
 		if v == nil {
-			desc := fmt.Sprintf("%s: no job found for id %s", funcName,
-				string(id))
+			desc := fmt.Sprintf("%s: no job found for id %s", funcName, id)
 			return dbError(ErrValueNotFound, desc)
 		}
 		err = json.Unmarshal(v, &job)
@@ -122,5 +121,5 @@ func (job *Job) Persist(db *bolt.DB) error {
 
 // Delete removes the associated job from the database.
 func (job *Job) Delete(db *bolt.DB) error {
-	return deleteEntry(db, jobBkt, []byte(job.UUID))
+	return deleteEntry(db, jobBkt, job.UUID)
 }

--- a/pool/job_test.go
+++ b/pool/job_test.go
@@ -48,7 +48,7 @@ func testJob(t *testing.T, db *bolt.DB) {
 	}
 
 	// Fetch a job using its id.
-	fetchedJob, err := FetchJob(db, []byte(jobA.UUID))
+	fetchedJob, err := FetchJob(db, jobA.UUID)
 	if err != nil {
 		t.Fatalf("FetchJob err: %v", err)
 	}
@@ -69,11 +69,11 @@ func testJob(t *testing.T, db *bolt.DB) {
 	}
 
 	// Ensure the jobs were deleted.
-	_, err = FetchJob(db, []byte(jobB.UUID))
+	_, err = FetchJob(db, jobB.UUID)
 	if err == nil {
 		t.Fatalf("expected a value not found error: %v", err)
 	}
-	_, err = FetchJob(db, []byte(jobC.UUID))
+	_, err = FetchJob(db, jobC.UUID)
 	if err == nil {
 		t.Fatalf("expected a value not found error: %v", err)
 	}

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -1062,7 +1062,7 @@ func (pm *PaymentMgr) generatePayoutTxDetails(ctx context.Context, txC TxCreator
 				continue
 			}
 
-			acc, err := FetchAccount(pm.cfg.DB, []byte(pmt.Account))
+			acc, err := FetchAccount(pm.cfg.DB, pmt.Account)
 			if err != nil {
 				return nil, nil, nil, 0, err
 			}

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -59,16 +59,16 @@ func (txB *txBroadcasterImpl) PublishTransaction(ctx context.Context, req *walle
 }
 
 // fetchShare fetches the share referenced by the provided id.
-func fetchShare(db *bolt.DB, id []byte) (*Share, error) {
+func fetchShare(db *bolt.DB, id string) (*Share, error) {
 	var share Share
 	err := db.View(func(tx *bolt.Tx) error {
 		bkt, err := fetchShareBucket(tx)
 		if err != nil {
 			return err
 		}
-		v := bkt.Get(id)
+		v := bkt.Get([]byte(id))
 		if v == nil {
-			return fmt.Errorf("no share found for id %s", string(id))
+			return fmt.Errorf("no share found for id %s", id)
 		}
 		err = json.Unmarshal(v, &share)
 		return err

--- a/pool/share.go
+++ b/pool/share.go
@@ -30,11 +30,11 @@ var ShareWeights = map[string]*big.Rat{
 
 // shareID generates a unique share id using the provided account and time
 // created.
-func shareID(account string, createdOn int64) []byte {
+func shareID(account string, createdOn int64) string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString(hex.EncodeToString(nanoToBigEndianBytes(createdOn)))
 	_, _ = buf.WriteString(account)
-	return buf.Bytes()
+	return buf.String()
 }
 
 // Share represents verifiable work performed by a pool client.
@@ -47,7 +47,7 @@ type Share struct {
 // NewShare creates a share with the provided account and weight.
 func NewShare(account string, weight *big.Rat) *Share {
 	return &Share{
-		UUID:    string(shareID(account, time.Now().UnixNano())),
+		UUID:    shareID(account, time.Now().UnixNano()),
 		Account: account,
 		Weight:  weight,
 	}

--- a/pool/share_test.go
+++ b/pool/share_test.go
@@ -17,7 +17,7 @@ import (
 func persistShare(db *bolt.DB, account string, weight *big.Rat, createdOnNano int64) error {
 	id := shareID(account, createdOnNano)
 	share := &Share{
-		UUID:    string(id),
+		UUID:    id,
 		Account: account,
 		Weight:  weight,
 	}

--- a/pool/upgrades.go
+++ b/pool/upgrades.go
@@ -216,8 +216,7 @@ func shareIDUpgrade(tx *bolt.Tx) error {
 		}
 
 		createdOn := bigEndianBytesToNano(k)
-		id := shareID(share.Account, int64(createdOn))
-		share.UUID = string(id)
+		share.UUID = shareID(share.Account, int64(createdOn))
 
 		sBytes, err := json.Marshal(share)
 		if err != nil {
@@ -306,7 +305,7 @@ func paymentSourceUpgrade(tx *bolt.Tx) error {
 		}
 
 		key := paymentID(payment.Height, payment.CreatedOn, payment.Account)
-		err = pmtbkt.Put(key, pBytes)
+		err = pmtbkt.Put([]byte(key), pBytes)
 		if err != nil {
 			desc := fmt.Sprintf("%s: unable to persist payment: %v",
 				funcName, err)
@@ -352,7 +351,7 @@ func paymentSourceUpgrade(tx *bolt.Tx) error {
 		}
 
 		key := paymentID(payment.Height, payment.CreatedOn, payment.Account)
-		err = abkt.Put(key, pBytes)
+		err = abkt.Put([]byte(key), pBytes)
 		if err != nil {
 			desc := fmt.Sprintf("%s: unable to persist payment: %v",
 				funcName, err)

--- a/pool/upgrades_test.go
+++ b/pool/upgrades_test.go
@@ -135,8 +135,8 @@ func verifyV3Upgrade(t *testing.T, db *bolt.DB) {
 			}
 
 			id := paymentID(payment.Height, payment.CreatedOn, payment.Account)
-			if !bytes.Equal(k, id) {
-				return fmt.Errorf("%s: expected payment id (%x) to be "+
+			if !bytes.Equal(k, []byte(id)) {
+				return fmt.Errorf("%s: expected payment id (%s) to be "+
 					"the same as its key (%x)", funcName, id, k)
 
 			}
@@ -163,9 +163,9 @@ func verifyV3Upgrade(t *testing.T, db *bolt.DB) {
 			}
 
 			id := paymentID(payment.Height, payment.CreatedOn, payment.Account)
-			if !bytes.Equal(k, id) {
+			if !bytes.Equal(k, []byte(id)) {
 				return fmt.Errorf("%s: expected archived payment id "+
-					"(%x) to be the same as its key (%x)", funcName, id, k)
+					"(%s) to be the same as its key (%x)", funcName, id, k)
 			}
 
 			if payment.Source == nil {


### PR DESCRIPTION
Regular conversion of database IDs between `string` and `[]byte` is necessary because bbolt expects all keys and values to be byte arrays. Because this is specific to bbolt and we want to generalise the code to work with other database implementations, the majority of our code should handle IDs as `string` and only convert to `[]byte` as close to the bbolt code as possible.

This has a nice side-effect of removing a large amount of inline type conversion.

Part of #257