### PR TITLE
Use go 1.16 features

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.15, 1.16]
+        go: [1.16, 1.17]
 
     services:
       postgres:
@@ -30,13 +30,9 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
       - name: Build
-        env:
-          GO111MODULE: "on"
         run: go build ./...
       - name: Test
-        env:
-          GO111MODULE: "on"
         run: |
           ./run_tests.sh

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mining, a certificate from an authority (`CA`) like
 
 Building or updating from source requires the following build dependencies:
 
-- **Go 1.14 or later**
+- **Go 1.16 or later**
 
   Installation instructions can be found here: <https://golang.org/doc/install>.
   It is recommended to add `$GOPATH/bin` to your `PATH` at this point.
@@ -64,13 +64,10 @@ Building or updating from source requires the following build dependencies:
   Installation instructions can be found at <https://git-scm.com> or
   <https://gitforwindows.org>.
 
-To build and install from a checked-out repo or a copy of the latest release, 
-run `go install . ./cmd/...` in the root directory.  Some notes:
-
-- Set the `GO111MODULE=on` environment variable.
-
-- The `dcrpool` executable will be installed to `$GOPATH/bin`.  `GOPATH`
-  defaults to `$HOME/go` (or `%USERPROFILE%\go` on Windows) if unset.
+To build and install from a checked-out repo or a copy of the latest release,
+run `go install . ./cmd/...` in the root directory.
+The `dcrpool` executable will be installed to `$GOPATH/bin`.  `GOPATH` defaults
+to `$HOME/go` (or `%USERPROFILE%\go` on Windows) if unset.
 
 ## Database
 

--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 	"crypto/elliptic"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -242,10 +241,10 @@ func genCertPair(certFile, keyFile string) error {
 	}
 
 	// Write cert and key files.
-	if err = ioutil.WriteFile(certFile, cert, 0644); err != nil {
+	if err = os.WriteFile(certFile, cert, 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(keyFile, key, 0600); err != nil {
+	if err = os.WriteFile(keyFile, key, 0600); err != nil {
 		os.Remove(certFile)
 		return err
 	}
@@ -770,7 +769,7 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	cfg.dcrdRPCCerts, err = ioutil.ReadFile(cfg.DcrdRPCCert)
+	cfg.dcrdRPCCerts, err = os.ReadFile(cfg.DcrdRPCCert)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pool/boltupgrades_test.go
+++ b/pool/boltupgrades_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +35,7 @@ var boltDBUpgradeTests = [...]struct {
 func TestBoltDBUpgrades(t *testing.T) {
 	t.Parallel()
 
-	d, err := ioutil.TempDir("", "dcrpool_test_upgrades")
+	d, err := os.MkdirTemp("", "dcrpool_test_upgrades")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pool/db_test.go
+++ b/pool/db_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -163,7 +163,7 @@ func Test_BoltDB_HttpBackup(t *testing.T) {
 	}
 
 	// Check reported length matches actual.
-	body, err := ioutil.ReadAll(rr.Result().Body)
+	body, err := io.ReadAll(rr.Result().Body)
 	if err != nil {
 		t.Fatalf("could not read http response body: %v", err)
 	}

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -13,9 +13,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -370,7 +370,7 @@ func (h *Hub) Connect(ctx context.Context) error {
 	// mining as a publicly available mining pool.
 	if !h.cfg.SoloPool {
 		serverCAs := x509.NewCertPool()
-		serverCert, err := ioutil.ReadFile(h.cfg.WalletRPCCert)
+		serverCert, err := os.ReadFile(h.cfg.WalletRPCCert)
 		if err != nil {
 			return err
 		}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 The Decred developers
+# Copyright (c) 2020-2021 The Decred developers
 # Use of this source code is governed by an ISC
 # license that can be found in the LICENSE file.
 #
@@ -15,16 +15,7 @@
 
 set -ex
 
-# run `go mod download` and `go mod tidy` and fail if the git status of
-# go.mod and/or go.sum changes
-MOD_STATUS=$(git status --porcelain go.mod go.sum)
-go mod download
-go mod tidy
-UPDATED_MOD_STATUS=$(git status --porcelain go.mod go.sum)
-if [ "$UPDATED_MOD_STATUS" != "$MOD_STATUS" ]; then
-    echo "Running `go mod tidy` modified go.mod and/or go.sum"
-    exit 1
-fi
+go version
 
 # run tests
 env GORACE="halt_on_error=1" go test -race ./...


### PR DESCRIPTION
Now that Go 1.16 is the minimum supported version, we can take advantage of new features introduced in 1.16.

- Use features from Go 1.16 tooling
    - GO111MODULE environment variable now defaults to "on"
    - "go build" and "go test" now exit with an error rather than silently modifying go.mod or go.sum files
    - Update README.md
    - Use latest linter

- Don't use deprecated ioutil package