### PR TITLE
Improve test coverage for DB accessors

### DIFF
--- a/pool/account.go
+++ b/pool/account.go
@@ -38,7 +38,8 @@ func NewAccount(address string) *Account {
 	}
 }
 
-// fetchAccount fetches the account referenced by the provided id.
+// fetchAccount fetches the account referenced by the provided id. Returns
+// an error if the account is not found.
 func (db *BoltDB) fetchAccount(id string) (*Account, error) {
 	const funcName = "fetchAccount"
 	var account Account
@@ -67,7 +68,9 @@ func (db *BoltDB) fetchAccount(id string) (*Account, error) {
 	return &account, err
 }
 
-// persistAccount saves the account to the database.
+// persistAccount saves the account to the database. Before persisting the
+// account, it sets the createdOn timestamp. Returns an error if an account
+// already exists with the same ID.
 func (db *BoltDB) persistAccount(acc *Account) error {
 	const funcName = "persistAccount"
 	return db.DB.Update(func(tx *bolt.Tx) error {
@@ -77,9 +80,7 @@ func (db *BoltDB) persistAccount(acc *Account) error {
 		}
 
 		// Do not persist already existing account.
-		id := []byte(acc.UUID)
-		v := bkt.Get(id)
-		if v != nil {
+		if bkt.Get([]byte(acc.UUID)) != nil {
 			desc := fmt.Sprintf("%s: account %s already exists", funcName,
 				acc.UUID)
 			return dbError(ErrValueFound, desc)

--- a/pool/account_test.go
+++ b/pool/account_test.go
@@ -25,7 +25,7 @@ func testAccount(t *testing.T) {
 	// Creating the same account twice should fail.
 	err = db.persistAccount(accountA)
 	if !errors.Is(err, ErrValueFound) {
-		t.Fatal("expected value found error")
+		t.Fatalf("expected value found error, got %v", err)
 	}
 
 	// Fetch an account with its id.
@@ -34,6 +34,7 @@ func testAccount(t *testing.T) {
 		t.Fatalf("fetchAccount error: %v", err)
 	}
 
+	// Ensure fetched values match persisted values.
 	if fetchedAccount.Address != accountA.Address {
 		t.Fatalf("expected %v as fetched account address, got %v",
 			accountA.Address, fetchedAccount.Address)
@@ -42,6 +43,11 @@ func testAccount(t *testing.T) {
 	if fetchedAccount.UUID != accountA.UUID {
 		t.Fatalf("expected %v as fetched account id, got %v",
 			accountA.UUID, fetchedAccount.UUID)
+	}
+
+	// Ensure CreatedOn has been given a value.
+	if fetchedAccount.CreatedOn == 0 {
+		t.Fatal("expected account createdon to have non-zero value")
 	}
 
 	// Delete all accounts.
@@ -58,11 +64,17 @@ func testAccount(t *testing.T) {
 	// Ensure the accounts have both been deleted.
 	_, err = db.fetchAccount(accountA.UUID)
 	if !errors.Is(err, ErrValueNotFound) {
-		t.Fatal("expected value not found error")
+		t.Fatalf("expected value not found error, got %v", err)
 	}
 
 	_, err = db.fetchAccount(accountB.UUID)
 	if !errors.Is(err, ErrValueNotFound) {
-		t.Fatal("expected value not found error")
+		t.Fatalf("expected value not found error, got %v", err)
+	}
+
+	// Deleting an account which does not exist should not return an error.
+	err = db.deleteAccount(accountA.UUID)
+	if err != nil {
+		t.Fatalf("delete accountA error: %v ", err)
 	}
 }

--- a/pool/boltdb.go
+++ b/pool/boltdb.go
@@ -305,6 +305,20 @@ func fetchPoolBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	return pbkt, nil
 }
 
+// bigEndianBytesToNano returns nanosecond time from the provided
+// big endian bytes.
+func bigEndianBytesToNano(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}
+
+// nanoToBigEndianBytes returns an 8-byte big endian representation of
+// the provided nanosecond time.
+func nanoToBigEndianBytes(nano int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(nano))
+	return b
+}
+
 func (db *BoltDB) persistPoolMode(mode uint32) error {
 	return db.DB.Update(func(tx *bolt.Tx) error {
 		pbkt := tx.Bucket(poolBkt)

--- a/pool/database.go
+++ b/pool/database.go
@@ -42,6 +42,7 @@ type Database interface {
 
 	// Share
 	PersistShare(share *Share) error
+	fetchShare(id string) (*Share, error)
 	ppsEligibleShares(max int64) ([]*Share, error)
 	pplnsEligibleShares(min int64) ([]*Share, error)
 	pruneShares(minNano int64) error
@@ -57,7 +58,7 @@ type Database interface {
 	// Job
 	fetchJob(id string) (*Job, error)
 	persistJob(job *Job) error
-	deleteJob(job *Job) error
+	deleteJob(id string) error
 	deleteJobsBeforeHeight(height uint32) error
 }
 

--- a/pool/job.go
+++ b/pool/job.go
@@ -6,7 +6,6 @@ package pool
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -20,14 +19,6 @@ type Job struct {
 	UUID   string `json:"uuid"`
 	Height uint32 `json:"height"`
 	Header string `json:"header"`
-}
-
-// nanoToBigEndianBytes returns an 8-byte big endian representation of
-// the provided nanosecond time.
-func nanoToBigEndianBytes(nano int64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, uint64(nano))
-	return b
 }
 
 // jobID generates a unique job id of the provided block height.

--- a/pool/job_test.go
+++ b/pool/job_test.go
@@ -1,48 +1,49 @@
 package pool
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
-func persistJob(bdb Database, header string, height uint32) (*Job, error) {
-	job := NewJob(header, height)
-	err := bdb.persistJob(job)
-	if err != nil {
-		return nil, fmt.Errorf("unable to persist job: %v", err)
-	}
-	return job, nil
-}
-
 func testJob(t *testing.T) {
-	jobA, err := persistJob(db, "0700000093bdee7083c6e02147cf76724a685f0148636"+
+	// Create some valid jobs.
+	jobA := NewJob("0700000093bdee7083c6e02147cf76724a685f0148636"+
 		"b2faf96353d1cbf5c0a954100007991153ad03eb0e31ead44b75ebc9f760870098431d4e6"+
 		"aa85e742cbad517ebd853b9bf059e8eeb91591e4a7d4005acc62e92bfd27b17309a5a41dd"+
 		"24016428f0100000000000000000000003c000000dd742920204e00000000000038000000"+
 		"66010000f171cc5d000000000000000000000000000000000000000000000000000000000"+
 		"000000000000000000000008000000100000000000005a0", 56)
+	err := db.persistJob(jobA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	jobB, err := persistJob(db, "0700000047e9425eabcf920eecf0c00c7bc46c6062049"+
+	jobB := NewJob("0700000047e9425eabcf920eecf0c00c7bc46c6062049"+
 		"071c59edcb0e55c0226690800005695619a600321a8389d1bee5b3a207efc81e05c111d38"+
 		"1e960c8bf05ca336b55b528e9d5044c52aa0c713ae152f3fdb592f6ee82fa1776440ca72a"+
 		"2fc9f77760100000000000000000000003c000000dd742920204e00000000000039000000"+
 		"a6030000f171cc5d000000000000000000000000000000000000000000000000000000000"+
 		"000000000000000000000008000000100000000000005a0", 57)
+	err = db.persistJob(jobB)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	jobC, err := persistJob(db, "070000005c05ebb5be0fa2b5785ab3ca72294e6e1865"+
+	jobC := NewJob("070000005c05ebb5be0fa2b5785ab3ca72294e6e1865"+
 		"9df687f77605d31388a52875000003b7a9efb7222e37102c0de947df02107d455b9d76af"+
 		"76366d381a28f2dacdadabb7a2afa76f07917d676bd3033fc48f3ce77312729fa43d8a23"+
 		"d680effcc019010000000000000000000a003c000000dd742920204e0000000000003a00"+
 		"0000d9180000f371cc5d0000000000000000000000000000000000000000000000000000"+
 		"00000000000000000000000000008000000100000000000005a0", 58)
+	err = db.persistJob(jobC)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Creating the same job twice should fail.
+	err = db.persistJob(jobA)
+	if !errors.Is(err, ErrValueFound) {
+		t.Fatalf("expected value found error, got %v", err)
 	}
 
 	// Fetch a job using its id.
@@ -51,49 +52,70 @@ func testJob(t *testing.T) {
 		t.Fatalf("fetchJob err: %v", err)
 	}
 
-	if fetchedJob == nil {
-		t.Fatal("expected a non-nil job")
+	// Ensure fetched values match persisted values.
+	if fetchedJob.Header != jobA.Header {
+		t.Fatalf("expected %v as fetched job header, got %v",
+			jobA.Header, fetchedJob.Header)
+	}
+
+	if fetchedJob.UUID != jobA.UUID {
+		t.Fatalf("expected %v as fetched job id, got %v",
+			jobA.UUID, fetchedJob.UUID)
+	}
+
+	if fetchedJob.Height != jobA.Height {
+		t.Fatalf("expected %v as fetched job height, got %v",
+			jobA.Height, fetchedJob.Height)
 	}
 
 	// Delete jobs B and C.
-	err = db.deleteJob(jobB)
+	err = db.deleteJob(jobB.UUID)
 	if err != nil {
 		t.Fatalf("job delete error: %v", err)
 	}
 
-	err = db.deleteJob(jobC)
+	err = db.deleteJob(jobC.UUID)
 	if err != nil {
 		t.Fatalf("job delete error: %v", err)
 	}
 
 	// Ensure the jobs were deleted.
 	_, err = db.fetchJob(jobB.UUID)
-	if err == nil {
-		t.Fatalf("expected a value not found error: %v", err)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
 	}
 	_, err = db.fetchJob(jobC.UUID)
-	if err == nil {
-		t.Fatalf("expected a value not found error: %v", err)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
+	}
+
+	// Deleting an job which does not exist should not return an error.
+	err = db.deleteJob(jobA.UUID)
+	if err != nil {
+		t.Fatalf("delete jobA error: %v ", err)
 	}
 }
 
 func testDeleteJobsBeforeHeight(t *testing.T) {
-	jobA, err := persistJob(db, "0700000093bdee7083c6e02147cf76724a685f0148636"+
+	// Create some valid jobs.
+	jobA := NewJob("0700000093bdee7083c6e02147cf76724a685f0148636"+
 		"b2faf96353d1cbf5c0a954100007991153ad03eb0e31ead44b75ebc9f760870098431d4e6"+
 		"aa85e742cbad517ebd853b9bf059e8eeb91591e4a7d4005acc62e92bfd27b17309a5a41dd"+
 		"24016428f0100000000000000000000003c000000dd742920204e00000000000038000000"+
 		"66010000f171cc5d000000000000000000000000000000000000000000000000000000000"+
 		"000000000000000000000008000000100000000000005a0", 56)
+	err := db.persistJob(jobA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	jobB, err := persistJob(db, "0700000047e9425eabcf920eecf0c00c7bc46c6062049"+
+	jobB := NewJob("0700000047e9425eabcf920eecf0c00c7bc46c6062049"+
 		"071c59edcb0e55c0226690800005695619a600321a8389d1bee5b3a207efc81e05c111d38"+
 		"1e960c8bf05ca336b55b528e9d5044c52aa0c713ae152f3fdb592f6ee82fa1776440ca72a"+
 		"2fc9f77760100000000000000000000003c000000dd742920204e00000000000039000000"+
 		"a6030000f171cc5d000000000000000000000000000000000000000000000000000000000"+
 		"000000000000000000000008000000100000000000005a0", 57)
+	err = db.persistJob(jobB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,9 +128,10 @@ func testDeleteJobsBeforeHeight(t *testing.T) {
 
 	// Ensure job A has been pruned with job B remaining.
 	_, err = db.fetchJob(jobA.UUID)
-	if err == nil {
-		t.Fatal("expected a value not found error")
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
 	}
+
 	_, err = db.fetchJob(jobB.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error fetching job B: %v", err)

--- a/pool/payment_test.go
+++ b/pool/payment_test.go
@@ -5,6 +5,7 @@
 package pool
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -85,8 +86,8 @@ func testPayment(t *testing.T) {
 	// Ensure the payment B was archived.
 	id = paymentID(pmtB.Height, pmtB.CreatedOn, pmtB.Account)
 	_, err = db.fetchPayment(id)
-	if err == nil {
-		t.Fatalf("expected a value not found error: %v", err)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
 	}
 
 	// Delete payment C.
@@ -98,8 +99,8 @@ func testPayment(t *testing.T) {
 	// Ensure the payment C was deleted.
 	id = paymentID(pmtC.Height, pmtC.CreatedOn, pmtC.Account)
 	fetchedPayment, err = db.fetchPayment(id)
-	if err == nil {
-		t.Fatalf("expected a value not found error: %v", err)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
 	}
 
 	if fetchedPayment != nil {

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -2,7 +2,6 @@ package pool
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -141,12 +140,6 @@ func NewPaymentMgr(pCfg *PaymentMgrConfig) (*PaymentMgr, error) {
 	}
 
 	return pm, nil
-}
-
-// bigEndianBytesToNano returns nanosecond time from the provided
-// big endian bytes.
-func bigEndianBytesToNano(b []byte) uint64 {
-	return binary.BigEndian.Uint64(b)
 }
 
 // sharePercentages calculates the percentages due each participating account

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -397,7 +397,7 @@ func testPaymentMgr(t *testing.T) {
 	// Ensure payment maturity works as expected.
 	for i := 0; i < shareCount; i++ {
 		// Create readily available shares for account X.
-		err = persistShare(db, xID, weight, thirtyBefore)
+		err = persistShare(db, xID, weight, thirtyBefore+int64(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -405,7 +405,7 @@ func testPaymentMgr(t *testing.T) {
 	sixtyAfter := time.Now().Add((time.Second * 60)).UnixNano()
 	for i := 0; i < shareCount; i++ {
 		// Create future shares for account Y.
-		err = persistShare(db, yID, weight, sixtyAfter)
+		err = persistShare(db, yID, weight, sixtyAfter+int64(i))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -19,7 +18,6 @@ import (
 	"github.com/decred/dcrd/dcrutil/v3"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/wire"
-	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc"
 )
 
@@ -58,27 +56,6 @@ func (txB *txBroadcasterImpl) SignTransaction(ctx context.Context, req *walletrp
 // PublishTransaction broadcasts the transaction unto the network.
 func (txB *txBroadcasterImpl) PublishTransaction(ctx context.Context, req *walletrpc.PublishTransactionRequest, options ...grpc.CallOption) (*walletrpc.PublishTransactionResponse, error) {
 	return txB.publishTransaction(ctx, req, options...)
-}
-
-// fetchShare fetches the share referenced by the provided id.
-func fetchShare(db *BoltDB, id string) (*Share, error) {
-	var share Share
-	err := db.DB.View(func(tx *bolt.Tx) error {
-		bkt, err := fetchBucket(tx, shareBkt)
-		if err != nil {
-			return err
-		}
-		v := bkt.Get([]byte(id))
-		if v == nil {
-			return fmt.Errorf("no share found for id %s", id)
-		}
-		err = json.Unmarshal(v, &share)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &share, err
 }
 
 func TestSharePercentages(t *testing.T) {

--- a/pool/share_test.go
+++ b/pool/share_test.go
@@ -15,9 +15,10 @@ import (
 // weight.
 func persistShare(db Database, account string, weight *big.Rat, createdOnNano int64) error {
 	share := &Share{
-		UUID:    shareID(account, createdOnNano),
-		Account: account,
-		Weight:  weight,
+		UUID:      shareID(account, createdOnNano),
+		Account:   account,
+		Weight:    weight,
+		CreatedOn: createdOnNano,
 	}
 	err := db.PersistShare(share)
 	if err != nil {
@@ -32,13 +33,13 @@ func testShares(t *testing.T) {
 
 	// Create a valid share.
 	share := NewShare(account, weight)
-	err := db.persistShare(share)
+	err := db.PersistShare(share)
 	if err != nil {
 		t.Fatalf("could not persist share: %v", err)
 	}
 
 	// Creating the same share twice should fail.
-	err = db.persistShare(share)
+	err = db.PersistShare(share)
 	if !errors.Is(err, ErrValueFound) {
 		t.Fatalf("expected value found error, got %v", err)
 	}
@@ -58,6 +59,11 @@ func testShares(t *testing.T) {
 	if fetchedShare.Account != share.Account {
 		t.Fatalf("expected %v as fetched share account, got %v",
 			share.Account, fetchedShare.Account)
+	}
+
+	if fetchedShare.CreatedOn != share.CreatedOn {
+		t.Fatalf("expected %v as fetched share created on, got %v",
+			share.CreatedOn, fetchedShare.CreatedOn)
 	}
 
 	if fetchedShare.Weight.Cmp(share.Weight) != 0 {

--- a/pool/share_test.go
+++ b/pool/share_test.go
@@ -5,6 +5,7 @@
 package pool
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -13,9 +14,8 @@ import (
 // persistShare creates a persisted share with the provided account and share
 // weight.
 func persistShare(db Database, account string, weight *big.Rat, createdOnNano int64) error {
-	id := shareID(account, createdOnNano)
 	share := &Share{
-		UUID:    id,
+		UUID:    shareID(account, createdOnNano),
 		Account: account,
 		Weight:  weight,
 	}
@@ -27,29 +27,48 @@ func persistShare(db Database, account string, weight *big.Rat, createdOnNano in
 }
 
 func testShares(t *testing.T) {
-	shareACreatedOn := time.Now().Add(-(time.Second * 10)).UnixNano()
-	shareBCreatedOn := time.Now().Add(-(time.Second * 20)).UnixNano()
+	account := "9e5b83c58170e46b2dee1315aa3b00efd96b5839498fda135b8eddb34f6b34ee"
 	weight := new(big.Rat).SetFloat64(1.0)
-	err := persistShare(db, xID, weight, shareACreatedOn) // Share A
+
+	// Create a valid share.
+	share := NewShare(account, weight)
+	err := db.persistShare(share)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("could not persist share: %v", err)
 	}
 
-	err = persistShare(db, yID, weight, shareBCreatedOn) // Share B
-	if err != nil {
-		t.Fatal(err)
+	// Creating the same share twice should fail.
+	err = db.persistShare(share)
+	if !errors.Is(err, ErrValueFound) {
+		t.Fatalf("expected value found error, got %v", err)
 	}
 
-	// Fetch share A and B.
-	aID := shareID(xID, shareACreatedOn)
-	_, err = fetchShare(db, aID)
+	// Fetch share using its id.
+	fetchedShare, err := db.fetchShare(share.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error fetching share A: %v", err)
 	}
-	bID := shareID(yID, shareBCreatedOn)
-	_, err = fetchShare(db, bID)
-	if err != nil {
-		t.Fatalf("unexpected error fetching share B: %v", err)
+
+	// Ensure fetched values match persisted values.
+	if fetchedShare.UUID != share.UUID {
+		t.Fatalf("expected %v as fetched share id, got %v",
+			share.UUID, fetchedShare.UUID)
+	}
+
+	if fetchedShare.Account != share.Account {
+		t.Fatalf("expected %v as fetched share account, got %v",
+			share.Account, fetchedShare.Account)
+	}
+
+	if fetchedShare.Weight.Cmp(share.Weight) != 0 {
+		t.Fatalf("expected %v as fetched share weight, got %v",
+			share.Weight, fetchedShare.Weight)
+	}
+
+	// Expect error when fetching share which doesnt exist.
+	_, err = db.fetchShare("not a real ID")
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
 	}
 }
 
@@ -239,13 +258,13 @@ func testPruneShares(t *testing.T) {
 
 	// Ensure share A got pruned with share B remaining.
 	shareAID := shareID(xID, eightyBefore)
-	_, err = fetchShare(db, shareAID)
-	if err == nil {
-		t.Fatal("expected value not found error")
+	_, err = db.fetchShare(shareAID)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
 	}
 
 	shareBID := shareID(yID, thirtyBefore)
-	_, err = fetchShare(db, shareBID)
+	_, err = db.fetchShare(shareBID)
 	if err != nil {
 		t.Fatalf("unexpected error fetching share B: %v", err)
 	}
@@ -256,8 +275,8 @@ func testPruneShares(t *testing.T) {
 	}
 
 	// Ensure share B got pruned.
-	_, err = fetchShare(db, shareBID)
-	if err == nil {
-		t.Fatalf("expected value not found error")
+	_, err = db.fetchShare(shareBID)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value not found error, got %v", err)
 	}
 }


### PR DESCRIPTION
- Move int64 <> byte conversion to boltdb.go because it is a generic bbolt helper used in multiple places.
- Various improvements to database accessor test coverage.  eg. checking errors more strictly, checking data fields are stored and retrieved correctly.
- Add fetchShare to Database interface. This is only used by test code, but its going to be needed for both BoltDB and PostgresDB, so it should be included in the interface.
- When inserting data, ensure database keys have not already been used. Return ErrValueFound if they have. Postgres will do this at the DB level, so enforcing the same checks in our BoltDB code helps to keep the interface and implementations consistent.

Improving the DB test coverage will help to ensure a Postgres DB implementation matches the Bolt DB implementation (#257)