### PR TITLE
docs: Update postgres guide with tested new vers.

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,33 +1,29 @@
 # Running dcrpool with PostgreSQL
 
-Tested with PostgreSQL 13.0.
+Tested with PostgreSQL 13.0, 14.9, 15.4, and 16.0.
 
 **Note:** When running in Postgres mode, backups will not be created
 automatically by dcrpool.
 
 ## Setup
 
-1. Connect to your instance of PostgreSQL using `psql` to create a new database
-    and a new user for dcrpool.
+1. Connect to your instance of PostgreSQL using `psql` to create a new role and
+    a new database for dcrpool.
     Be sure to substitute the example password `12345` with something more secure.
 
     ```no-highlight
-    postgres=# CREATE DATABASE dcrpooldb;
-    CREATE DATABASE
-    postgres=# CREATE USER dcrpooluser WITH ENCRYPTED PASSWORD '12345';
+    postgres=# CREATE ROLE dcrpooluser WITH LOGIN NOINHERIT PASSWORD '12345';
     CREATE ROLE
-    postgres=# GRANT ALL PRIVILEGES ON DATABASE dcrpooldb to dcrpooluser;
-    GRANT
+    postgres=# CREATE DATABASE dcrpooldb OWNER dcrpooluser;
+    CREATE DATABASE
     ```
 
 1. **Developers only** - if you are modifying code and wish to run the dcrpool
    test suite, you will need to create an additional database.
 
     ```no-highlight
-    postgres=# CREATE DATABASE dcrpooltestdb;
+    postgres=# CREATE DATABASE dcrpooltestdb OWNER dcrpooluser;
     CREATE DATABASE
-    postgres=# GRANT ALL PRIVILEGES ON DATABASE dcrpooltestdb to dcrpooluser;
-    GRANT
     ```
 
 1. Add the database connection details to the dcrpool config file.


### PR DESCRIPTION
This updates the postgres guide to include the latest versions of postgres which I've now tested and confirmed that they work as intended.

It also modifies the instructions to create a role with login and then create a database with that role as owner as opposed to creating a user that is then granted persmissions to the database.

This approach is generally preferred and all recent versions of postgres (versions >= 8.1) treat 'create user' as an alias for 'create role' with the login permission granted anyway.

As an aside, historically roles were allowed to own database objects while users were not, however, since users are actually just roles nowadays, there is no long a distinction.  However, it is still widely considered best practice to use 'create role' when the role will be the owner of a databaes for backward compatibility.