### PR TITLE
pool: Remove code related to unsupported ASICs.

### DIFF
--- a/internal/gui/assets/templates/index.html
+++ b/internal/gui/assets/templates/index.html
@@ -76,10 +76,6 @@
                                             rel="noopener noreferrer"
                                             href="https://mining.obelisk.tech/downloads/firmware/obelisk-sc1-v1.3.2.img">Obelisk&nbsp;DCR1</a>
                                     </li>
-                                    <li><a
-                                            rel="noopener noreferrer"
-                                            href="https://file12.bitmain.com/shop-product/firmware/Antminer%20DR5/Firmware/00720190727142534231Ato7d2300650/Antminer-DR5-201907161801-600M.tar.gz">Antminer&nbsp;DR5</a>
-                                    </li>
                                 </ul>
                             </div>
                         </div>

--- a/internal/gui/assets/templates/index.html
+++ b/internal/gui/assets/templates/index.html
@@ -63,11 +63,6 @@
                             </p>
                             <div class="d-flex flex-row">
                                 <ul>
-                                    <li>
-                                        <a
-                                            rel="noopener noreferrer"
-                                            href="http://www.innosilicon.com.cn/download/d9_20190521_071217.swu">Innosilicon&nbsp;D9</a>
-                                    </li>
                                     <li><a
                                             rel="noopener noreferrer"
                                             href="https://mining.obelisk.tech/downloads/firmware/obelisk-sc1-v1.3.2.img">Obelisk&nbsp;DCR1</a>

--- a/internal/gui/assets/templates/index.html
+++ b/internal/gui/assets/templates/index.html
@@ -70,10 +70,6 @@
                                     </li>
                                     <li><a
                                             rel="noopener noreferrer"
-                                            href="https://file12.bitmain.com/shop-product/firmware/Antminer%20DR3/Firmware/007201907271437364778LxDsS1k06AF/Antminer-DR3-201907161805-410M.tar.gz">Antminer&nbsp;DR3</a>
-                                    </li>
-                                    <li><a
-                                            rel="noopener noreferrer"
                                             href="https://mining.obelisk.tech/downloads/firmware/obelisk-sc1-v1.3.2.img">Obelisk&nbsp;DCR1</a>
                                     </li>
                                 </ul>

--- a/internal/gui/assets/templates/index.html
+++ b/internal/gui/assets/templates/index.html
@@ -58,14 +58,12 @@
                         </div>
                         <div class="carousel-text col-lg-8 col-12 px-4">
                             <h2>Identify the Miner</h2>
-                            <p> The pool currently supports the miners and their associated linked firmwares listed
-                                below:
+                            <p>The pool currently supports the miners below:
                             </p>
                             <div class="d-flex flex-row">
                                 <ul>
-                                    <li><a
-                                            rel="noopener noreferrer"
-                                            href="https://mining.obelisk.tech/downloads/firmware/obelisk-sc1-v1.3.2.img">Obelisk&nbsp;DCR1</a>
+                                    <li>
+                                        Coming Soon!
                                     </li>
                                 </ul>
                             </div>

--- a/internal/gui/assets/templates/index.html
+++ b/internal/gui/assets/templates/index.html
@@ -80,10 +80,6 @@
                                             rel="noopener noreferrer"
                                             href="https://file12.bitmain.com/shop-product/firmware/Antminer%20DR5/Firmware/00720190727142534231Ato7d2300650/Antminer-DR5-201907161801-600M.tar.gz">Antminer&nbsp;DR5</a>
                                     </li>
-                                    <li><a
-                                            rel="noopener noreferrer"
-                                            href="https://github.com/decred/dcrpool/files/5651882/upgrade-whatsminer-h6-20190404.18.zip">Whatsminer&nbsp;D1</a>
-                                    </li>
                                 </ul>
                             </div>
                         </div>

--- a/pool/client.go
+++ b/pool/client.go
@@ -1209,7 +1209,7 @@ func (c *Client) send() {
 						c.handleCPUWork(req)
 						log.Tracef("%s notified of new work", id)
 
-					case AntminerDR3, AntminerDR5:
+					case AntminerDR3:
 						c.handleAntminerDR3Work(req)
 						log.Tracef("%s notified of new work", id)
 

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -412,43 +412,6 @@ func testClientMessageHandling(t *testing.T) {
 		t.Fatalf("expected a non-error response, got %s", resp.Error.Message)
 	}
 
-	// Ensure an Innosilicon D9 client receives a valid non-error
-	// response when a valid subscribe request is sent.
-	err = setMiner(client, InnosiliconD9)
-	if err != nil {
-		t.Fatalf("unexpected set miner error: %v", err)
-	}
-
-	id++
-	d9, d9Version := splitMinerID(d9ID)
-	r = SubscribeRequest(&id, userAgent(d9, d9Version), "")
-	err = sE.Encode(r)
-	if err != nil {
-		t.Fatalf("[Encode] unexpected error: %v", err)
-	}
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case data = <-recvCh:
-	}
-	msg, mType, err = IdentifyMessage(data)
-	if err != nil {
-		t.Fatalf("[IdentifyMessage] unexpected error: %v", err)
-	}
-	if mType != ResponseMessage {
-		t.Fatalf("expected a subscribe response message, got %v", mType)
-	}
-	resp, ok = msg.(*Response)
-	if !ok {
-		t.Fatalf("expected subsribe response with id %d, got %d", *r.ID, resp.ID)
-	}
-	if resp.ID != *r.ID {
-		t.Fatalf("expected subscribe response with id %d, got %d", *r.ID, resp.ID)
-	}
-	if resp.Error != nil {
-		t.Fatalf("expected a non-error response, got %s", resp.Error.Message)
-	}
-
 	// Ensure a CPU client receives a valid non-error response when a
 	// valid subscribe request is sent.
 	err = setMiner(client, CPU)
@@ -579,35 +542,6 @@ func testClientMessageHandling(t *testing.T) {
 		t.Fatalf("expected last work time for %s connection "+
 			"to be more than zero, got %d", client.id,
 			client.lastWorkTime)
-	}
-
-	// Send a work notification to an Innosilicon D9 client.
-	err = setMiner(client, InnosiliconD9)
-	if err != nil {
-		t.Fatalf("unexpected set miner error: %v", err)
-	}
-
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case client.ch <- r:
-	}
-
-	// Ensure the work notification received is unique to the D9.
-	var d9Work []byte
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case d9Work = <-recvCh:
-	}
-	if bytes.Equal(cpuWork, d9Work) {
-		t.Fatalf("expected innosilicond9 work to be different from cpu work")
-	}
-
-	// Claim a weighted share for the Innosilicon D9 client.
-	err = client.claimWeightedShare()
-	if err != nil {
-		t.Fatalf("[claimWeightedShare (D9)] unexpected error: %v", err)
 	}
 
 	// Send a work notification to an Obelisk DCR1 client.
@@ -936,40 +870,6 @@ func testClientMessageHandling(t *testing.T) {
 	}
 	if resp.Error != nil {
 		t.Fatalf("expected no-error work submission response, got %v", resp.Error)
-	}
-
-	// Ensure the pool processes Innosilicon D9 work submissions.
-	err = setMiner(client, InnosiliconD9)
-	if err != nil {
-		t.Fatalf("unexpected set miner error: %v", err)
-	}
-
-	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000",
-		"954cee5d", "6ddf0200")
-	err = sE.Encode(sub)
-	if err != nil {
-		t.Fatalf("[Encode] unexpected error: %v", err)
-	}
-	var d9Sub []byte
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case d9Sub = <-recvCh:
-	}
-	msg, mType, err = IdentifyMessage(d9Sub)
-	if err != nil {
-		t.Fatalf("[IdentifyMessage] unexpected error: %v", err)
-	}
-	if mType != ResponseMessage {
-		t.Fatalf("expected a response message, got %v", mType)
-	}
-	resp, ok = msg.(*Response)
-	if !ok {
-		t.Fatalf("unable to cast message as response")
-	}
-	if resp.ID != *sub.ID {
-		t.Fatalf("expected a response with id %d, got %d", *sub.ID, resp.ID)
 	}
 
 	// Ensure the pool processes Obelisk DCR1 work submissions.

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -677,35 +677,6 @@ func testClientMessageHandling(t *testing.T) {
 		t.Fatalf("[claimWeightedShare (DR3)] unexpected error: %v", err)
 	}
 
-	// Send a work notification to an Antminer DR5 client.
-	err = setMiner(client, AntminerDR5)
-	if err != nil {
-		t.Fatalf("unexpected set miner error: %v", err)
-	}
-
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case client.ch <- r:
-	}
-
-	// Ensure the work notification received is identical to that of the DR3.
-	var dr5Work []byte
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case dr5Work = <-recvCh:
-	}
-	if !bytes.Equal(dr5Work, dr3Work) {
-		t.Fatalf("expected antminer dr5 work to be equal to antminer dr3 work")
-	}
-
-	// Claim a weighted share for the Antminer DR5.
-	err = client.claimWeightedShare()
-	if err != nil {
-		t.Fatalf("[claimWeightedShare (DR5)] unexpected error: %v", err)
-	}
-
 	// Send a work notification to an Obelisk DCR1 client.
 	err = setMiner(client, ObeliskDCR1)
 	if err != nil {
@@ -725,9 +696,9 @@ func testClientMessageHandling(t *testing.T) {
 		t.Fatalf("client context done: %v", err)
 	case dcr1Work = <-recvCh:
 	}
-	if !bytes.Equal(dr5Work, dcr1Work) {
+	if !bytes.Equal(dr3Work, dcr1Work) {
 		t.Fatalf("expected obelisk DCR1 work to be different from " +
-			"antminer dr5 work")
+			"antminer dr3 work")
 	}
 
 	// Claim a weighted share for the Obelisk DCR1.
@@ -1055,40 +1026,6 @@ func testClientMessageHandling(t *testing.T) {
 	case dr3Sub = <-recvCh:
 	}
 	msg, mType, err = IdentifyMessage(dr3Sub)
-	if err != nil {
-		t.Fatalf("[IdentifyMessage] unexpected error: %v", err)
-	}
-	if mType != ResponseMessage {
-		t.Fatalf("expected a response message, got %v", mType)
-	}
-	resp, ok = msg.(*Response)
-	if !ok {
-		t.Fatalf("unable to cast message as response")
-	}
-	if resp.ID != *sub.ID {
-		t.Fatalf("expected a response with id %d, got %d", *sub.ID, resp.ID)
-	}
-
-	// Ensure the pool processes Antminer DR5 work submissions.
-	err = setMiner(client, AntminerDR5)
-	if err != nil {
-		t.Fatalf("unexpected set miner error: %v", err)
-	}
-
-	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000",
-		"954cee5d", "6ddf0200")
-	err = sE.Encode(sub)
-	if err != nil {
-		t.Fatalf("[Encode] unexpected error: %v", err)
-	}
-	var dr5Sub []byte
-	select {
-	case <-client.ctx.Done():
-		t.Fatalf("client context done: %v", err)
-	case dr5Sub = <-recvCh:
-	}
-	msg, mType, err = IdentifyMessage(dr5Sub)
 	if err != nil {
 		t.Fatalf("[IdentifyMessage] unexpected error: %v", err)
 	}

--- a/pool/difficulty.go
+++ b/pool/difficulty.go
@@ -21,7 +21,6 @@ const (
 	CPU               = "cpu"
 	InnosiliconD9     = "innosilicond9"
 	AntminerDR3       = "antminerdr3"
-	AntminerDR5       = "antminerdr5"
 	ObeliskDCR1       = "obeliskdcr1"
 	NiceHashValidator = "nicehash"
 )
@@ -34,7 +33,6 @@ var (
 		ObeliskDCR1:       new(big.Int).SetInt64(1.2e12),
 		InnosiliconD9:     new(big.Int).SetInt64(2.4e12),
 		AntminerDR3:       new(big.Int).SetInt64(7.8e12),
-		AntminerDR5:       new(big.Int).SetInt64(35e12),
 		NiceHashValidator: new(big.Int).SetInt64(20e10),
 	}
 )

--- a/pool/difficulty.go
+++ b/pool/difficulty.go
@@ -20,7 +20,6 @@ import (
 const (
 	CPU               = "cpu"
 	InnosiliconD9     = "innosilicond9"
-	AntminerDR3       = "antminerdr3"
 	ObeliskDCR1       = "obeliskdcr1"
 	NiceHashValidator = "nicehash"
 )
@@ -32,7 +31,6 @@ var (
 		CPU:               new(big.Int).SetInt64(5e3),
 		ObeliskDCR1:       new(big.Int).SetInt64(1.2e12),
 		InnosiliconD9:     new(big.Int).SetInt64(2.4e12),
-		AntminerDR3:       new(big.Int).SetInt64(7.8e12),
 		NiceHashValidator: new(big.Int).SetInt64(20e10),
 	}
 )

--- a/pool/difficulty.go
+++ b/pool/difficulty.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -22,7 +22,6 @@ const (
 	InnosiliconD9     = "innosilicond9"
 	AntminerDR3       = "antminerdr3"
 	AntminerDR5       = "antminerdr5"
-	WhatsminerD1      = "whatsminerd1"
 	ObeliskDCR1       = "obeliskdcr1"
 	NiceHashValidator = "nicehash"
 )
@@ -36,7 +35,6 @@ var (
 		InnosiliconD9:     new(big.Int).SetInt64(2.4e12),
 		AntminerDR3:       new(big.Int).SetInt64(7.8e12),
 		AntminerDR5:       new(big.Int).SetInt64(35e12),
-		WhatsminerD1:      new(big.Int).SetInt64(48e12),
 		NiceHashValidator: new(big.Int).SetInt64(20e10),
 	}
 )

--- a/pool/difficulty.go
+++ b/pool/difficulty.go
@@ -19,7 +19,6 @@ import (
 // Supported mining clients.
 const (
 	CPU               = "cpu"
-	ObeliskDCR1       = "obeliskdcr1"
 	NiceHashValidator = "nicehash"
 )
 
@@ -28,7 +27,6 @@ var (
 	// corresponding hash rates.
 	minerHashes = map[string]*big.Int{
 		CPU:               new(big.Int).SetInt64(5e3),
-		ObeliskDCR1:       new(big.Int).SetInt64(1.2e12),
 		NiceHashValidator: new(big.Int).SetInt64(20e10),
 	}
 )

--- a/pool/difficulty.go
+++ b/pool/difficulty.go
@@ -19,7 +19,6 @@ import (
 // Supported mining clients.
 const (
 	CPU               = "cpu"
-	InnosiliconD9     = "innosilicond9"
 	ObeliskDCR1       = "obeliskdcr1"
 	NiceHashValidator = "nicehash"
 )
@@ -30,7 +29,6 @@ var (
 	minerHashes = map[string]*big.Int{
 		CPU:               new(big.Int).SetInt64(5e3),
 		ObeliskDCR1:       new(big.Int).SetInt64(1.2e12),
-		InnosiliconD9:     new(big.Int).SetInt64(2.4e12),
 		NiceHashValidator: new(big.Int).SetInt64(20e10),
 	}
 )

--- a/pool/difficulty_test.go
+++ b/pool/difficulty_test.go
@@ -73,20 +73,16 @@ func TestDifficulty(t *testing.T) {
 	diffSet := []struct {
 		miner       string
 		expectedErr error
-	}{
-		{
-			miner:       CPU,
-			expectedErr: nil,
-		},
-		{
-			miner:       "",
-			expectedErr: errs.ValueNotFound,
-		},
-		{
-			miner:       "antminerdr7",
-			expectedErr: errs.ValueNotFound,
-		},
-	}
+	}{{
+		miner:       CPU,
+		expectedErr: nil,
+	}, {
+		miner:       "",
+		expectedErr: errs.ValueNotFound,
+	}, {
+		miner:       "non-existent",
+		expectedErr: errs.ValueNotFound,
+	}}
 
 	for idx, tc := range diffSet {
 		net := chaincfg.SimNetParams()

--- a/pool/hashdata_test.go
+++ b/pool/hashdata_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func testHashData(t *testing.T) {
-	miner := ObeliskDCR1
+	const miner = CPU
 	extraNonce1 := "ca750c60"
 	ip := "127.0.0.1:5550"
 	now := time.Now()

--- a/pool/message.go
+++ b/pool/message.go
@@ -626,11 +626,11 @@ func GenerateSolvedBlockHeader(headerE string, extraNonce1E string,
 		copy(headerEB[288:296], []byte(extraNonce1E))
 		copy(headerEB[296:304], []byte(extraNonce2E))
 
-	// The Antiminer DR3 and DR5 return a 12-byte entraNonce comprised of the
+	// The Antiminer DR3 returns a 12-byte extraNonce comprised of the
 	// extraNonce1 and extraNonce2 regardless of the extraNonce2Size specified
 	// in the mining.subscribe message. The nTime and nonce values submitted are
 	// big endian, they have to be reversed before block header reconstruction.
-	case AntminerDR3, AntminerDR5:
+	case AntminerDR3:
 		nTimeERev, err := hexReversed(nTimeE)
 		if err != nil {
 			return nil, err

--- a/pool/message.go
+++ b/pool/message.go
@@ -604,28 +604,6 @@ func GenerateSolvedBlockHeader(headerE string, extraNonce1E string,
 		copy(headerEB[288:296], []byte(extraNonce1E))
 		copy(headerEB[296:304], []byte(extraNonce2E))
 
-	// The Obelisk DCR1 does not respect the extraNonce2Size specified in the
-	// mining.subscribe response sent to it. It returns a 4-byte extraNonce2
-	// regardless of the extraNonce2Size provided.
-	// The extraNonce2 value submitted is exclusively the extraNonce2.
-	// The nTime and nonce values submitted are big endian, they have to
-	// be reversed to little endian before header reconstruction.
-	case ObeliskDCR1:
-		nTimeERev, err := hexReversed(nTimeE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[272:280], []byte(nTimeERev))
-
-		nonceERev, err := hexReversed(nonceE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[280:288], []byte(nonceERev))
-
-		copy(headerEB[288:296], []byte(extraNonce1E))
-		copy(headerEB[296:304], []byte(extraNonce2E))
-
 	default:
 		desc := fmt.Sprintf("miner %s is unknown", miner)
 		return nil, errs.MsgError(errs.MinerUnknown, desc)

--- a/pool/message.go
+++ b/pool/message.go
@@ -626,26 +626,6 @@ func GenerateSolvedBlockHeader(headerE string, extraNonce1E string,
 		copy(headerEB[288:296], []byte(extraNonce1E))
 		copy(headerEB[296:304], []byte(extraNonce2E))
 
-	// The Innosilicon D9 respects the extraNonce2Size specified in the
-	// mining.subscribe response sent to it. The extraNonce2 value submitted is
-	// exclusively the extraNonce2. The nTime and nonce values submitted are
-	// big endian, they have to be reversed to little endian before header
-	// reconstruction.
-	case InnosiliconD9:
-		nTimeERev, err := hexReversed(nTimeE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[272:280], []byte(nTimeERev))
-
-		nonceERev, err := hexReversed(nonceE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[280:288], []byte(nonceERev))
-		copy(headerEB[288:296], []byte(extraNonce1E))
-		copy(headerEB[296:304], []byte(extraNonce2E))
-
 	default:
 		desc := fmt.Sprintf("miner %s is unknown", miner)
 		return nil, errs.MsgError(errs.MinerUnknown, desc)

--- a/pool/message.go
+++ b/pool/message.go
@@ -664,25 +664,6 @@ func GenerateSolvedBlockHeader(headerE string, extraNonce1E string,
 		copy(headerEB[288:296], []byte(extraNonce1E))
 		copy(headerEB[296:304], []byte(extraNonce2E))
 
-	// The Whatsminer D1 does not respect the extraNonce2Size specified in the
-	// mining.subscribe response sent to it. The 8-byte extranonce submitted is
-	// for the extraNonce1 and extraNonce2. The nTime and nonce values submitted
-	// are big endian, they have to be reversed to little endian before header
-	// reconstruction.
-	case WhatsminerD1:
-		nTimeERev, err := hexReversed(nTimeE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[272:280], []byte(nTimeERev))
-
-		nonceERev, err := hexReversed(nonceE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[280:288], []byte(nonceERev))
-		copy(headerEB[288:304], []byte(extraNonce2E))
-
 	default:
 		desc := fmt.Sprintf("miner %s is unknown", miner)
 		return nil, errs.MsgError(errs.MinerUnknown, desc)

--- a/pool/message.go
+++ b/pool/message.go
@@ -626,24 +626,6 @@ func GenerateSolvedBlockHeader(headerE string, extraNonce1E string,
 		copy(headerEB[288:296], []byte(extraNonce1E))
 		copy(headerEB[296:304], []byte(extraNonce2E))
 
-	// The Antiminer DR3 returns a 12-byte extraNonce comprised of the
-	// extraNonce1 and extraNonce2 regardless of the extraNonce2Size specified
-	// in the mining.subscribe message. The nTime and nonce values submitted are
-	// big endian, they have to be reversed before block header reconstruction.
-	case AntminerDR3:
-		nTimeERev, err := hexReversed(nTimeE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[272:280], []byte(nTimeERev))
-
-		nonceERev, err := hexReversed(nonceE)
-		if err != nil {
-			return nil, err
-		}
-		copy(headerEB[280:288], []byte(nonceERev))
-		copy(headerEB[288:312], []byte(extraNonce2E))
-
 	// The Innosilicon D9 respects the extraNonce2Size specified in the
 	// mining.subscribe response sent to it. The extraNonce2 value submitted is
 	// exclusively the extraNonce2. The nTime and nonce values submitted are

--- a/pool/miner_id.go
+++ b/pool/miner_id.go
@@ -14,9 +14,8 @@ var (
 	// These miner ids represent the expected identifications returned by
 	// supported miners in their mining.subscribe requests.
 
-	cpuID  = "cpuminer/1.0.0"
-	dcr1ID = "cgminer/4.10.0"
-	nhID   = "NiceHash/1.0.0"
+	cpuID = "cpuminer/1.0.0"
+	nhID  = "NiceHash/1.0.0"
 )
 
 // minerIDPair represents miner subscription identification pairing
@@ -43,11 +42,9 @@ func newMinerIDPair(id string, miners ...string) *minerIDPair {
 func generateMinerIDs() map[string]*minerIDPair {
 	ids := make(map[string]*minerIDPair)
 	cpu := newMinerIDPair(cpuID, CPU)
-	obelisk := newMinerIDPair(dcr1ID, ObeliskDCR1)
 	nicehash := newMinerIDPair(nhID, NiceHashValidator)
 
 	ids[cpu.id] = cpu
-	ids[obelisk.id] = obelisk
 	ids[nicehash.id] = nicehash
 	return ids
 }

--- a/pool/miner_id.go
+++ b/pool/miner_id.go
@@ -16,7 +16,6 @@ var (
 
 	cpuID  = "cpuminer/1.0.0"
 	dcr1ID = "cgminer/4.10.0"
-	d9ID   = "sgminer/4.4.2"
 	nhID   = "NiceHash/1.0.0"
 )
 
@@ -45,12 +44,10 @@ func generateMinerIDs() map[string]*minerIDPair {
 	ids := make(map[string]*minerIDPair)
 	cpu := newMinerIDPair(cpuID, CPU)
 	obelisk := newMinerIDPair(dcr1ID, ObeliskDCR1)
-	innosilicon := newMinerIDPair(d9ID, InnosiliconD9)
 	nicehash := newMinerIDPair(nhID, NiceHashValidator)
 
 	ids[cpu.id] = cpu
 	ids[obelisk.id] = obelisk
-	ids[innosilicon.id] = innosilicon
 	ids[nicehash.id] = nicehash
 	return ids
 }

--- a/pool/miner_id.go
+++ b/pool/miner_id.go
@@ -17,7 +17,6 @@ var (
 	cpuID  = "cpuminer/1.0.0"
 	dcr1ID = "cgminer/4.10.0"
 	d9ID   = "sgminer/4.4.2"
-	dr3ID  = "cgminer/4.9.0"
 	nhID   = "NiceHash/1.0.0"
 )
 
@@ -47,13 +46,11 @@ func generateMinerIDs() map[string]*minerIDPair {
 	cpu := newMinerIDPair(cpuID, CPU)
 	obelisk := newMinerIDPair(dcr1ID, ObeliskDCR1)
 	innosilicon := newMinerIDPair(d9ID, InnosiliconD9)
-	antminer := newMinerIDPair(dr3ID, AntminerDR3)
 	nicehash := newMinerIDPair(nhID, NiceHashValidator)
 
 	ids[cpu.id] = cpu
 	ids[obelisk.id] = obelisk
 	ids[innosilicon.id] = innosilicon
-	ids[antminer.id] = antminer
 	ids[nicehash.id] = nicehash
 	return ids
 }

--- a/pool/miner_id.go
+++ b/pool/miner_id.go
@@ -47,7 +47,7 @@ func generateMinerIDs() map[string]*minerIDPair {
 	cpu := newMinerIDPair(cpuID, CPU)
 	obelisk := newMinerIDPair(dcr1ID, ObeliskDCR1)
 	innosilicon := newMinerIDPair(d9ID, InnosiliconD9)
-	antminer := newMinerIDPair(dr3ID, AntminerDR3, AntminerDR5)
+	antminer := newMinerIDPair(dr3ID, AntminerDR3)
 	nicehash := newMinerIDPair(nhID, NiceHashValidator)
 
 	ids[cpu.id] = cpu

--- a/pool/miner_id.go
+++ b/pool/miner_id.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -18,7 +18,6 @@ var (
 	dcr1ID = "cgminer/4.10.0"
 	d9ID   = "sgminer/4.4.2"
 	dr3ID  = "cgminer/4.9.0"
-	d1ID   = "whatsminer/d1-v1.0"
 	nhID   = "NiceHash/1.0.0"
 )
 
@@ -49,14 +48,12 @@ func generateMinerIDs() map[string]*minerIDPair {
 	obelisk := newMinerIDPair(dcr1ID, ObeliskDCR1)
 	innosilicon := newMinerIDPair(d9ID, InnosiliconD9)
 	antminer := newMinerIDPair(dr3ID, AntminerDR3, AntminerDR5)
-	whatsminer := newMinerIDPair(d1ID, WhatsminerD1)
 	nicehash := newMinerIDPair(nhID, NiceHashValidator)
 
 	ids[cpu.id] = cpu
 	ids[obelisk.id] = obelisk
 	ids[innosilicon.id] = innosilicon
 	ids[antminer.id] = antminer
-	ids[whatsminer.id] = whatsminer
 	ids[nicehash.id] = nicehash
 	return ids
 }

--- a/pool/share.go
+++ b/pool/share.go
@@ -18,8 +18,7 @@ import (
 //
 //	(Hash of Miner X * Weight of LHM)/ Hash of LHM
 var ShareWeights = map[string]*big.Rat{
-	CPU:         new(big.Rat).SetFloat64(1.0), // Reserved for testing.
-	ObeliskDCR1: new(big.Rat).SetFloat64(1.0),
+	CPU: new(big.Rat).SetFloat64(1.0), // Reserved for testing.
 }
 
 // shareID generates a unique share id using the provided account, creation

--- a/pool/share.go
+++ b/pool/share.go
@@ -21,7 +21,6 @@ var ShareWeights = map[string]*big.Rat{
 	CPU:           new(big.Rat).SetFloat64(1.0), // Reserved for testing.
 	ObeliskDCR1:   new(big.Rat).SetFloat64(1.0),
 	InnosiliconD9: new(big.Rat).SetFloat64(2.182),
-	AntminerDR3:   new(big.Rat).SetFloat64(7.091),
 }
 
 // shareID generates a unique share id using the provided account, creation

--- a/pool/share.go
+++ b/pool/share.go
@@ -22,7 +22,6 @@ var ShareWeights = map[string]*big.Rat{
 	ObeliskDCR1:   new(big.Rat).SetFloat64(1.0),
 	InnosiliconD9: new(big.Rat).SetFloat64(2.182),
 	AntminerDR3:   new(big.Rat).SetFloat64(7.091),
-	AntminerDR5:   new(big.Rat).SetFloat64(31.181),
 }
 
 // shareID generates a unique share id using the provided account, creation

--- a/pool/share.go
+++ b/pool/share.go
@@ -18,9 +18,8 @@ import (
 //
 //	(Hash of Miner X * Weight of LHM)/ Hash of LHM
 var ShareWeights = map[string]*big.Rat{
-	CPU:           new(big.Rat).SetFloat64(1.0), // Reserved for testing.
-	ObeliskDCR1:   new(big.Rat).SetFloat64(1.0),
-	InnosiliconD9: new(big.Rat).SetFloat64(2.182),
+	CPU:         new(big.Rat).SetFloat64(1.0), // Reserved for testing.
+	ObeliskDCR1: new(big.Rat).SetFloat64(1.0),
 }
 
 // shareID generates a unique share id using the provided account, creation

--- a/pool/share.go
+++ b/pool/share.go
@@ -12,9 +12,9 @@ import (
 	"time"
 )
 
-// ShareWeights reprsents the associated weights for each known DCR miner.
+// ShareWeights represents the associated weights for each known DCR miner.
 // With the share weight of the lowest hash DCR miner (LHM) being 1, the
-// rest were calculated as :
+// rest were calculated as:
 //
 //	(Hash of Miner X * Weight of LHM)/ Hash of LHM
 var ShareWeights = map[string]*big.Rat{
@@ -23,7 +23,6 @@ var ShareWeights = map[string]*big.Rat{
 	InnosiliconD9: new(big.Rat).SetFloat64(2.182),
 	AntminerDR3:   new(big.Rat).SetFloat64(7.091),
 	AntminerDR5:   new(big.Rat).SetFloat64(31.181),
-	WhatsminerD1:  new(big.Rat).SetFloat64(43.636),
 }
 
 // shareID generates a unique share id using the provided account, creation


### PR DESCRIPTION
**This requires #399**.

This removes all code related to ASICs that are no longer supported since they mine blake256 and the hash algorithm is now blake3.

The removals are done in separate commits to ease review.

In particular, support is removed for the following ASICs:

* Whatsminer D1
* Antminer DR5
* Antminer DR3
* Innosilicon D9
* Obelisk DCR1