### PR TITLE
pool: fix set diff for unsupported miners.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -489,6 +489,12 @@ func (c *Client) handleExtraNonceSubscribeRequest(req *Request, allowed bool) er
 
 // setDifficulty sends the pool client's difficulty ratio.
 func (c *Client) setDifficulty() {
+	// Do not send a difficulty notification if the diff info
+	// for the miner is not set.
+	if c.diffInfo == nil {
+		return
+	}
+
 	c.mtx.RLock()
 	diffRat := c.diffInfo.difficulty
 	c.mtx.RUnlock()


### PR DESCRIPTION
This fixes a bug related to sending a set difficulty notification for an unsupported miner.

Work towards #316.