### PR TITLE
pool: superfluous work notif after submission.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -872,10 +872,6 @@ func (c *Client) process() {
 						continue
 					}
 
-					if allowed {
-						c.updateWork(true)
-					}
-
 				default:
 					log.Errorf("unknown request method for message %s: %s",
 						req.String(), req.Method)

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -1090,13 +1090,6 @@ func testClientMessageHandling(t *testing.T) {
 		t.Fatalf("expected a non-error work submission response, got %v", resp.Error)
 	}
 
-	// Discard the updated work sent after a successful submission.
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case <-recvCh:
-	}
-
 	// Ensure a CPU client receives an error response when
 	// submitting duplicate work.
 	id++


### PR DESCRIPTION
This removes an unnecessary work notification to clients that submit valid work submission. It's is unnecessary because additional work submissions can be found from the unexplored nonce space and if there is the need for updated work the timestamp rolled work process will provide that.

