### PR TITLE
multi: update a homedir config flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ options will be needed, refer to [postgres.md](./docs/postgres.md).
 ### Example output of a solo pool startup
 
 ```no-highlight
-dcrpool --configfile=pool.conf --homedir=/tmp/dcrpool-harness/pool
+dcrpool --configfile=pool.conf --appdata=/tmp/dcrpool-harness/pool
 2020-12-22 20:10:31.120 [INF] POOL: Maximum work submission generation time at pool difficulty is 28s.
 2020-12-22 20:10:31.129 [INF] POOL: Solo pool mode active.
 2020-12-22 20:10:31.149 [INF] MP: Version: 1.1.0+dev
@@ -159,7 +159,7 @@ options will be needed, refer to [postgres.md](./docs/postgres.md).
 ### Example output of a mining pool startup
 
 ```no-highlight
-dcrpool --configfile=pool.conf --homedir=/tmp/dcrpool-harness/pool
+dcrpool --configfile=pool.conf --appdata=/tmp/dcrpool-harness/pool
 2020-12-22 19:57:45.795 [INF] POOL: Maximum work submission generation time at pool difficulty is 20s.
 2020-12-22 19:57:45.816 [INF] POOL: Payment method is PPLNS.
 2020-12-22 19:57:45.916 [INF] MP: Version: 1.1.0+dev

--- a/cmd/miner/config.go
+++ b/cmd/miner/config.go
@@ -44,7 +44,7 @@ var runServiceCommand func(string) error
 
 // config describes the connection parameters for the client.
 type config struct {
-	HomeDir    string `long:"homedir" ini-name:"homedir" description:"Path to application home directory."`
+	HomeDir    string `long:"appdata" ini-name:"appdata" description:"Path to application home directory."`
 	ConfigFile string `long:"configfile" ini-name:"configfile" description:"Path to configuration file."`
 	ActiveNet  string `long:"activenet" ini-name:"activenet" description:"The active network being mined on. {simnet, testnet3, mainnet}"`
 	User       string `long:"user" ini-name:"user" description:"The username of the mining account."`

--- a/config.go
+++ b/config.go
@@ -92,7 +92,7 @@ var runServiceCommand func(string) error
 // config defines the configuration options for the pool.
 type config struct {
 	ShowVersion           bool          `long:"version" no-ini:"true" description:"Display version information and exit."`
-	HomeDir               string        `long:"homedir" ini-name:"homedir" description:"Path to application home directory."`
+	HomeDir               string        `long:"appdata" ini-name:"appdata" description:"Path to application home directory."`
 	ConfigFile            string        `long:"configfile" ini-name:"configfile" description:"Path to configuration file."`
 	DataDir               string        `long:"datadir" ini-name:"datadir" description:"The data directory."`
 	ActiveNet             string        `long:"activenet" ini-name:"activenet" description:"The active network being mined on. {testnet3, mainnet, simnet}"`

--- a/harness.sh
+++ b/harness.sh
@@ -250,7 +250,7 @@ tmux new-window -t $TMUX_SESSION -n 'mwallet'
 # generate the needed dcrpool key pairs before starting the wallet.
 tmux send-keys "cd ${HARNESS_ROOT}/pool" C-m
 tmux send-keys "dcrpool --configfile=pool.conf --gencertsonly \
---homedir=${HARNESS_ROOT}/pool" C-m
+--appdata=${HARNESS_ROOT}/pool" C-m
 
 tmux send-keys "cd ${HARNESS_ROOT}/mwallet" C-m
 echo "Creating simnet master wallet"
@@ -378,7 +378,7 @@ echo "Starting dcrpool"
 sleep 5
 tmux new-window -t $TMUX_SESSION -n 'pool'
 tmux send-keys "cd ${HARNESS_ROOT}/pool" C-m
-tmux send-keys "dcrpool --configfile=pool.conf --homedir=${HARNESS_ROOT}/pool \
+tmux send-keys "dcrpool --configfile=pool.conf --appdata=${HARNESS_ROOT}/pool \
 --purgedb" C-m
 
 ################################################################################
@@ -389,7 +389,7 @@ for ((i = 0; i < $NUMBER_OF_CLIENTS; i++)); do
   sleep 1
   tmux new-window -t $TMUX_SESSION -n c$i
   tmux send-keys "cd ${HARNESS_ROOT}/c$i" C-m
-  tmux send-keys "miner --configfile=client.conf --homedir=${HARNESS_ROOT}/c$i" C-m
+  tmux send-keys "miner --configfile=client.conf --appdata=${HARNESS_ROOT}/c$i" C-m
 done
 
 tmux attach-session -t $TMUX_SESSION


### PR DESCRIPTION
This updates the `--homedir` flag to `--appdata` to be consistent with `dcrd` and `dcrwallet`. 

This is a breaking change. Normally deprecation would be preferred but since the upcoming release already has breaking changes 
and it'd not be great managing two homedir config vars with different values.

Resolves #307