### PR TITLE
Disable account lookup on solo pools.

### DIFF
--- a/gui/account.go
+++ b/gui/account.go
@@ -68,6 +68,7 @@ func (ui *GUI) account(w http.ResponseWriter, r *http.Request) {
 			CSRF:        csrf.TemplateField(r),
 			Designation: ui.cfg.Designation,
 			ShowMenu:    true,
+			SoloPool:    ui.cfg.SoloPool,
 		},
 		MinedWork:             recentWork,
 		PendingPaymentsTotal:  totalPending,

--- a/gui/admin.go
+++ b/gui/admin.go
@@ -59,6 +59,7 @@ func (ui *GUI) adminPage(w http.ResponseWriter, r *http.Request) {
 			CSRF:        csrf.TemplateField(r),
 			Designation: ui.cfg.Designation,
 			ShowMenu:    false,
+			SoloPool:    ui.cfg.SoloPool,
 		},
 		PoolStatsData: poolStatsData{
 			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),

--- a/gui/assets/public/css/dcrpool.css
+++ b/gui/assets/public/css/dcrpool.css
@@ -8656,7 +8656,7 @@ https://flickity.metafizzy.co
   font-size: 14px;
   height: 20px;
   margin-top: 2px;
-  opacity: 0;
+  opacity: 1;
   transition: all 0.25s;
 }
 

--- a/gui/assets/templates/header.html
+++ b/gui/assets/templates/header.html
@@ -86,14 +86,14 @@
                             <p>To know your mining account details, enter your mining address.</p>
                             <form class="modal-form" id="account-form" action="/account" method="head">
                                 <div class="modal-input">
-                                    <input type="text" name="address" required placeholder="Mining Address" spellcheck="false">
+                                    <input type="text" name="address" required {{ if .SoloPool }}disabled{{end}} placeholder="Mining Address" spellcheck="false">
                                     <div class="icon-warning"></div>
                                 </div>
-                                <div class="err-message"></div>
+                                <div class="err-message">{{ if .SoloPool }} Account lookup disabled in solo pool mode {{end}}</div>
                             </form>
                             <div class="d-flex flex-row pt-4 align-items-center">
                                 <a data-toggle="modal" href="#admin-modal">I'm an Admin</a>
-                                <button form="account-form" type="submit" class="btn btn-primary ml-auto">Enter</button>
+                                <button form="account-form" type="submit" {{ if .SoloPool }}disabled{{end}} class="btn btn-primary ml-auto">Enter</button>
                             </div>
                         </div>
                     </div>

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -117,6 +117,7 @@ type headerData struct {
 	CSRF        template.HTML
 	Designation string
 	ShowMenu    bool
+	SoloPool    bool
 }
 
 // route configures the http router of the user interface.

--- a/gui/index.go
+++ b/gui/index.go
@@ -55,6 +55,7 @@ func (ui *GUI) renderIndex(w http.ResponseWriter, r *http.Request, modalError st
 			CSRF:        csrf.TemplateField(r),
 			Designation: ui.cfg.Designation,
 			ShowMenu:    true,
+			SoloPool:    ui.cfg.SoloPool,
 		},
 		PoolStatsData: poolStatsData{
 			LastWorkHeight:    ui.cfg.FetchLastWorkHeight(),


### PR DESCRIPTION
Disable account lookup form element and display a message to notify the feature is not available.

Closes #308 