### PR TITLE
gui: Rework create and run lifecycles.

### DIFF
--- a/internal/gui/cache.go
+++ b/internal/gui/cache.go
@@ -89,19 +89,45 @@ type Cache struct {
 	lastPaymentInfoMtx    sync.RWMutex
 }
 
-// InitCache initialises and returns a cache for use in the GUI.
-func InitCache(work []*pool.AcceptedWork, quotas []*pool.Quota,
-	hashData map[string][]*pool.HashData, pendingPmts []*pool.Payment,
-	archivedPmts []*pool.Payment, blockExplorerURL string,
-	lastPmtHeight uint32, lastPmtPaidOn, lastPmtCreatedOn int64) *Cache {
+// initCache initialises and returns a cache for use in the GUI.
+func initCache(cfg *Config) (*Cache, error) {
+	work, err := cfg.FetchMinedWork()
+	if err != nil {
+		return nil, err
+	}
 
-	cache := Cache{blockExplorerURL: blockExplorerURL}
+	quotas, err := cfg.FetchWorkQuotas()
+	if err != nil {
+		return nil, err
+	}
+
+	hashData, err := cfg.FetchHashData()
+	if err != nil {
+		return nil, err
+	}
+
+	pendingPmts, err := cfg.FetchPendingPayments()
+	if err != nil {
+		return nil, err
+	}
+
+	archivedPmts, err := cfg.FetchArchivedPayments()
+	if err != nil {
+		return nil, err
+	}
+
+	lastPmtHeight, lastPmtPaidOn, lastPmtCreatedOn, err := cfg.FetchLastPaymentInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	cache := Cache{blockExplorerURL: cfg.BlockExplorerURL}
 	cache.updateMinedWork(work)
 	cache.updateRewardQuotas(quotas)
 	cache.updateHashData(hashData)
 	cache.updatePayments(pendingPmts, archivedPmts)
 	cache.updateLastPaymentInfo(lastPmtHeight, lastPmtPaidOn, lastPmtCreatedOn)
-	return &cache
+	return &cache, nil
 }
 
 // min returns the smaller of the two provided integers.


### PR DESCRIPTION
**This requires #370**.

This consists of a series of commits that ultimately make the gui webserver respect the context and perform an orderly shutdown when it is canceled as well 

* First, it consolidates the logic that creates the GUI instance.

  It's generally good practice to first create everything that can fail and then create the final instance at once with the results versus doing it piecemeal.

  Piecemeal creation is typically more error prone and, while not a huge concern here, it also ends up needlessly creating objects that are just thrown away in the event of a later error.

* Second, it initializes the cache when GUI is created.

  It accomplishes this by updating the init func to accept the config instead of individual components and moving the logic that acquires the details via the config from the `Run` method into it.

  It also unexports the `InitCache` method since it is only ever used internal to the `gui` package.

  Not only does it further consolidate the creation logic in one place, it also exposes any errors back to the main thread when the pool is first initializing so any issues can be corrected immediately.

* Third, it splits out the code that periodically updates the cache and notifies websocket clients into a separate method that is invoked by `Run` and introduces a waitgroup for it.

* Fourth, itm oves the code that starts the webserver listeners into a separate method that is invoked by `Run` and removes the `server` field from the GUI type since it is only needed locally in the new method.

* Finally, it makes the webserver respect the context so it is shutdown in an orderly fashion when the context is canceled and updates the gui `Run` method to add the goroutine to the waitgroup now that it will be shutdown as expected.