### PR TITLE
multi: Remove no longer relevant blake256 pad code.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -76,9 +76,6 @@ type ClientConfig struct {
 	db Database
 	// SoloPool represents the solo pool mining mode.
 	SoloPool bool
-	// Blake256Pad represents the extra padding needed for work
-	// submissions over the getwork RPC.
-	Blake256Pad []byte
 	// NonceIterations returns the possible header nonce iterations.
 	NonceIterations float64
 	// FetchMinerDifficulty returns the difficulty information for the
@@ -588,8 +585,6 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 	}
 	submissionB := make([]byte, getworkDataLen)
 	copy(submissionB[:wire.MaxBlockHeaderPayload], headerB)
-	copy(submissionB[wire.MaxBlockHeaderPayload:],
-		c.cfg.Blake256Pad)
 	submission := hex.EncodeToString(submissionB)
 	accepted, err := c.cfg.SubmitWork(ctx, submission)
 	if err != nil {

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -31,7 +31,6 @@ var (
 
 	powLimit    = chaincfg.SimNetParams().PowLimit
 	iterations  = math.Pow(2, float64(256-powLimit.BitLen()))
-	blake256Pad = generateBlake256Pad()
 	maxGenTime  = time.Millisecond * 500
 	cTimeout    = time.Millisecond * 2000
 	hashCalcMax = time.Millisecond * 1500
@@ -39,7 +38,6 @@ var (
 		new(big.Rat).SetInt(powLimit), maxGenTime)
 	config = &ClientConfig{
 		ActiveNet:       chaincfg.SimNetParams(),
-		Blake256Pad:     blake256Pad,
 		NonceIterations: iterations,
 		MaxGenTime:      maxGenTime,
 		FetchMinerDifficulty: func(miner string) (*DifficultyInfo, error) {

--- a/pool/endpoint.go
+++ b/pool/endpoint.go
@@ -26,9 +26,6 @@ type EndpointConfig struct {
 	db Database
 	// SoloPool represents the solo pool mining mode.
 	SoloPool bool
-	// Blake256Pad represents the extra padding needed for work
-	// submissions over the getwork RPC.
-	Blake256Pad []byte
 	// NonceIterations returns the possible header nonce iterations.
 	NonceIterations float64
 	// MaxConnectionsPerHost represents the maximum number of connections
@@ -173,7 +170,6 @@ func (e *Endpoint) connect(ctx context.Context) {
 				ActiveNet:            e.cfg.ActiveNet,
 				db:                   e.cfg.db,
 				SoloPool:             e.cfg.SoloPool,
-				Blake256Pad:          e.cfg.Blake256Pad,
 				NonceIterations:      e.cfg.NonceIterations,
 				FetchMinerDifficulty: e.cfg.FetchMinerDifficulty,
 				SubmitWork:           e.cfg.SubmitWork,

--- a/pool/endpoint_test.go
+++ b/pool/endpoint_test.go
@@ -32,7 +32,6 @@ func testEndpoint(t *testing.T) {
 	powLimit := chaincfg.SimNetParams().PowLimit
 	iterations := math.Pow(2, float64(256-powLimit.BitLen()))
 	maxGenTime := time.Second * 20
-	blake256Pad := generateBlake256Pad()
 	poolDiffs := NewDifficultySet(chaincfg.SimNetParams(),
 		new(big.Rat).SetInt(powLimit), maxGenTime)
 	connections := make(map[string]uint32)
@@ -42,7 +41,6 @@ func testEndpoint(t *testing.T) {
 		ActiveNet:             chaincfg.SimNetParams(),
 		db:                    db,
 		SoloPool:              true,
-		Blake256Pad:           blake256Pad,
 		NonceIterations:       iterations,
 		MaxConnectionsPerHost: maxConnsPerHost,
 		FetchMinerDifficulty: func(miner string) (*DifficultyInfo, error) {


### PR DESCRIPTION
This removes the blake256 padding code since it no longer applies.