### PR TITLE
Update to golangci-lint 1.40.1.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -77,6 +77,12 @@ var (
 	}
 )
 
+func splitMinerID(id string) (string, string) {
+	const separator = "/"
+	split := strings.Split(id, separator)
+	return split[0], split[1]
+}
+
 func setCurrentWork(work string) {
 	currentWorkMtx.Lock()
 	currentWork = work
@@ -420,10 +426,8 @@ func testClientMessageHandling(t *testing.T) {
 		return false
 	}
 	id++
-	sep := "/"
-	d1ID := strings.Split(D1ID, sep)
-	d1 := d1ID[0]
-	d1Version := d1ID[1]
+
+	d1, d1Version := splitMinerID(d1ID)
 
 	r = SubscribeRequest(&id, userAgent(d1, d1Version), "mn001")
 	err = sE.Encode(r)
@@ -495,9 +499,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 
 	id++
-	dr3ID := strings.Split(DR3ID, sep)
-	dr3 := dr3ID[0]
-	dr3Version := dr3ID[1]
+	dr3, dr3Version := splitMinerID(dr3ID)
 	r = SubscribeRequest(&id, userAgent(dr3, dr3Version), "")
 	err = sE.Encode(r)
 	if err != nil {
@@ -534,9 +536,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 
 	id++
-	dcr1ID := strings.Split(DCR1ID, sep)
-	dcr1 := dcr1ID[0]
-	dcr1Version := dcr1ID[1]
+	dcr1, dcr1Version := splitMinerID(dcr1ID)
 	r = SubscribeRequest(&id, userAgent(dcr1, dcr1Version), "")
 	err = sE.Encode(r)
 	if err != nil {
@@ -573,9 +573,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 
 	id++
-	d9ID := strings.Split(D9ID, sep)
-	d9 := d9ID[0]
-	d9Version := d9ID[1]
+	d9, d9Version := splitMinerID(d9ID)
 	r = SubscribeRequest(&id, userAgent(d9, d9Version), "")
 	err = sE.Encode(r)
 	if err != nil {
@@ -612,9 +610,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 
 	id++
-	cpuID := strings.Split(CPUID, sep)
-	cpu := cpuID[0]
-	cpuVersion := cpuID[1]
+	cpu, cpuVersion := splitMinerID(cpuID)
 	r = SubscribeRequest(&id, userAgent(cpu, cpuVersion), "")
 	err = sE.Encode(r)
 	if err != nil {
@@ -1472,10 +1468,7 @@ func testClientTimeRolledWork(t *testing.T) {
 	// Ensure a CPU client receives a valid non-error response when
 	// a valid subscribe request is sent.
 	id++
-	sep := "/"
-	cpuID := strings.Split(CPUID, sep)
-	cpu := cpuID[0]
-	cpuVersion := cpuID[1]
+	cpu, cpuVersion := splitMinerID(cpuID)
 	r = SubscribeRequest(&id, userAgent(cpu, cpuVersion), "")
 	err = sE.Encode(r)
 	if err != nil {
@@ -1579,7 +1572,7 @@ func testClientUpgrades(t *testing.T) {
 	}
 
 	minerIdx := 0
-	idPair := minerIDs[DR3ID]
+	idPair := minerIDs[dr3ID]
 
 	// Trigger a client upgrade.
 	atomic.StoreInt64(&client.submissions, 50)

--- a/pool/message.go
+++ b/pool/message.go
@@ -88,12 +88,12 @@ func NewStratumError(code uint32, err error) *StratumError {
 	}
 }
 
-// MashalJSON marshals the stratum error into valid JSON.
+// MarshalJSON marshals the stratum error into valid JSON.
 func (s *StratumError) MarshalJSON() ([]byte, error) {
 	return json.Marshal([]interface{}{s.Code, s.Message, s.Traceback})
 }
 
-// MashalJSON unmarshals the provided JSON bytes into a stratum error.
+// UnmarshalJSON unmarshals the provided JSON bytes into a stratum error.
 func (s *StratumError) UnmarshalJSON(p []byte) error {
 	var tmp []interface{}
 	if err := json.Unmarshal(p, &tmp); err != nil {

--- a/pool/miner_id.go
+++ b/pool/miner_id.go
@@ -14,12 +14,12 @@ var (
 	// These miner ids represent the expected identifications returned by
 	// supported miners in their mining.subscribe requests.
 
-	CPUID  = "cpuminer/1.0.0"
-	DCR1ID = "cgminer/4.10.0"
-	D9ID   = "sgminer/4.4.2"
-	DR3ID  = "cgminer/4.9.0"
-	D1ID   = "whatsminer/d1-v1.0"
-	NHID   = "NiceHash/1.0.0"
+	cpuID  = "cpuminer/1.0.0"
+	dcr1ID = "cgminer/4.10.0"
+	d9ID   = "sgminer/4.4.2"
+	dr3ID  = "cgminer/4.9.0"
+	d1ID   = "whatsminer/d1-v1.0"
+	nhID   = "NiceHash/1.0.0"
 )
 
 // minerIDPair represents miner subscription identification pairing
@@ -45,12 +45,12 @@ func newMinerIDPair(id string, miners ...string) *minerIDPair {
 // generateMinerIDs creates the miner id pairings for all supported miners.
 func generateMinerIDs() map[string]*minerIDPair {
 	ids := make(map[string]*minerIDPair)
-	cpu := newMinerIDPair(CPUID, CPU)
-	obelisk := newMinerIDPair(DCR1ID, ObeliskDCR1)
-	innosilicon := newMinerIDPair(D9ID, InnosiliconD9)
-	antminer := newMinerIDPair(DR3ID, AntminerDR3, AntminerDR5)
-	whatsminer := newMinerIDPair(D1ID, WhatsminerD1)
-	nicehash := newMinerIDPair(NHID, NiceHashValidator)
+	cpu := newMinerIDPair(cpuID, CPU)
+	obelisk := newMinerIDPair(dcr1ID, ObeliskDCR1)
+	innosilicon := newMinerIDPair(d9ID, InnosiliconD9)
+	antminer := newMinerIDPair(dr3ID, AntminerDR3, AntminerDR5)
+	whatsminer := newMinerIDPair(d1ID, WhatsminerD1)
+	nicehash := newMinerIDPair(nhID, NiceHashValidator)
 
 	ids[cpu.id] = cpu
 	ids[obelisk.id] = obelisk

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -43,7 +43,7 @@ fi
 golangci-lint run --disable-all --deadline=10m \
   --out-format=$OUT_FORMAT \
   --enable=gofmt \
-  --enable=golint \
+  --enable=revive \
   --enable=vet \
   --enable=gosimple \
   --enable=unconvert \


### PR DESCRIPTION
Linter `golint` has been deprecated and replaced with `revive`.