### PR TITLE
gui: Create listener in GUI constructor.

### DIFF
--- a/dcrpool.go
+++ b/dcrpool.go
@@ -109,7 +109,7 @@ func newGUI(cfg *config, hub *pool.Hub) (*gui.GUI, error) {
 		gcfg.HTTPBackupDB = hub.HTTPBackupDB
 	}
 
-	return gui.NewGUI(gcfg)
+	return gui.New(gcfg)
 }
 
 // realMain is the real main function for dcrpool.  It is necessary to work


### PR DESCRIPTION
This creates the listener in the GUI constructor so any issues with listening will cause the entire pool to fail to start thereby allowing the admin to resolve any issues immediately.