### PR TITLE
Bundled test improvements

### DIFF
--- a/pool/acceptedwork.go
+++ b/pool/acceptedwork.go
@@ -155,8 +155,8 @@ func (db *BoltDB) updateAcceptedWork(work *AcceptedWork) error {
 }
 
 // deleteAcceptedWork removes the associated accepted work from the database.
-func (db *BoltDB) deleteAcceptedWork(work *AcceptedWork) error {
-	return deleteEntry(db, workBkt, work.UUID)
+func (db *BoltDB) deleteAcceptedWork(id string) error {
+	return deleteEntry(db, workBkt, id)
 }
 
 // listMinedWork returns work data associated with all blocks mined by the pool

--- a/pool/acceptedwork_test.go
+++ b/pool/acceptedwork_test.go
@@ -5,16 +5,6 @@ import (
 	"testing"
 )
 
-func persistAcceptedWork(db Database, blockHash string, prevHash string,
-	height uint32, minedBy string, miner string) (*AcceptedWork, error) {
-	acceptedWork := NewAcceptedWork(blockHash, prevHash, height, minedBy, miner)
-	err := db.persistAcceptedWork(acceptedWork)
-	if err != nil {
-		return nil, err
-	}
-	return acceptedWork, nil
-}
-
 func testAcceptedWork(t *testing.T) {
 	// Created some valid accepted work.
 	workA := NewAcceptedWork(

--- a/pool/acceptedwork_test.go
+++ b/pool/acceptedwork_test.go
@@ -152,21 +152,21 @@ func testAcceptedWork(t *testing.T) {
 	}
 
 	// Delete all work.
-	err = db.deleteAcceptedWork(workA)
+	err = db.deleteAcceptedWork(workA.UUID)
 	if err != nil {
 		t.Fatalf("delete workA error: %v ", err)
 	}
 
-	err = db.deleteAcceptedWork(workB)
+	err = db.deleteAcceptedWork(workB.UUID)
 	if err != nil {
 		t.Fatalf("delete workB error: %v ", err)
 	}
-	err = db.deleteAcceptedWork(workC)
+	err = db.deleteAcceptedWork(workC.UUID)
 	if err != nil {
 		t.Fatalf("delete workC error: %v ", err)
 	}
 
-	err = db.deleteAcceptedWork(workD)
+	err = db.deleteAcceptedWork(workD.UUID)
 	if err != nil {
 		t.Fatalf("delete workD error: %v ", err)
 	}

--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -118,7 +118,7 @@ func (cs *ChainState) pruneAcceptedWork(ctx context.Context, height uint32) erro
 		// If the block has no confirmations at the current height,
 		// it is an orphan. Prune it.
 		if confs <= 0 {
-			err = cs.cfg.db.deleteAcceptedWork(work)
+			err = cs.cfg.db.deleteAcceptedWork(work.UUID)
 			if err != nil {
 				return err
 			}

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -118,8 +118,8 @@ func testChainState(t *testing.T) {
 		t.Fatalf("expected a valid accepted work, got: %v", err)
 	}
 	_, err = db.fetchAcceptedWork(workB.UUID)
-	if err == nil {
-		t.Fatal("expected a no value found error")
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value found error, got %v", err)
 	}
 
 	// Delete work A.
@@ -175,8 +175,8 @@ func testChainState(t *testing.T) {
 	}
 
 	_, err = db.fetchPayment(paymentA.UUID)
-	if err == nil {
-		t.Fatalf("expected payment A to be pruned at height %d", 28)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value found error, got %v", err)
 	}
 
 	_, err = db.fetchPayment(paymentB.UUID)
@@ -191,8 +191,8 @@ func testChainState(t *testing.T) {
 	}
 
 	_, err = db.fetchPayment(paymentB.UUID)
-	if err == nil {
-		t.Fatalf("expected payment B to be pruned at height %d", 29)
+	if !errors.Is(err, ErrValueNotFound) {
+		t.Fatalf("expected value found error, got %v", err)
 	}
 
 	cs.cfg.GetBlock = getBlock

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -122,7 +123,7 @@ func testChainState(t *testing.T) {
 	}
 
 	// Delete work A.
-	err = db.deleteAcceptedWork(workA)
+	err = db.deleteAcceptedWork(workA.UUID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -139,12 +139,14 @@ func testChainState(t *testing.T) {
 		BlockHash: chainhash.Hash{0}.String(),
 		Coinbase:  chainhash.Hash{0}.String(),
 	}
-	paymentA, err := persistPayment(db, xID, zeroSource, amt, height, estMaturity)
+	paymentA := NewPayment(xID, zeroSource, amt, height, estMaturity)
+	err = db.PersistPayment(paymentA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	paymentB, err := persistPayment(db, yID, zeroSource, amt, height+1, estMaturity+1)
+	paymentB := NewPayment(yID, zeroSource, amt, height+1, estMaturity+1)
+	err = db.PersistPayment(paymentB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -84,24 +84,21 @@ func testChainState(t *testing.T) {
 	cs := NewChainState(cCfg)
 
 	// Test pruneAcceptedWork.
-	workA, err := persistAcceptedWork(db,
+	workA := NewAcceptedWork(
 		"00000000000000001e2065a7248a9b4d3886fe3ca3128eebedddaf35fb26e58c",
 		"000000000000000007301a21efa98033e06f7eba836990394fff9f765f1556b1",
 		396692, yID, "dr3")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	workA.Confirmed = true
-	err = db.updateAcceptedWork(workA)
+	err = db.persistAcceptedWork(workA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	workB, err := persistAcceptedWork(db,
+	workB := NewAcceptedWork(
 		"000000000000000025aa4a7ba8c3ece4608376bf84a82ec7e025991460097198",
 		"00000000000000001e2065a7248a9b4d3886fe3ca3128eebedddaf35fb26e58c",
 		396693, xID, "dr5")
+	err = db.persistAcceptedWork(workB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pool/database.go
+++ b/pool/database.go
@@ -52,7 +52,7 @@ type Database interface {
 	fetchAcceptedWork(id string) (*AcceptedWork, error)
 	persistAcceptedWork(work *AcceptedWork) error
 	updateAcceptedWork(work *AcceptedWork) error
-	deleteAcceptedWork(work *AcceptedWork) error
+	deleteAcceptedWork(id string) error
 	listMinedWork() ([]*AcceptedWork, error)
 	fetchUnconfirmedWork(height uint32) ([]*AcceptedWork, error)
 

--- a/pool/payment.go
+++ b/pool/payment.go
@@ -61,7 +61,8 @@ func NewPayment(account string, source *PaymentSource, amount dcrutil.Amount,
 	}
 }
 
-// fetchPayment fetches the payment referenced by the provided id.
+// fetchPayment fetches the payment referenced by the provided id. Returns an
+// error if the payment is not found.
 func (db *BoltDB) fetchPayment(id string) (*Payment, error) {
 	const funcName = "fetchPayment"
 	var payment Payment

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -878,12 +878,16 @@ func testPaymentMgr(t *testing.T) {
 	height = uint32(10)
 	estMaturity = uint32(26)
 	amt, _ = dcrutil.NewAmount(5)
-	_, err = persistPayment(db, xID, zeroSource, amt, height, estMaturity)
+
+	pmtX := NewPayment(xID, zeroSource, amt, height, estMaturity)
+	err = db.PersistPayment(pmtX)
 	if err != nil {
 		cancel()
 		t.Fatal(err)
 	}
-	_, err = persistPayment(db, yID, randSource, amt, height, estMaturity)
+
+	pmtY := NewPayment(yID, randSource, amt, height, estMaturity)
+	err = db.PersistPayment(pmtY)
 	if err != nil {
 		cancel()
 		t.Fatal(err)


### PR DESCRIPTION
This PR contains multiple small improvements to testing code, most importantly improved test coverage for database code (supporting #257)

- Extra test coverage for DB code in `payments.go` and `acceptedwork.go`
- Properly check type of some errors in tests
- Remove helpers `persistPayment` and `persistAcceptedWork` which didnt really help much.
- Update Database interface so `deleteAcceptedWork` accepts an `id string` param, rather than an `AcceptedWork` struct.