### PR TITLE
miner: avoid sending already known submissions. 

### DIFF
--- a/cmd/miner/client.go
+++ b/cmd/miner/client.go
@@ -121,6 +121,8 @@ func (m *Miner) keepAlive(ctx context.Context) {
 
 			time.Sleep(time.Second * 2)
 
+			log.Infof("dialing %s...", m.config.Pool)
+
 			conn, err := net.Dial("tcp", m.config.Pool)
 			if err != nil {
 				log.Errorf("unable to connect to %s: %v", m.config.Pool, err)
@@ -168,13 +170,20 @@ func (m *Miner) read(ctx context.Context) {
 
 		data, err := m.reader.ReadBytes('\n')
 		if err != nil {
+			m.connectedMtx.Lock()
+			m.connected = false
+			m.connectedMtx.Unlock()
+
 			m.workMtx.Lock()
 			m.work = new(Work)
 			m.workMtx.Unlock()
 
-			m.connectedMtx.Lock()
-			m.connected = false
-			m.connectedMtx.Unlock()
+			// Signal the solver to abort hashing.
+			select {
+			case m.chainCh <- struct{}{}:
+			default:
+				// Non-blocking send fallthrough.
+			}
 
 			select {
 			case <-ctx.Done():

--- a/cmd/miner/client.go
+++ b/cmd/miner/client.go
@@ -207,6 +207,15 @@ func (m *Miner) read(ctx context.Context) {
 			log.Errorf("unable to read bytes: %v", err)
 			continue
 		}
+
+		select {
+		case <-ctx.Done():
+			m.wg.Done()
+			return
+		default:
+			// Non-blocking receive fallthrough.
+		}
+
 		m.readCh <- data
 	}
 }

--- a/cmd/miner/cpuminer.go
+++ b/cmd/miner/cpuminer.go
@@ -213,6 +213,15 @@ func (m *CPUMiner) solve(ctx context.Context) {
 
 		switch m.solveBlock(ctx, headerB, target) {
 		case true:
+			m.miner.connectedMtx.RLock()
+			connected := m.miner.connected
+			m.miner.connectedMtx.RUnlock()
+
+			if !connected {
+				log.Tracef("miner disconnected, skipping work submission")
+				continue
+			}
+
 			// Send a submit work request.
 			worker := fmt.Sprintf("%s.%s", m.miner.config.Address,
 				m.miner.config.User)


### PR DESCRIPTION
This addresses some issues identified with the cpu miner in testing. Each issue has been addressed in a commit.

- miner: prioritize clean jobs:  
	- This updates the miner to immediately begin solving new work if it is marked as a clean job.

- miner: avoid sending already known submissions:  
	- This avoids sending already known submissions by comparing the previously sent submission nonce data to the newly solved nonce data and only proceeding if they do not match.

- miner: avoid submitting work when disconnected:  
	- This updates the disconnection process to first update the solver and avoid work submissions.

- miner: fix possible read hang:  
	- This fixes a case where process goroutine terminates on a context signal while the read process sends to its unbuffered read channel.
