### PR TITLE
multi: Wrap errors for better errors.Is/As support.

### DIFF
--- a/config.go
+++ b/config.go
@@ -513,7 +513,7 @@ func loadConfig() (*config, []string, error) {
 		err = preIni.WriteFile(preCfg.ConfigFile,
 			flags.IniIncludeComments|flags.IniIncludeDefaults)
 		if err != nil {
-			err = fmt.Errorf("error creating a default config file: %v", err)
+			err = fmt.Errorf("error creating a default config file: %w", err)
 			fmt.Fprintln(os.Stderr, err)
 			return nil, nil, err
 		}
@@ -786,7 +786,7 @@ func loadConfig() (*config, []string, error) {
 		// Ensure the profiling address is a valid tcp address.
 		_, portStr, err := net.SplitHostPort(cfg.Profile)
 		if err != nil {
-			err := fmt.Errorf("invalid profile address: %s", err)
+			err := fmt.Errorf("invalid profile address: %w", err)
 			fmt.Fprintln(os.Stderr, err)
 			fmt.Fprintln(os.Stderr, usageMessage)
 			return nil, nil, err

--- a/dcrpool.go
+++ b/dcrpool.go
@@ -75,12 +75,12 @@ func newPool(db pool.Database, cfg *config) (*miningPool, error) {
 	var err error
 	p.hub, err = pool.NewHub(p.cancel, hcfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize hub: %v", err)
+		return nil, fmt.Errorf("unable to initialize hub: %w", err)
 	}
 
 	err = p.hub.Connect(p.ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to establish node connections: %v", err)
+		return nil, fmt.Errorf("unable to establish node connections: %w", err)
 	}
 
 	err = p.hub.FetchWork(p.ctx)

--- a/pool/boltupgrades_test.go
+++ b/pool/boltupgrades_test.go
@@ -97,7 +97,7 @@ func verifyV2Upgrade(t *testing.T, db *BoltDB) {
 			var share Share
 			err := json.Unmarshal(v, &share)
 			if err != nil {
-				return fmt.Errorf("%s: unable to unmarshal share: %v",
+				return fmt.Errorf("%s: unable to unmarshal share: %w",
 					funcName, err)
 			}
 
@@ -133,7 +133,7 @@ func verifyV3Upgrade(t *testing.T, db *BoltDB) {
 			var payment Payment
 			err := json.Unmarshal(v, &payment)
 			if err != nil {
-				return fmt.Errorf("%s: unable to unmarshal payment: %v",
+				return fmt.Errorf("%s: unable to unmarshal payment: %w",
 					funcName, err)
 			}
 
@@ -161,7 +161,7 @@ func verifyV3Upgrade(t *testing.T, db *BoltDB) {
 			var payment Payment
 			err := json.Unmarshal(v, &payment)
 			if err != nil {
-				return fmt.Errorf("%s: unable to unmarshal payment: %v",
+				return fmt.Errorf("%s: unable to unmarshal payment: %w",
 					funcName, err)
 			}
 
@@ -224,7 +224,7 @@ func verifyV5Upgrade(t *testing.T, db *BoltDB) {
 			var share Share
 			err := json.Unmarshal(v, &share)
 			if err != nil {
-				return fmt.Errorf("%s: unable to unmarshal share: %v",
+				return fmt.Errorf("%s: unable to unmarshal share: %w",
 					funcName, err)
 			}
 
@@ -269,7 +269,7 @@ func verifyV6Upgrade(t *testing.T, db *BoltDB) {
 			var pmt Payment
 			err := json.Unmarshal(v, &pmt)
 			if err != nil {
-				return fmt.Errorf("%s: unable to unmarshal payment: %v",
+				return fmt.Errorf("%s: unable to unmarshal payment: %w",
 					funcName, err)
 			}
 
@@ -295,7 +295,7 @@ func verifyV6Upgrade(t *testing.T, db *BoltDB) {
 			var pmt Payment
 			err := json.Unmarshal(v, &pmt)
 			if err != nil {
-				return fmt.Errorf("%s: unable to unmarshal archived payment: %v",
+				return fmt.Errorf("%s: unable to unmarshal archived payment: %w",
 					funcName, err)
 			}
 

--- a/pool/client.go
+++ b/pool/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 The Decred developers
+// Copyright (c) 2019-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -581,7 +581,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 	if !c.cfg.SoloPool {
 		err := c.claimWeightedShare()
 		if err != nil {
-			err := fmt.Errorf("%s: %v", id, err)
+			err := fmt.Errorf("%s: %w", id, err)
 			sErr := NewStratumError(Unknown, err)
 			resp := SubmitWorkResponse(*req.ID, false, sErr)
 			c.ch <- resp

--- a/pool/db_test.go
+++ b/pool/db_test.go
@@ -81,15 +81,14 @@ func Test_BoltDB_FetchBucketHelpers(t *testing.T) {
 		if pbkt == nil {
 			pbkt, err = tx.CreateBucketIfNotExists(poolBkt)
 			if err != nil {
-				return fmt.Errorf("unable to create %s bucket: %v",
+				return fmt.Errorf("unable to create %s bucket: %w",
 					string(poolBkt), err)
-
 			}
 			vbytes := make([]byte, 4)
 			binary.LittleEndian.PutUint32(vbytes, BoltDBVersion)
 			err = pbkt.Put(versionK, vbytes)
 			if err != nil {
-				return fmt.Errorf("unable to persist version: %v", err)
+				return fmt.Errorf("unable to persist version: %w", err)
 			}
 		}
 		return nil

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -296,7 +296,7 @@ func NewHub(cancel context.CancelFunc, hcfg *HubConfig) (*Hub, error) {
 		if errors.Is(err, errs.ValueNotFound) {
 			err = hcfg.DB.persistPoolMode(cfgMode)
 			if err != nil {
-				return nil, fmt.Errorf("failed to persist pool mode: %v", err)
+				return nil, fmt.Errorf("failed to persist pool mode: %w", err)
 			}
 			dbMode = cfgMode
 		} else {
@@ -383,7 +383,7 @@ func (h *Hub) Connect(ctx context.Context) error {
 		keypair, err := tls.LoadX509KeyPair(h.cfg.WalletTLSCert,
 			h.cfg.WalletTLSKey)
 		if err != nil {
-			return fmt.Errorf("unable to read keypair: %v", err)
+			return fmt.Errorf("unable to read keypair: %w", err)
 		}
 		creds := credentials.NewTLS(&tls.Config{
 			Certificates: []tls.Certificate{keypair},


### PR DESCRIPTION
This updates all remaining cases of unwrapped errors in `fmt.Errorf` calls to wrap the underlying errors with the `%w` format verb to ensure they work nicely with `errors.Is` and `errors.As`.
