### PR TITLE
multi: fix pruning work for reorged blocks.

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -91,6 +91,9 @@ const (
 	// BlockConf indicates a block confirmation error.
 	BlockConf = ErrorKind("BlockConf")
 
+	// BlockNotFound indicates a block not found error.
+	BlockNotFound = ErrorKind("BlockNotFound")
+
 	// ClaimShare indicates a share claim error.
 	ClaimShare = ErrorKind("ClaimShare")
 

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -41,6 +41,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{HexLength, "HexLength"},
 		{TxConf, "TxConf"},
 		{BlockConf, "BlockConf"},
+		{BlockNotFound, "BlockNotFound"},
 		{ClaimShare, "ClaimShare"},
 		{LimitExceeded, "LimitExceeded"},
 		{LowDifficulty, "LowDifficulty"},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	decred.org/dcrwallet v1.6.0-rc1
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
 	github.com/decred/dcrd/certgen v1.1.1
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,9 @@ github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0/go.mod h1:t2qaZ3hNnxHZ5kz
 github.com/decred/dcrd/blockchain/v3 v3.0.0/go.mod h1:LD5VA95qdb+DlRiPI8VLBimDqvlDCAJsidZ5oD6nc/U=
 github.com/decred/dcrd/certgen v1.1.1 h1:MYPG5jCysnbF4OiJ1++YumFEu2p/MsM/zxmmqC9mVFg=
 github.com/decred/dcrd/certgen v1.1.1/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyLRN07EO0cNBV6DGU=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.3 h1:PF2czcYZGW3dz4i/35AUfVAgnqHl9TMNQt1ADTYGOoE=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.3/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/chaincfg/v3 v3.0.0 h1:+TFbu7ZmvBwM+SZz5mrj6cun9ts/6DAL5sqnsaFBHGQ=
 github.com/decred/dcrd/chaincfg/v3 v3.0.0/go.mod h1:EspyubQ7D2w6tjP7rBGDIE7OTbuMgBjR2F2kZFnh31A=
 github.com/decred/dcrd/connmgr/v3 v3.0.0/go.mod h1:cPI43Aggp1lOhrVG75eJ3c3BwuFx0NhT77FK34ky+ak=

--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -119,7 +119,11 @@ func (cs *ChainState) pruneAcceptedWork(ctx context.Context, height uint32) erro
 		}
 		confs, err := cs.cfg.GetBlockConfirmations(ctx, hash)
 		if err != nil {
-			return err
+			// Do not error if the block being pruned cannot be found. It
+			// most likely got reorged off the chain.
+			if !errors.Is(err, errs.BlockNotFound) {
+				return err
+			}
 		}
 
 		// If the block has no confirmations at the current height,


### PR DESCRIPTION
This fixes a case where confirmations for a block having associated work cannot be found because it got reorged off the chain. The fix modifies the check to not error if the rpc error indicates the block cannot be found.