### PR TITLE
pool: Add missing response to subscribe handler.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -394,6 +394,9 @@ func (c *Client) handleSubscribeRequest(req *Request, allowed bool) error {
 	info, err := c.cfg.FetchMinerDifficulty(miner)
 	if err != nil {
 		c.mtx.Unlock()
+		sErr := NewStratumError(Unknown, err)
+		resp := SubscribeResponse(*req.ID, "", "", 0, sErr)
+		c.sendMessage(resp)
 		return err
 	}
 	c.miner = miner


### PR DESCRIPTION
The handler for subscribe requests seemed to have incomplete error handling for the case where FetchMinerDifficulty failed. No response was being returned to the caller.

This adds a generic Unknown error response so that the caller is not left hanging.