### PR TITLE
pool: Keep hub waitgroup local.

### DIFF
--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -45,8 +45,6 @@ type ChainStateConfig struct {
 	Cancel context.CancelFunc
 	// SignalCache sends the provided cache update event to the gui cache.
 	SignalCache func(event CacheUpdateEvent)
-	// HubWg represents the hub's waitgroup.
-	HubWg *sync.WaitGroup
 }
 
 // blockNotification wraps a block header notification and a done channel.
@@ -201,7 +199,6 @@ func (cs *ChainState) handleChainUpdates(ctx context.Context) {
 		case <-ctx.Done():
 			close(cs.discCh)
 			close(cs.connCh)
-			cs.cfg.HubWg.Done()
 			return
 
 		case msg := <-cs.connCh:

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -82,7 +82,6 @@ func testChainState(t *testing.T) {
 		GetBlockConfirmations: getBlockConfirmations,
 		SignalCache:           signalCache,
 		Cancel:                cancel,
-		HubWg:                 new(sync.WaitGroup),
 	}
 
 	cs := NewChainState(cCfg)
@@ -230,8 +229,12 @@ func testChainState(t *testing.T) {
 
 	cs.cfg.GetBlock = getBlock
 
-	cCfg.HubWg.Add(1)
-	go cs.handleChainUpdates(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		cs.handleChainUpdates(ctx)
+		wg.Done()
+	}()
 
 	// Create the accepted work to be confirmed.
 	work := NewAcceptedWork(
@@ -389,5 +392,5 @@ func testChainState(t *testing.T) {
 	}
 
 	cancel()
-	cs.cfg.HubWg.Wait()
+	wg.Wait()
 }

--- a/pool/endpoint.go
+++ b/pool/endpoint.go
@@ -36,8 +36,6 @@ type EndpointConfig struct {
 	MaxConnectionsPerHost uint32
 	// MaxGenTime represents the share creation target time for the pool.
 	MaxGenTime time.Duration
-	// HubWg represents the hub's waitgroup.
-	HubWg *sync.WaitGroup
 	// FetchMinerDifficulty returns the difficulty information for the
 	// provided miner if it exists.
 	FetchMinerDifficulty func(string) (*DifficultyInfo, error)
@@ -215,7 +213,6 @@ func (e *Endpoint) disconnect(ctx context.Context) {
 			e.clientsMtx.Unlock()
 
 			e.wg.Done()
-			e.cfg.HubWg.Done()
 			return
 
 		case <-e.discCh:

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -117,8 +117,6 @@ type PaymentMgrConfig struct {
 	CoinbaseConfTimeout time.Duration
 	// SignalCache sends the provided cache update event to the gui cache.
 	SignalCache func(event CacheUpdateEvent)
-	// HubWg represents the hub's waitgroup.
-	HubWg *sync.WaitGroup
 }
 
 // paymentMsg represents a payment processing signal.
@@ -942,11 +940,11 @@ func (pm *PaymentMgr) processPayments(msg *paymentMsg) {
 }
 
 // handlePayments processes dividend payment signals.
+// This MUST be run as a goroutine.
 func (pm *PaymentMgr) handlePayments(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			pm.cfg.HubWg.Done()
 			return
 
 		case msg := <-pm.paymentCh:


### PR DESCRIPTION
The waitgroup for the hub is currently being passed down into all various configuration structs for each of the goroutines it runs which requires a lot of plumbing and is quite error prone.

This addresses that by modifying the logic to keep the hub waitgroup local to the run method and removes the aforementioned unnecessary plumbing.

These changes have also exposed an issue with endpoint.run in that it never terminates, but this commit does not fix that issue.