### PR TITLE
pool: Improve share UUID with random value.

### DIFF
--- a/pool/boltupgrades.go
+++ b/pool/boltupgrades.go
@@ -5,6 +5,7 @@
 package pool
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -223,6 +224,15 @@ func shareIDUpgrade(tx *bolt.Tx) error {
 		desc := fmt.Sprintf("%s: bucket %s not found", funcName,
 			string(shareBkt))
 		return errs.DBError(errs.StorageNotFound, desc)
+	}
+
+	// shareID generates the share id using the provided account and random
+	// uint64 that was in effect at the time of the upgrade.
+	shareID := func(account string, createdOn int64) string {
+		var buf bytes.Buffer
+		_, _ = buf.WriteString(hex.EncodeToString(nanoToBigEndianBytes(createdOn)))
+		_, _ = buf.WriteString(account)
+		return buf.String()
 	}
 
 	toDelete := [][]byte{}

--- a/pool/hub_test.go
+++ b/pool/hub_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"math/rand"
 	"net"
 	"strings"
 	"sync"
@@ -348,20 +349,21 @@ func testHub(t *testing.T) {
 
 	// Ensure work quotas are generated as expected.
 	now := time.Now()
+	prng := rand.New(rand.NewSource(now.UnixNano()))
 	tenBefore := now.Add(-(time.Second * 10)).UnixNano()
 	thirtyBefore := now.Add(-(time.Second * 30)).UnixNano()
 	sixtyAfter := now.Add(time.Second * 60).UnixNano()
 	xWeight := new(big.Rat).SetFloat64(1.0)
 	yWeight := new(big.Rat).SetFloat64(4.0)
-	err = persistShare(db, xID, xWeight, sixtyAfter)
+	err = persistShare(db, xID, xWeight, sixtyAfter, prng.Uint64())
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = persistShare(db, xID, xWeight, tenBefore)
+	err = persistShare(db, xID, xWeight, tenBefore, prng.Uint64())
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = persistShare(db, yID, yWeight, thirtyBefore)
+	err = persistShare(db, yID, yWeight, thirtyBefore, prng.Uint64())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**This is rebased on #389**.

The postgres tests currently fail when running on fast systems due to the lack of a generating unique share IDs.

After digging into the failure a bit, the root cause is that the UUID used for the share id is not created with any randomness to it.

As the test failure demonstrates, it is generally not a good idea to rely solely on timestamps for generating supposedly unique values.  While it is fairly unlikely that two shares will come in at the same nanosecond in most cases, there are a variety of factors that can lead to such a situation.

So, this appends a random value to the share UUID in order to help ensure a unique overall value and updates the callers accordingly.  It also updates the database upgrade code to ensure the old share id format is used when performing the old version upgrade.