### PR TITLE
multi: No string pointer on submit work.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -89,7 +89,7 @@ type ClientConfig struct {
 	// RemoveClient removes the client from the pool.
 	RemoveClient func(*Client)
 	// SubmitWork sends solved block data to the consensus daemon.
-	SubmitWork func(context.Context, *string) (bool, error)
+	SubmitWork func(context.Context, string) (bool, error)
 	// FetchCurrentWork returns the current work of the pool.
 	FetchCurrentWork func() string
 	// WithinLimit returns if the client is still within its request limits.
@@ -622,7 +622,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 	copy(submissionB[wire.MaxBlockHeaderPayload:],
 		c.cfg.Blake256Pad)
 	submission := hex.EncodeToString(submissionB)
-	accepted, err := c.cfg.SubmitWork(ctx, &submission)
+	accepted, err := c.cfg.SubmitWork(ctx, submission)
 	if err != nil {
 		sErr := NewStratumError(Unknown, err)
 		resp := SubmitWorkResponse(*req.ID, false, sErr)

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -51,7 +51,7 @@ var (
 			// Do Nothing.
 		},
 		RemoveClient: func(c *Client) {},
-		SubmitWork: func(_ context.Context, submission *string) (bool, error) {
+		SubmitWork: func(_ context.Context, submission string) (bool, error) {
 			return false, nil
 		},
 		FetchCurrentWork: func() string {
@@ -1017,7 +1017,7 @@ func testClientMessageHandling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected set miner error: %v", err)
 	}
-	client.cfg.SubmitWork = func(_ context.Context, submission *string) (bool, error) {
+	client.cfg.SubmitWork = func(_ context.Context, submission string) (bool, error) {
 		return false, fmt.Errorf("unable to submit work")
 	}
 	id++
@@ -1048,7 +1048,7 @@ func testClientMessageHandling(t *testing.T) {
 	if resp.Error == nil {
 		t.Fatalf("expected a submit work error")
 	}
-	client.cfg.SubmitWork = func(_ context.Context, submission *string) (bool, error) {
+	client.cfg.SubmitWork = func(_ context.Context, submission string) (bool, error) {
 		return true, nil
 	}
 
@@ -1115,7 +1115,7 @@ func testClientMessageHandling(t *testing.T) {
 	if resp.Error == nil {
 		t.Fatal("expected a work exists work submission error")
 	}
-	client.cfg.SubmitWork = func(_ context.Context, submission *string) (bool, error) {
+	client.cfg.SubmitWork = func(_ context.Context, submission string) (bool, error) {
 		return false, nil
 	}
 

--- a/pool/endpoint.go
+++ b/pool/endpoint.go
@@ -40,7 +40,7 @@ type EndpointConfig struct {
 	// provided miner if it exists.
 	FetchMinerDifficulty func(string) (*DifficultyInfo, error)
 	// SubmitWork sends solved block data to the consensus daemon.
-	SubmitWork func(context.Context, *string) (bool, error)
+	SubmitWork func(context.Context, string) (bool, error)
 	// FetchCurrentWork returns the current work of the pool.
 	FetchCurrentWork func() string
 	// WithinLimit returns if a client is within its request limits.

--- a/pool/endpoint_test.go
+++ b/pool/endpoint_test.go
@@ -46,7 +46,7 @@ func testEndpoint(t *testing.T) {
 		FetchMinerDifficulty: func(miner string) (*DifficultyInfo, error) {
 			return poolDiffs.fetchMinerDifficulty(miner)
 		},
-		SubmitWork: func(_ context.Context, submission *string) (bool, error) {
+		SubmitWork: func(_ context.Context, submission string) (bool, error) {
 			return false, nil
 		},
 		FetchCurrentWork: func() string {

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -418,12 +418,12 @@ func (h *Hub) Connect(ctx context.Context) error {
 }
 
 // submitWork sends solved block data to the consensus daemon for evaluation.
-func (h *Hub) submitWork(ctx context.Context, data *string) (bool, error) {
+func (h *Hub) submitWork(ctx context.Context, data string) (bool, error) {
 	if h.nodeConn == nil {
 		return false, errs.PoolError(errs.Disconnected, "node disconnected")
 	}
 
-	return h.nodeConn.GetWorkSubmit(ctx, *data)
+	return h.nodeConn.GetWorkSubmit(ctx, data)
 }
 
 // getWork fetches available work from the consensus daemon.

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -508,7 +508,7 @@ func testHub(t *testing.T) {
 	<-confNotif.Done
 
 	// Ensure the hub can process submitted work.
-	_, err = hub.submitWork(ctx, &workE)
+	_, err = hub.submitWork(ctx, workE)
 	if err != nil {
 		t.Fatalf("unexpected submit work error: %v", err)
 	}


### PR DESCRIPTION
This modifies the SubmitWork function to take the submission directly instead of a pointer to it.

Strings are already reference types, so there is no reason to take a pointer to a string unless the calee intended to change what the caller's string points at. Moreover, taking a pointer could also lead to unnecessary allocations.