### PR TITLE
Set PaidOnHeight & TxID for archived payments.

### DIFF
--- a/cmd/miner/client.go
+++ b/cmd/miner/client.go
@@ -275,7 +275,7 @@ func (m *Miner) process(ctx context.Context) {
 						continue
 					}
 
-					log.Tracef("subscription details: %s, %s, %s, %d",
+					log.Tracef("subscription details: %s, %s, %d",
 						notifyID, extraNonce1E, extraNonce2Size)
 
 					m.extraNonce1E = extraNonce1E

--- a/harness.sh
+++ b/harness.sh
@@ -23,7 +23,7 @@ MASTER_WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e140
 VOTING_WALLET_SEED="aabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbcaabbc"
 WALLET_PASS=123
 ADMIN_PASS=admin
-SOLO_POOL=1
+SOLO_POOL=0
 MAX_GEN_TIME=20s
 MINER_MAX_PROCS=1
 PAYMENT_METHOD="pplns"
@@ -77,6 +77,7 @@ CLIENT_ADDRS=(
 NUMBER_OF_CLIENTS=1
 
 if [ -d "${HARNESS_ROOT}" ]; then
+  echo "Deleting ${HARNESS_ROOT}"
   rm -R "${HARNESS_ROOT}"
 fi
 

--- a/pool/boltdb.go
+++ b/pool/boltdb.go
@@ -974,6 +974,8 @@ func (db *BoltDB) ArchivePayment(pmt *Payment) error {
 		// Create a new payment to add to the archive.
 		aPmt := NewPayment(pmt.Account, pmt.Source, pmt.Amount, pmt.Height,
 			pmt.EstimatedMaturity)
+		aPmt.TransactionID = pmt.TransactionID
+		aPmt.PaidOnHeight = pmt.PaidOnHeight
 		aPmtB, err := json.Marshal(aPmt)
 		if err != nil {
 			desc := fmt.Sprintf("%s: unable to marshal payment bytes: %v",

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -86,6 +86,7 @@ func TestPool(t *testing.T) {
 		"testPPLNSEligibleShares":    testPPLNSEligibleShares,
 		"testPruneShares":            testPruneShares,
 		"testPayment":                testPayment,
+		"testArchivePayment":         testArchivePayment,
 		"testPaymentAccessors":       testPaymentAccessors,
 		"testEndpoint":               testEndpoint,
 		"testClientHashCalc":         testClientHashCalc,

--- a/pool/postgres.go
+++ b/pool/postgres.go
@@ -610,6 +610,8 @@ func (db *PostgresDB) ArchivePayment(p *Payment) error {
 
 	aPmt := NewPayment(p.Account, p.Source, p.Amount, p.Height,
 		p.EstimatedMaturity)
+	aPmt.TransactionID = p.TransactionID
+	aPmt.PaidOnHeight = p.PaidOnHeight
 
 	_, err = tx.Exec(insertArchivedPayment,
 		aPmt.UUID, aPmt.Account, aPmt.EstimatedMaturity, aPmt.Height, aPmt.Amount,


### PR DESCRIPTION
Previously these values were not being saved correctly because they were not being set when a new Payment was created in the DB code.