### PR TITLE
pool: Don't leak process pmts goroutine.

### DIFF
--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -33,7 +33,7 @@ type ChainStateConfig struct {
 	// SoloPool represents the solo pool mining mode.
 	SoloPool bool
 	// ProcessPayments relays payment signals for processing.
-	ProcessPayments func(msg *paymentMsg)
+	ProcessPayments func(context.Context, *paymentMsg)
 	// GeneratePayments creates payments for participating accounts in pool
 	// mining mode based on the configured payment scheme.
 	GeneratePayments func(uint32, *PaymentSource, dcrutil.Amount, int64) error
@@ -227,7 +227,7 @@ func (cs *ChainState) handleChainUpdates(ctx context.Context) error {
 
 			soloPool := cs.cfg.SoloPool
 			if !soloPool {
-				go cs.cfg.ProcessPayments(&paymentMsg{
+				go cs.cfg.ProcessPayments(ctx, &paymentMsg{
 					CurrentHeight:  header.Height,
 					TreasuryActive: treasuryActive,
 					Done:           make(chan struct{}),

--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -43,7 +43,7 @@ func testChainState(t *testing.T) {
 		t.Fatalf("unexpected serialization error: %v", err)
 	}
 
-	processPayments := func(*paymentMsg) {}
+	processPayments := func(context.Context, *paymentMsg) {}
 	generatePayments := func(uint32, *PaymentSource, dcrutil.Amount, int64) error {
 		return nil
 	}

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -937,8 +937,11 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32, treasuryA
 }
 
 // processPayments relays payment signals for processing.
-func (pm *PaymentMgr) processPayments(msg *paymentMsg) {
-	pm.paymentCh <- msg
+func (pm *PaymentMgr) processPayments(ctx context.Context, msg *paymentMsg) {
+	select {
+	case <-ctx.Done():
+	case pm.paymentCh <- msg:
+	}
 }
 
 // handlePayments processes dividend payment signals.

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -1515,7 +1515,7 @@ func testPaymentMgrSignals(t *testing.T) {
 		wg.Done()
 	}()
 
-	mgr.processPayments(&msgA)
+	mgr.processPayments(ctx, &msgA)
 	<-msgA.Done
 
 	// Esure the payment lifecycle process cancels the context when an
@@ -1541,7 +1541,7 @@ func testPaymentMgrSignals(t *testing.T) {
 		TreasuryActive: false,
 		Done:           make(chan struct{}),
 	}
-	mgr.processPayments(&msgB)
+	mgr.processPayments(ctx, &msgB)
 	<-msgB.Done
 
 	cancel()


### PR DESCRIPTION
This ensures the process payments method in the payment manager that handles sending payment messages respects a provided context so it does not potentially leak a goroutine if the context context controlling the payment manager is canceled prior to receiving the message.