### PR TITLE
pool: Correct some test failure paths.

### DIFF
--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -254,7 +254,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 	resp, ok := msg.(*Response)
 	if !ok {
-		t.Fatalf("expected response with id %d, got %d", *r.ID, resp.ID)
+		t.Fatalf("expected response, got %T", msg)
 	}
 	if resp.ID != *r.ID {
 		t.Fatalf("expected response with id %d, got %d", *r.ID, resp.ID)
@@ -286,7 +286,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 	resp, ok = msg.(*Response)
 	if !ok {
-		t.Fatalf("expected response with id %d, got %d", *r.ID, resp.ID)
+		t.Fatalf("expected response, got %T", msg)
 	}
 	if resp.Error == nil {
 		t.Fatal("expected an invalid username authorize error response")
@@ -314,7 +314,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 	resp, ok = msg.(*Response)
 	if !ok {
-		t.Fatalf("expected response with id %d, got %d", *r.ID, resp.ID)
+		t.Fatalf("expected response, got %T", msg)
 	}
 	if resp.Error == nil {
 		t.Fatal("expected a rate limit error response")
@@ -346,7 +346,7 @@ func testClientMessageHandling(t *testing.T) {
 	}
 	resp, ok = msg.(*Response)
 	if !ok {
-		t.Fatalf("expected response with id %d, got %d", *r.ID, resp.ID)
+		t.Fatalf("expected response, got %T", msg)
 	}
 	if resp.ID != *r.ID {
 		t.Fatalf("expected response with id %d, got %d", *r.ID, resp.ID)


### PR DESCRIPTION
The current tests in the client message handling incorrect reference the fields of a response message in the case the message type isn't the expected type which would be a panic since the instance variable would be nil in that case.

This corrects that by showing the expected and received message types instead.