### PR TITLE
pool: Use bitlen for calculating iterations.

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -38,9 +37,7 @@ func newHub(cfg *config, db pool.Database, cancel context.CancelFunc) (*pool.Hub
 		Pass:         cfg.RPCPass,
 		Certificates: cfg.dcrdRPCCerts,
 	}
-	powLimit := cfg.net.PowLimit
-	powLimitF, _ := new(big.Float).SetInt(powLimit).Float64()
-	iterations := math.Pow(2, 256-math.Floor(math.Log2(powLimitF)))
+	iterations := math.Pow(2, float64(256-cfg.net.PowLimit.BitLen()))
 
 	hcfg := &pool.HubConfig{
 		DB:                    db,

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -30,14 +30,13 @@ var (
 	currentWork    string
 	currentWorkMtx sync.RWMutex
 
-	powLimit     = chaincfg.SimNetParams().PowLimit
-	powLimitF, _ = new(big.Float).SetInt(powLimit).Float64()
-	iterations   = math.Pow(2, 256-math.Floor(math.Log2(powLimitF)))
-	blake256Pad  = generateBlake256Pad()
-	maxGenTime   = time.Millisecond * 500
-	cTimeout     = time.Millisecond * 2000
-	hashCalcMax  = time.Millisecond * 1500
-	poolDiffs    = NewDifficultySet(chaincfg.SimNetParams(),
+	powLimit    = chaincfg.SimNetParams().PowLimit
+	iterations  = math.Pow(2, float64(256-powLimit.BitLen()))
+	blake256Pad = generateBlake256Pad()
+	maxGenTime  = time.Millisecond * 500
+	cTimeout    = time.Millisecond * 2000
+	hashCalcMax = time.Millisecond * 1500
+	poolDiffs   = NewDifficultySet(chaincfg.SimNetParams(),
 		new(big.Rat).SetInt(powLimit), maxGenTime)
 	config = &ClientConfig{
 		ActiveNet:       chaincfg.SimNetParams(),

--- a/pool/difficulty.go
+++ b/pool/difficulty.go
@@ -62,13 +62,11 @@ func DifficultyToTarget(net *chaincfg.Params, difficulty *big.Rat) *big.Rat {
 // hashrate can generate a pool share by the provided target time.
 func calculatePoolDifficulty(net *chaincfg.Params, hashRate *big.Int, targetTimeSecs *big.Int) *big.Rat {
 	hashesPerTargetTime := new(big.Int).Mul(hashRate, targetTimeSecs)
-	powLimit := net.PowLimit
-	powLimitFloat, _ := new(big.Float).SetInt(powLimit).Float64()
 
 	// The number of possible iterations is calculated as:
 	//
 	//    iterations := 2^(256 - floor(log2(pow_limit)))
-	iterations := math.Pow(2, 256-math.Floor(math.Log2(powLimitFloat)))
+	iterations := math.Pow(2, float64(256-net.PowLimit.BitLen()))
 
 	// The difficulty at which the provided hashrate can mine a block is
 	// calculated as:

--- a/pool/endpoint_test.go
+++ b/pool/endpoint_test.go
@@ -29,8 +29,7 @@ func makeConn(listener *net.TCPListener, serverCh chan net.Conn) (net.Conn, net.
 
 func testEndpoint(t *testing.T) {
 	powLimit := chaincfg.SimNetParams().PowLimit
-	powLimitF, _ := new(big.Float).SetInt(powLimit).Float64()
-	iterations := math.Pow(2, 256-math.Floor(math.Log2(powLimitF)))
+	iterations := math.Pow(2, float64(256-powLimit.BitLen()))
 	maxGenTime := time.Second * 20
 	blake256Pad := generateBlake256Pad()
 	poolDiffs := NewDifficultySet(chaincfg.SimNetParams(),

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -281,8 +281,7 @@ func (t *tNodeConnection) Shutdown() {}
 func testHub(t *testing.T) {
 	activeNet := chaincfg.SimNetParams()
 	powLimit := chaincfg.SimNetParams().PowLimit
-	powLimitF, _ := new(big.Float).SetInt(powLimit).Float64()
-	iterations := math.Pow(2, 256-math.Floor(math.Log2(powLimitF)))
+	iterations := math.Pow(2, float64(256-powLimit.BitLen()))
 	hcfg := &HubConfig{
 		ActiveNet:             activeNet,
 		DB:                    db,


### PR DESCRIPTION
This switches the calculation for the number of iterations to use the pow limit bit length as opposed to a less accurate round trip through a log2 float64 approximation.