### PR TITLE
Payment ID followup

### DIFF
--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -160,7 +160,7 @@ func (cs *ChainState) prunePayments(ctx context.Context, height uint32) error {
 		// If the block has no confirmations at the current height,
 		// it is an orphan. Delete the payments associated with it.
 		if confs <= 0 {
-			err = cs.cfg.db.deletePayment(payment)
+			err = cs.cfg.db.deletePayment(payment.UUID)
 			if err != nil {
 				return err
 			}

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -157,14 +157,12 @@ func testChainState(t *testing.T) {
 		t.Fatalf("prunePayments error: %v", err)
 	}
 
-	aID := paymentID(paymentA.Height, paymentA.CreatedOn, paymentA.Account)
-	_, err = db.fetchPayment(aID)
+	_, err = db.fetchPayment(paymentA.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error fetching payment A: %v", err)
 	}
 
-	bID := paymentID(paymentB.Height, paymentB.CreatedOn, paymentB.Account)
-	_, err = db.fetchPayment(bID)
+	_, err = db.fetchPayment(paymentB.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error fetching payment B: %v", err)
 	}
@@ -175,12 +173,12 @@ func testChainState(t *testing.T) {
 		t.Fatalf("prunePayments error: %v", err)
 	}
 
-	_, err = db.fetchPayment(aID)
+	_, err = db.fetchPayment(paymentA.UUID)
 	if err == nil {
 		t.Fatalf("expected payment A to be pruned at height %d", 28)
 	}
 
-	_, err = db.fetchPayment(bID)
+	_, err = db.fetchPayment(paymentB.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error fetching payment B: %v", err)
 	}
@@ -191,7 +189,7 @@ func testChainState(t *testing.T) {
 		t.Fatalf("prunePayments error: %v", err)
 	}
 
-	_, err = db.fetchPayment(bID)
+	_, err = db.fetchPayment(paymentB.UUID)
 	if err == nil {
 		t.Fatalf("expected payment B to be pruned at height %d", 29)
 	}

--- a/pool/database.go
+++ b/pool/database.go
@@ -32,7 +32,7 @@ type Database interface {
 	fetchPayment(id string) (*Payment, error)
 	PersistPayment(payment *Payment) error
 	updatePayment(payment *Payment) error
-	deletePayment(payment *Payment) error
+	deletePayment(id string) error
 	ArchivePayment(payment *Payment) error
 	fetchPaymentsAtHeight(height uint32) ([]*Payment, error)
 	fetchPendingPayments() ([]*Payment, error)

--- a/pool/payment.go
+++ b/pool/payment.go
@@ -120,8 +120,7 @@ func (db *BoltDB) updatePayment(pmt *Payment) error {
 
 // deletePayment purges the referenced payment from the database. Note that
 // archived payments cannot be deleted.
-func (db *BoltDB) deletePayment(pmt *Payment) error {
-	id := paymentID(pmt.Height, pmt.CreatedOn, pmt.Account)
+func (db *BoltDB) deletePayment(id string) error {
 	return deleteEntry(db, paymentBkt, id)
 }
 

--- a/pool/payment_test.go
+++ b/pool/payment_test.go
@@ -48,8 +48,7 @@ func testPayment(t *testing.T) {
 	}
 
 	// Fetch a payment using its id.
-	id := paymentID(pmtA.Height, pmtA.CreatedOn, pmtA.Account)
-	fetchedPayment, err := db.fetchPayment(id)
+	fetchedPayment, err := db.fetchPayment(pmtA.UUID)
 	if err != nil {
 		t.Fatalf("fetchPayment err: %v", err)
 	}
@@ -65,8 +64,7 @@ func testPayment(t *testing.T) {
 		t.Fatalf("payment update err: %v", err)
 	}
 
-	id = paymentID(pmtB.Height, pmtB.CreatedOn, pmtB.Account)
-	fetchedPayment, err = db.fetchPayment(id)
+	fetchedPayment, err = db.fetchPayment(pmtB.UUID)
 	if err != nil {
 		t.Fatalf("fetchPayment err: %v", err)
 	}
@@ -84,21 +82,19 @@ func testPayment(t *testing.T) {
 	}
 
 	// Ensure the payment B was archived.
-	id = paymentID(pmtB.Height, pmtB.CreatedOn, pmtB.Account)
-	_, err = db.fetchPayment(id)
+	_, err = db.fetchPayment(pmtB.UUID)
 	if !errors.Is(err, ErrValueNotFound) {
 		t.Fatalf("expected value not found error, got %v", err)
 	}
 
 	// Delete payment C.
-	err = db.deletePayment(pmtC)
+	err = db.deletePayment(pmtC.UUID)
 	if err != nil {
 		t.Fatalf("payment delete error: %v", err)
 	}
 
 	// Ensure the payment C was deleted.
-	id = paymentID(pmtC.Height, pmtC.CreatedOn, pmtC.Account)
-	fetchedPayment, err = db.fetchPayment(id)
+	fetchedPayment, err = db.fetchPayment(pmtC.UUID)
 	if !errors.Is(err, ErrValueNotFound) {
 		t.Fatalf("expected value not found error, got %v", err)
 	}

--- a/pool/upgrades.go
+++ b/pool/upgrades.go
@@ -32,7 +32,7 @@ const (
 	// It restores the created on time field for shares.
 	shareCreatedOnVersion = 5
 
-	// paymentUUIDVersion is the sixthversion of the database.
+	// paymentUUIDVersion is the sixth version of the database.
 	// It adds the UUID field to payments.
 	paymentUUIDVersion = 6
 
@@ -531,14 +531,14 @@ func paymentUUIDUpgrade(tx *bolt.Tx) error {
 
 		pBytes, err := json.Marshal(pmt)
 		if err != nil {
-			desc := fmt.Sprintf("%s: unable to marshal share bytes: %v",
+			desc := fmt.Sprintf("%s: unable to marshal payment bytes: %v",
 				funcName, err)
 			return dbError(ErrParse, desc)
 		}
 
 		err = pmtbkt.Put(k, pBytes)
 		if err != nil {
-			desc := fmt.Sprintf("%s: unable to persist share: %v",
+			desc := fmt.Sprintf("%s: unable to persist payment: %v",
 				funcName, err)
 			return dbError(ErrPersistEntry, desc)
 		}
@@ -565,14 +565,14 @@ func paymentUUIDUpgrade(tx *bolt.Tx) error {
 
 		pBytes, err := json.Marshal(pmt)
 		if err != nil {
-			desc := fmt.Sprintf("%s: unable to marshal share bytes: %v",
+			desc := fmt.Sprintf("%s: unable to marshal payment bytes: %v",
 				funcName, err)
 			return dbError(ErrParse, desc)
 		}
 
 		err = abkt.Put(k, pBytes)
 		if err != nil {
-			desc := fmt.Sprintf("%s: unable to persist share: %v",
+			desc := fmt.Sprintf("%s: unable to persist payment: %v",
 				funcName, err)
 			return dbError(ErrPersistEntry, desc)
 		}


### PR DESCRIPTION
Following up from #276, a couple of additional changes.

- The first commit in this PR fixes a bug where archived payments were not having their UUID set correctly, the old value was being used. Using `NewPayment` to create the archive payment ensures all fields are set correctly, and also removes the need to call `time.Now` in the database code (duplicated in NewPayment).

- The second commit removes a lot of instances where we were recreating a payment ID with `paymentID()`, even though we already had it accessible in `payment.UUID`