### PR TITLE
pool: fix client connection termination.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -814,12 +814,12 @@ func (c *Client) process() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			_, err := c.conn.Write([]byte{})
+			err := c.conn.Close()
 			if err != nil {
 				c.mtx.RLock()
 				id := c.id
 				c.mtx.RUnlock()
-				log.Errorf("%s: unable to send close message: %v", id, err)
+				log.Errorf("%s: unable to close connection: %v", id, err)
 			}
 			c.wg.Done()
 			return


### PR DESCRIPTION
This fixes how client connections are terminated by the pool. Previously an empty message was being used to terminate the connection but this fails with i/o timeouts which would leave the connection in a false state of still being connected to the pool.