### PR TITLE
multi: Zero alloc for done chans.

### DIFF
--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -50,7 +50,7 @@ type ChainStateConfig struct {
 // blockNotification wraps a block header notification and a done channel.
 type blockNotification struct {
 	Header []byte
-	Done   chan bool
+	Done   chan struct{}
 }
 
 // ChainState represents the current state of the chain.
@@ -233,7 +233,7 @@ func (cs *ChainState) handleChainUpdates(ctx context.Context) {
 				go cs.cfg.ProcessPayments(&paymentMsg{
 					CurrentHeight:  header.Height,
 					TreasuryActive: treasuryActive,
-					Done:           make(chan bool),
+					Done:           make(chan struct{}),
 				})
 			}
 

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -277,7 +277,7 @@ func testChainState(t *testing.T) {
 
 	malformedMsg := &blockNotification{
 		Header: headerMB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.connCh <- malformedMsg
 	<-malformedMsg.Done
@@ -305,13 +305,13 @@ func testChainState(t *testing.T) {
 
 	minedMsg := &blockNotification{
 		Header: minedHeaderB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.connCh <- minedMsg
 	<-minedMsg.Done
 	confMsg := &blockNotification{
 		Header: confHeaderB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.connCh <- confMsg
 	<-confMsg.Done
@@ -328,13 +328,13 @@ func testChainState(t *testing.T) {
 
 	discConfMsg := &blockNotification{
 		Header: confHeaderB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.discCh <- discConfMsg
 	<-discConfMsg.Done
 	discMinedMsg := &blockNotification{
 		Header: minedHeaderB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.discCh <- discMinedMsg
 	<-discMinedMsg.Done
@@ -353,20 +353,20 @@ func testChainState(t *testing.T) {
 	// process.
 	malformedMsg = &blockNotification{
 		Header: headerMB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.discCh <- malformedMsg
 	<-malformedMsg.Done
 
 	confMsg = &blockNotification{
 		Header: confHeaderB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.connCh <- confMsg
 	<-confMsg.Done
 	discConfMsg = &blockNotification{
 		Header: confHeaderB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	cs.discCh <- discConfMsg
 	<-discConfMsg.Done

--- a/pool/endpoint.go
+++ b/pool/endpoint.go
@@ -66,7 +66,7 @@ type EndpointConfig struct {
 // connection wraps a client connection and a done channel.
 type connection struct {
 	Conn net.Conn
-	Done chan bool
+	Done chan struct{}
 }
 
 // Endpoint represents a stratum endpoint.
@@ -129,7 +129,7 @@ func (e *Endpoint) listen(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case e.connCh <- &connection{Conn: conn, Done: make(chan bool)}:
+		case e.connCh <- &connection{Conn: conn, Done: make(chan struct{})}:
 		}
 	}
 }

--- a/pool/endpoint_test.go
+++ b/pool/endpoint_test.go
@@ -129,7 +129,7 @@ func testEndpoint(t *testing.T) {
 	defer srvA.Close()
 	msgA := &connection{
 		Conn: connA,
-		Done: make(chan bool),
+		Done: make(chan struct{}),
 	}
 	endpoint.connCh <- msgA
 	<-msgA.Done
@@ -156,7 +156,7 @@ func testEndpoint(t *testing.T) {
 	defer srvB.Close()
 	msgB := &connection{
 		Conn: connB,
-		Done: make(chan bool),
+		Done: make(chan struct{}),
 	}
 	endpoint.connCh <- msgB
 	<-msgB.Done
@@ -168,7 +168,7 @@ func testEndpoint(t *testing.T) {
 	defer srvC.Close()
 	msgC := &connection{
 		Conn: connC,
-		Done: make(chan bool),
+		Done: make(chan struct{}),
 	}
 	endpoint.connCh <- msgC
 	<-msgC.Done
@@ -189,7 +189,7 @@ func testEndpoint(t *testing.T) {
 	defer srvD.Close()
 	msgD := &connection{
 		Conn: connD,
-		Done: make(chan bool),
+		Done: make(chan struct{}),
 	}
 	endpoint.connCh <- msgD
 	<-msgD.Done

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -564,13 +564,13 @@ func (h *Hub) createNotificationHandlers() *rpcclient.NotificationHandlers {
 		OnBlockConnected: func(headerB []byte, transactions [][]byte) {
 			h.chainState.connCh <- &blockNotification{
 				Header: headerB,
-				Done:   make(chan bool),
+				Done:   make(chan struct{}),
 			}
 		},
 		OnBlockDisconnected: func(headerB []byte) {
 			h.chainState.discCh <- &blockNotification{
 				Header: headerB,
-				Done:   make(chan bool),
+				Done:   make(chan struct{}),
 			}
 		},
 		OnWork: func(headerB []byte, target []byte, reason string) {

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -455,7 +455,7 @@ func testHub(t *testing.T) {
 
 	msgA := &connection{
 		Conn: conn,
-		Done: make(chan bool),
+		Done: make(chan struct{}),
 	}
 	hub.endpoint.connCh <- msgA
 	<-msgA.Done
@@ -502,7 +502,7 @@ func testHub(t *testing.T) {
 	}
 	confNotif := &blockNotification{
 		Header: headerB,
-		Done:   make(chan bool),
+		Done:   make(chan struct{}),
 	}
 	hub.chainState.connCh <- confNotif
 	<-confNotif.Done

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -123,7 +123,7 @@ type PaymentMgrConfig struct {
 type paymentMsg struct {
 	CurrentHeight  uint32
 	TreasuryActive bool
-	Done           chan bool
+	Done           chan struct{}
 }
 
 // PaymentMgr handles generating shares and paying out dividends to

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -1500,7 +1500,7 @@ func testPaymentMgrSignals(t *testing.T) {
 	msgA := paymentMsg{
 		CurrentHeight:  estMaturity + 1,
 		TreasuryActive: false,
-		Done:           make(chan bool),
+		Done:           make(chan struct{}),
 	}
 
 	var wg sync.WaitGroup
@@ -1534,7 +1534,7 @@ func testPaymentMgrSignals(t *testing.T) {
 	msgB := paymentMsg{
 		CurrentHeight:  estMaturity + 1,
 		TreasuryActive: false,
-		Done:           make(chan bool),
+		Done:           make(chan struct{}),
 	}
 	mgr.processPayments(&msgB)
 	<-msgB.Done


### PR DESCRIPTION
**This requires #359**.

Since the done channels are only used to signal completion by closing the channel, use a zero alloc `struct{}` for the type.