### PR TITLE
pool: Break on failed pool tests.

### DIFF
--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -111,6 +111,10 @@ func TestPool(t *testing.T) {
 
 	// Run all tests with bolt DB.
 	for testName, test := range tests {
+		if t.Failed() {
+			break
+		}
+
 		boltDB, err := setupBoltDB()
 		if err != nil {
 			t.Fatalf("setupBoltDB error: %v", err)
@@ -130,6 +134,10 @@ func TestPool(t *testing.T) {
 
 	// Run all tests with postgres DB.
 	for testName, test := range tests {
+		if t.Failed() {
+			break
+		}
+
 		postgresDB, err := setupPostgresDB()
 		if err != nil {
 			t.Fatalf("setupPostgresDB error: %v", err)


### PR DESCRIPTION
Any calls to `t.Fatal` inside of a `t.Run` will only fatal that specific instance of run.  This adds logic to stop running the remaining pool tests when there is a failed test.