### PR TITLE
pool: Correct account races.

### DIFF
--- a/pool/endpoint.go
+++ b/pool/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 The Decred developers
+// Copyright (c) 2019-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -221,7 +221,7 @@ func (e *Endpoint) generateHashIDs() map[string]struct{} {
 
 	ids := make(map[string]struct{}, len(e.clients))
 	for _, c := range e.clients {
-		hashID := hashDataID(c.account, c.extraNonce1)
+		hashID := hashDataID(c.FetchAccountID(), c.extraNonce1)
 		ids[hashID] = struct{}{}
 	}
 


### PR DESCRIPTION
The account and name fields of a client are not set until they are received via a mining.authorize message and the account field is accessed from separate goroutines which is a race.

This corrects that issue by introducing a separate mutex to protect both the account and the name field and updating all references to by protected by the mutex accordingly.

The name field doesn't appear to be used anywhere currently, however, it would also be a race to access it without the mutex for the same reason, so this takes the opportunity to ensure it is protected in case it is used in the future.

Fixes #374.