### PR TITLE
pool: Check ctx before sending to channel.

### DIFF
--- a/pool/hub.go
+++ b/pool/hub.go
@@ -553,11 +553,7 @@ func (h *Hub) processWork(headerE string) {
 		blockVersion, nBits, nTime, true)
 	h.endpoint.clientsMtx.Lock()
 	for _, client := range h.endpoint.clients {
-		select {
-		case client.ch <- workNotif:
-		default:
-			// Non-blocking send fallthrough.
-		}
+		client.sendMessage(workNotif)
 	}
 	h.endpoint.clientsMtx.Unlock()
 }


### PR DESCRIPTION
Check if the context is canceled before blindly sending to a channel which could be closed.