### PR TITLE
multi: use getTransaction grpc for confirmCoinbases. 

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -132,6 +132,9 @@ const (
 	// PublishTx indicates a transaction pubishing error.
 	PublishTx = ErrorKind("PublishTx")
 
+	// FetchTx indicates a fetch transaction error.
+	FetchTx = ErrorKind("FetchTx")
+
 	// TxOut indicates a transaction output related error.
 	TxOut = ErrorKind("TxOut")
 

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -54,6 +54,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{CreateTx, "CreateTx"},
 		{SignTx, "SignTx"},
 		{PublishTx, "PublishTx"},
+		{FetchTx, "FetchTx"},
 		{TxOut, "TxOut"},
 		{TxIn, "TxIn"},
 		{ContextCancelled, "ContextCancelled"},

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -153,6 +153,14 @@ func (t *tWalletConnection) Rescan(context.Context, *walletrpc.RescanRequest, ..
 	return client, nil
 }
 
+func (t *tWalletConnection) GetTransaction(context.Context, *walletrpc.GetTransactionRequest, ...grpc.CallOption) (*walletrpc.GetTransactionResponse, error) {
+	return &walletrpc.GetTransactionResponse{
+		Transaction:   &walletrpc.TransactionDetails{},
+		Confirmations: 25,
+		BlockHash:     zeroHash[:],
+	}, nil
+}
+
 type tNodeConnection struct{}
 
 func (t *tNodeConnection) CreateRawTransaction(context.Context, []chainjson.TransactionInput, map[dcrutil.Address]dcrutil.Amount, *int64, *int64) (*wire.MsgTx, error) {


### PR DESCRIPTION
This reworks coinbase confirmation function to uses the getTransaction grpc to fetch transaction details and confirm them. The rescan begin height is now a coinbase maturity length of blocks from the lowest reported block with a tx having inaccurate confirmation information. Tests have been updated.

