### PR TITLE
Remove database cleanup from payment manager tests.

### DIFF
--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -460,9 +460,16 @@ func testHub(t *testing.T) {
 		t.Fatalf("unexpected submit work error: %v", err)
 	}
 
-	// Ensure account X exists.
-	if !hub.AccountExists(xID) {
-		t.Fatalf("expected account with id %s to exist", xID)
+	// Create an account.
+	account := NewAccount(xAddr)
+	err = db.persistAccount(account)
+	if err != nil {
+		t.Fatalf("failed to insert account: %v", err)
+	}
+
+	// Ensure hub can check for account existence.
+	if !hub.AccountExists(account.UUID) {
+		t.Fatalf("expected account with id %s to exist", account.UUID)
 	}
 
 	// Ensure the gui CSRF secret can be generated.

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -447,6 +447,19 @@ func testPaymentMgrMaturity(t *testing.T) {
 }
 
 func testPaymentMgrPayment(t *testing.T) {
+	// Insert some test accounts.
+	accountX := NewAccount(xAddr)
+	err := db.persistAccount(accountX)
+	if err != nil {
+		t.Fatalf("failed to insert account: %v", err)
+	}
+
+	accountY := NewAccount(yAddr)
+	err = db.persistAccount(accountY)
+	if err != nil {
+		t.Fatalf("failed to insert account: %v", err)
+	}
+
 	mgr, err := createPaymentMgr(PPS)
 	if err != nil {
 		t.Fatalf("[createPaymentMgr] unexpected error: %v", err)

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -422,11 +422,11 @@ func testPaymentMgr(t *testing.T) {
 		t.Fatalf("[maturePendingPayments] unexpected error: %v", err)
 	}
 
-	if len(pmtSets) == 0 {
+	if len(pmtSets) != 1 {
 		t.Fatal("[maturePendingPayments] expected mature payments")
 	}
 
-	_, ok := pmtSets[zeroSource.BlockHash]
+	pmts, ok := pmtSets[zeroSource.BlockHash]
 	if !ok {
 		t.Fatalf("[maturePendingPayments] expected mature payments "+
 			"at height %d", height)

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -16,11 +16,11 @@ var (
 	// Account X address.
 	xAddr = "SsWKp7wtdTZYabYFYSc9cnxhwFEjA5g4pFc"
 	// Account X id.
-	xID = ""
+	xID = NewAccount(xAddr).UUID
 	// Account Y address.
 	yAddr = "Ssp7J7TUmi5iPhoQnWYNGQbeGhu6V3otJcS"
 	// Account Y id.
-	yID = ""
+	yID = NewAccount(yAddr).UUID
 	// Pool fee address.
 	poolFeeAddrs, _ = dcrutil.DecodeAddress(
 		"SsnbEmxCVXskgTHXvf3rEa17NA39qQuGHwQ",
@@ -46,21 +46,6 @@ func setupDB() error {
 	if err != nil {
 		return err
 	}
-
-	accountX := NewAccount(xAddr)
-	err = db.persistAccount(accountX)
-	if err != nil {
-		return err
-	}
-
-	accountY := NewAccount(yAddr)
-	err = db.persistAccount(accountY)
-	if err != nil {
-		return err
-	}
-
-	xID = accountX.UUID
-	yID = accountY.UUID
 
 	return err
 }

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -122,7 +122,11 @@ func TestPool(t *testing.T) {
 		"testPaymentAccessors":       testPaymentAccessors,
 		"testEndpoint":               testEndpoint,
 		"testClient":                 testClient,
-		"testPaymentMgr":             testPaymentMgr,
+		"testPaymentMgrPPS":          testPaymentMgrPPS,
+		"testPaymentMgrPPLNS":        testPaymentMgrPPLNS,
+		"testPaymentMgrMaturity":     testPaymentMgrMaturity,
+		"testPaymentMgrPayment":      testPaymentMgrPayment,
+		"testPaymentMgrDust":         testPaymentMgrDust,
 		"testChainState":             testChainState,
 		"testHub":                    testHub,
 	}

--- a/pool/share.go
+++ b/pool/share.go
@@ -198,7 +198,8 @@ func (db *BoltDB) pplnsEligibleShares(min int64) ([]*Share, error) {
 	return eligibleShares, err
 }
 
-// pruneShares removes invalidated shares from the db.
+// pruneShares removes shares with a createdOn time earlier than the provided
+// time.
 func (db *BoltDB) pruneShares(minNano int64) error {
 	funcName := "pruneShares"
 	minB := nanoToBigEndianBytes(minNano)


### PR DESCRIPTION
First commit is fixing an existing bug in `paymentmgr_test.go`.

Second is breaking down the monolithic paymentmgr test in to smaller chunks. This enables more detail about test failures, and also removes database cleanup code from within the tests which will help with testing against different database implementations. (#257)

A third commit to only insert accounts into the test database when required. Previously 2 test accounts were inserted every time the test db was initialized, even though the accounts are only required for a small set of tests.