### PR TITLE
multi: fix chain notif. blocking by pmt processor.

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -143,6 +143,9 @@ const (
 
 	// CreateAmount indicates an amount creation error.
 	CreateAmount = ErrorKind("CreateAmount")
+
+	// Rescan indicates an wallet rescan error.
+	Rescan = ErrorKind("Rescan")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -58,6 +58,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{TxIn, "TxIn"},
 		{ContextCancelled, "ContextCancelled"},
 		{CreateAmount, "CreateAmount"},
+		{Rescan, "Rescan"},
 	}
 
 	for i, test := range tests {

--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -31,7 +31,7 @@ type ChainStateConfig struct {
 	db Database
 	// SoloPool represents the solo pool mining mode.
 	SoloPool bool
-	// ProcessPayments relays payment signals for Processing.
+	// ProcessPayments relays payment signals for processing.
 	ProcessPayments func(msg *paymentMsg)
 	// GeneratePayments creates payments for participating accounts in pool
 	// mining mode based on the configured payment scheme.

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -44,9 +44,7 @@ func testChainState(t *testing.T) {
 		t.Fatalf("unexpected serialization error: %v", err)
 	}
 
-	payDividends := func(context.Context, uint32, bool) error {
-		return nil
-	}
+	processPayments := func(*paymentMsg) {}
 	generatePayments := func(uint32, *PaymentSource, dcrutil.Amount, int64) error {
 		return nil
 	}
@@ -78,7 +76,7 @@ func testChainState(t *testing.T) {
 	cCfg := &ChainStateConfig{
 		db:                    db,
 		SoloPool:              false,
-		PayDividends:          payDividends,
+		ProcessPayments:       processPayments,
 		GeneratePayments:      generatePayments,
 		GetBlock:              getBlock,
 		GetBlockConfirmations: getBlockConfirmations,
@@ -339,7 +337,6 @@ func testChainState(t *testing.T) {
 	}
 	cs.discCh <- discConfMsg
 	<-discConfMsg.Done
-	cs.cfg.PayDividends = payDividends
 
 	// Ensure the last work height can be updated.
 	initialLastWorkHeight := cs.fetchLastWorkHeight()

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -450,7 +450,7 @@ func (h *Hub) getTxConfNotifications(txHashes []chainhash.Hash, stopAfter int32)
 	log.Tracef("Requesting tx conf notifications for %d "+
 		"transactions (stop after #%d)", len(txHashes), stopAfter)
 	for _, hash := range txHashes {
-		hashes = append(hashes, hash[:])
+		hashes = append(hashes, hash.CloneBytes())
 		log.Tracef("    %s", hash)
 	}
 

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -447,8 +447,11 @@ func (h *Hub) getWork(ctx context.Context) (string, string, error) {
 // the provided transaction hashes.
 func (h *Hub) getTxConfNotifications(txHashes []chainhash.Hash, stopAfter int32) (func() (*walletrpc.ConfirmationNotificationsResponse, error), error) {
 	hashes := make([][]byte, 0, len(txHashes))
+	log.Tracef("Requesting tx conf notifications for %d "+
+		"transactions (stop after #%d)", len(txHashes), stopAfter)
 	for _, hash := range txHashes {
 		hashes = append(hashes, hash[:])
+		log.Tracef("    %s", hash)
 	}
 
 	req := &walletrpc.ConfirmationNotificationsRequest{

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -445,7 +445,7 @@ func (h *Hub) getWork(ctx context.Context) (string, string, error) {
 
 // getTxConfNotifications streams transaction confirmation notifications for
 // the provided transaction hashes.
-func (h *Hub) getTxConfNotifications(txHashes []*chainhash.Hash, stopAfter int32) (func() (*walletrpc.ConfirmationNotificationsResponse, error), error) {
+func (h *Hub) getTxConfNotifications(txHashes []chainhash.Hash, stopAfter int32) (func() (*walletrpc.ConfirmationNotificationsResponse, error), error) {
 	hashes := make([][]byte, 0, len(txHashes))
 	for _, hash := range txHashes {
 		hashes = append(hashes, hash[:])

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -100,6 +100,7 @@ var (
 type WalletConnection interface {
 	SignTransaction(context.Context, *walletrpc.SignTransactionRequest, ...grpc.CallOption) (*walletrpc.SignTransactionResponse, error)
 	PublishTransaction(context.Context, *walletrpc.PublishTransactionRequest, ...grpc.CallOption) (*walletrpc.PublishTransactionResponse, error)
+	Rescan(ctx context.Context, in *walletrpc.RescanRequest, opts ...grpc.CallOption) (walletrpc.WalletService_RescanClient, error)
 }
 
 // NodeConnection defines the functionality needed by a mining node

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -23,7 +23,42 @@ import (
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/wire"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
+
+type tRescanClient struct {
+	resp *walletrpc.RescanResponse
+	err  error
+	grpc.ClientStream
+}
+
+func (r *tRescanClient) Recv() (*walletrpc.RescanResponse, error) {
+	return r.resp, r.err
+}
+
+func (r *tRescanClient) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (r *tRescanClient) Trailer() metadata.MD {
+	return nil
+}
+
+func (r *tRescanClient) CloseSend() error {
+	return nil
+}
+
+func (r *tRescanClient) Context() context.Context {
+	return nil
+}
+
+func (r *tRescanClient) SendMsg(m interface{}) error {
+	return nil
+}
+
+func (r *tRescanClient) RecvMsg(m interface{}) error {
+	return nil
+}
 
 type tWalletConnection struct {
 }
@@ -107,6 +142,15 @@ func (t *tWalletConnection) PublishTransaction(context.Context, *walletrpc.Publi
 	return &walletrpc.PublishTransactionResponse{
 		TransactionHash: txHash,
 	}, nil
+}
+
+func (t *tWalletConnection) Rescan(context.Context, *walletrpc.RescanRequest, ...grpc.CallOption) (walletrpc.WalletService_RescanClient, error) {
+	client := new(tRescanClient)
+	client.resp = &walletrpc.RescanResponse{
+		RescannedThrough: 10000,
+	}
+
+	return client, nil
 }
 
 type tNodeConnection struct{}

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -43,7 +43,7 @@ const (
 	// failures before a wallet rescan is requested.
 	maxTxConfThreshold = uint32(3)
 
-	// paymentBufferSize repreents the buffering on the payment channel.
+	// paymentBufferSize is the size of the buffer on the payment channel.
 	paymentBufferSize = uint32(30)
 )
 
@@ -783,17 +783,17 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32, treasuryA
 		return errs.PoolError(errs.Disconnected, desc)
 	}
 
-	// Request a wallet rescan if tx confirmation failures are
-	// at threshold.
 	pCtx, pCancel := context.WithTimeout(ctx, pm.cfg.CoinbaseConfTimeout)
 	defer pCancel()
 
+	// Request a wallet rescan if tx confirmation failures are
+	// at threshold.
 	txConfCount := atomic.LoadUint32(&pm.failedTxConfs)
-	if txConfCount == maxTxConfThreshold {
+	if txConfCount >= maxTxConfThreshold {
 		beginHeight := uint32(0)
 
 		// Having no tx conf hashes at threshold indicates an
-		// underlining error.
+		// underlying error.
 		pm.mtx.Lock()
 		if len(pm.txConfHashes) == 0 {
 			pm.mtx.Unlock()
@@ -822,7 +822,7 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32, treasuryA
 		}
 		rescanSource, err := txB.Rescan(pCtx, rescanReq)
 		if err != nil {
-			desc := fmt.Sprintf("%s: tx creator cannot be nil", funcName)
+			desc := fmt.Sprintf("%s: rescan source cannot be nil", funcName)
 			return errs.PoolError(errs.Rescan, desc)
 		}
 

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -884,11 +884,16 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32, treasuryA
 			maxSpendableHeight = spendableHeight
 		}
 	}
-	if maxSpendableHeight < height {
-		maxSpendableHeight = height
+
+	var stopAfter uint32
+	switch {
+	case maxSpendableHeight > height:
+		stopAfter = maxSpendableHeight - height
+	default:
+		stopAfter = 1
 	}
 
-	err = pm.confirmCoinbases(pCtx, inputTxHashes, maxSpendableHeight)
+	err = pm.confirmCoinbases(pCtx, inputTxHashes, stopAfter)
 	if err != nil {
 		atomic.AddUint32(&pm.failedTxConfs, 1)
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -103,6 +103,7 @@ func TestPool(t *testing.T) {
 		"testPaymentMgrMaturity":     testPaymentMgrMaturity,
 		"testPaymentMgrPayment":      testPaymentMgrPayment,
 		"testPaymentMgrDust":         testPaymentMgrDust,
+		"testPaymentSignals":         testPaymentMgrSignals,
 		"testChainState":             testChainState,
 		"testHub":                    testHub,
 	}


### PR DESCRIPTION
This fixes chain notification messages being blocked by payment processing calls when tx confirmations are not accurately being reported.

The fix includes:

- ensuring a payment processing call concludes before starting another one via the processing flag.

- calling the payment process in a goroutine to avoid blocking the chain state process.

- keeping track of tx confirmation failures and starting a wallet rescan if the failures exceed threshold.

Associated tests have been updated.