### PR TITLE
Remove mode switching behaviour.

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -91,7 +91,7 @@ func newPool(cfg *config) (*miningPool, error) {
 		return nil, err
 	}
 
-	db, err := pool.InitBoltDB(cfg.DBFile, cfg.SoloPool)
+	db, err := pool.InitBoltDB(cfg.DBFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pool/database.go
+++ b/pool/database.go
@@ -15,6 +15,7 @@ type Database interface {
 	close() error
 
 	// Pool metadata
+	fetchPoolMode() (uint32, error)
 	persistPoolMode(mode uint32) error
 	fetchCSRFSecret() ([]byte, error)
 	persistCSRFSecret(secret []byte) error

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -107,9 +107,9 @@ func TestPool(t *testing.T) {
 
 	// All sub-tests to run.
 	tests := map[string]func(*testing.T){
-		"testDatabase":               testDatabase,
 		"testLastPaymentInfo":        testLastPaymentInfo,
 		"testLastPaymentCreatedOn":   testLastPaymentCreatedOn,
+		"testPoolMode":               testPoolMode,
 		"testAcceptedWork":           testAcceptedWork,
 		"testAccount":                testAccount,
 		"testJob":                    testJob,


### PR DESCRIPTION
This remove the behaviour which would automatically empty the database and create a new one when the pool mode was changed in config. The new behaviour is to log an error and prevent the pool from starting up.

The reason for this is the empty/backup behaviour does not map well onto other database implementations such as postgres, and after discussing with dnldd we agreed that its better for an admin to explicitly make the decision to backup and create a new DB, rather than the code doing it.

#257 