### PR TITLE
pool: Correct endpoint waitgroup logic.

### DIFF
--- a/pool/endpoint_test.go
+++ b/pool/endpoint_test.go
@@ -83,7 +83,6 @@ func testEndpoint(t *testing.T) {
 		t.Fatalf("[NewEndpoint] unexpected error: %v", err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	endpoint.wg.Add(1)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -235,7 +234,5 @@ func testEndpoint(t *testing.T) {
 	defer conn.Close()
 
 	cancel()
-	// TODO: This never finishes because endpoint.run never actually finishes
-	// due to the internal waitgroup not being handled properly.
-	// wg.Wait()
+	wg.Wait()
 }


### PR DESCRIPTION
**This requires #358**.

This corrects the waitgroup logic in endpoint handling to ensure it properly terminates when the context is canceled.

It also enables the wait at the end of the endpoint test to help prove correctness.
