### PR TITLE
multi: Avoid extra chaincfg param instances.

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,7 +21,6 @@ import (
 	flags "github.com/jessevdk/go-flags"
 
 	"github.com/decred/dcrd/certgen"
-	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrpool/pool"
@@ -67,7 +66,7 @@ const (
 )
 
 var (
-	defaultActiveNet     = chaincfg.SimNetParams().Name
+	defaultActiveNet     = simNetParams.Name
 	defaultPaymentMethod = pool.PPLNS
 	dcrpoolHomeDir       = dcrutil.AppDataDir("dcrpool", false)
 	defaultConfigFile    = filepath.Join(dcrpoolHomeDir, defaultConfigFilename)
@@ -506,11 +505,11 @@ func loadConfig(appName string) (*config, []string, error) {
 
 	// Set the mining active network.
 	switch cfg.ActiveNet {
-	case chaincfg.TestNet3Params().Name:
+	case testNet3Params.Name:
 		cfg.net = &testNet3Params
-	case chaincfg.MainNetParams().Name:
+	case mainNetParams.Name:
 		cfg.net = &mainNetParams
-	case chaincfg.SimNetParams().Name:
+	case simNetParams.Name:
 		cfg.net = &simNetParams
 	default:
 		err := fmt.Errorf("%s: unknown network provided: %v", funcName,
@@ -735,7 +734,7 @@ func loadConfig(appName string) (*config, []string, error) {
 		}
 	}
 
-	if cfg.ActiveNet != chaincfg.SimNetParams().Name && cfg.PurgeDB {
+	if cfg.ActiveNet != simNetParams.Name && cfg.PurgeDB {
 		err := fmt.Errorf("%s: database purging at startup is reserved for "+
 			"simnet testing only", funcName)
 		return nil, nil, err
@@ -764,7 +763,7 @@ func loadConfig(appName string) (*config, []string, error) {
 	// Define the client timeout to be approximately four block times
 	// per the active network, except for simnet.
 	switch cfg.ActiveNet {
-	case chaincfg.TestNet3Params().Name, chaincfg.MainNetParams().Name:
+	case testNet3Params.Name, mainNetParams.Name:
 		cfg.clientTimeout = cfg.net.TargetTimePerBlock * 4
 	default:
 		cfg.clientTimeout = time.Second * 30

--- a/pool/client.go
+++ b/pool/client.go
@@ -54,6 +54,10 @@ var (
 
 	// zeroHash is the default value for a chainhash.Hash.
 	zeroHash = chainhash.Hash{0}
+
+	// mainNetName is the name of the main network.  It is stored as a variable
+	// so only a single instance creation is needed.
+	mainNetName = chaincfg.MainNetParams().Name
 )
 
 // readPayload is a convenience type that wraps a message and its
@@ -204,7 +208,7 @@ func (c *Client) claimWeightedShare() error {
 	miner := c.miner
 	c.mtx.RUnlock()
 
-	if c.cfg.ActiveNet.Name == chaincfg.MainNetParams().Name && miner == CPU {
+	if c.cfg.ActiveNet.Name == mainNetName && miner == CPU {
 		desc := "cannot claim shares for cpu miners on mainnet, " +
 			"reserved for testing purposes only (simnet, testnet)"
 		return errs.PoolError(errs.ClaimShare, desc)


### PR DESCRIPTION
The chaincfg functions to get config params create a new instance on every invocation.  This avoids extra allocations by making use of the stored instances in the main package and storing the name of mainnet (which is the only use of it) in the pool module.