### PR TITLE
pool: Consolidate waitgroup logic.

### DIFF
--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -397,7 +398,12 @@ func testHub(t *testing.T) {
 			" than account x's work quota")
 	}
 
-	go hub.Run(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		hub.Run(ctx)
+		wg.Done()
+	}()
 
 	// Create the mined work to be confirmed.
 	work := NewAcceptedWork(
@@ -534,5 +540,5 @@ func testHub(t *testing.T) {
 	}
 
 	cancel()
-	hub.wg.Wait()
+	wg.Wait()
 }


### PR DESCRIPTION
This switches client, hub, endpoint over to use the new pattern that consolidates the waitgroup logic in a single location.

This pattern is easier to reason about and less error prone since it's trivial to see at a glance that the calls to `Done` are happening as intended versus having to chase them down all over the code.