### PR TITLE
pool: Avoid potential send to closed chan in hub.

### DIFF
--- a/pool/hub.go
+++ b/pool/hub.go
@@ -564,12 +564,10 @@ func (h *Hub) processWork(headerE string) {
 
 // createNotificationHandlers returns handlers for block and work notifications.
 func (h *Hub) createNotificationHandlers(ctx context.Context) *rpcclient.NotificationHandlers {
-	var closeConnChOnce, closeDiscChOnce sync.Once
 	return &rpcclient.NotificationHandlers{
 		OnBlockConnected: func(headerB []byte, transactions [][]byte) {
 			select {
 			case <-ctx.Done():
-				closeConnChOnce.Do(func() { close(h.chainState.connCh) })
 			case h.chainState.connCh <- &blockNotification{
 				Header: headerB,
 				Done:   make(chan struct{}),
@@ -579,7 +577,6 @@ func (h *Hub) createNotificationHandlers(ctx context.Context) *rpcclient.Notific
 		OnBlockDisconnected: func(headerB []byte) {
 			select {
 			case <-ctx.Done():
-				closeDiscChOnce.Do(func() { close(h.chainState.discCh) })
 			case h.chainState.discCh <- &blockNotification{
 				Header: headerB,
 				Done:   make(chan struct{}),


### PR DESCRIPTION
This avoids a potential case in the hub that could result in a panic during shutdown due to sending to a nil channel.

Since the rpcclient callbacks can be invoked at any, even after the context is done, some additional synchronization would be required to prevent attempting to send to the closed channels if they are closed when the context is done.

Rather than adding more elaborate synchronization logic, this simply chooses not to close the channels to resolve the situation because there really isn't any reason to close them and not closing them also resolves a secondary issue.  Namely, the receiving side doesn't check if the channels are closed, so closing them could actually lead to the channel being incorrectly selected without an accompanying message which itself could lead to a panic.

Finally, the receiving goroutine will be exited when the context completes meaning there won't be anything listening to the channels in very short order either which is even more reason not to worry about closing them.