### PR TITLE
pool: Do not populate/use gentx2.

### DIFF
--- a/cmd/miner/client.go
+++ b/cmd/miner/client.go
@@ -371,7 +371,7 @@ func (m *Miner) process(ctx context.Context) {
 						continue
 					}
 
-					jobID, prevBlockE, genTx1E, genTx2E, blockVersionE, _, _,
+					jobID, prevBlockE, genTx1E, blockVersionE, _, _,
 						cleanJob, err := pool.ParseWorkNotification(notif)
 					if err != nil {
 						log.Errorf("parse job notification error: %v", err)
@@ -380,7 +380,7 @@ func (m *Miner) process(ctx context.Context) {
 					}
 
 					blockHeader, err := pool.GenerateBlockHeader(blockVersionE,
-						prevBlockE, genTx1E, m.extraNonce1E, genTx2E)
+						prevBlockE, genTx1E, m.extraNonce1E)
 					if err != nil {
 						log.Errorf("generate block header error: %v", err)
 						m.cancel()

--- a/pool/client.go
+++ b/pool/client.go
@@ -541,7 +541,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 	// less than the pool target for the client.
 	if hashTarget.Cmp(tgt) > 0 {
 		err := fmt.Errorf("submitted work %s from %s is not less than its "+
-			"corresponding pool target", hash.String(), id)
+			"corresponding pool target", hash, id)
 		sErr := NewStratumError(LowDifficultyShare, err)
 		resp := SubmitWorkResponse(*req.ID, false, sErr)
 		c.sendMessage(resp)
@@ -759,10 +759,9 @@ func (c *Client) updateWork(cleanJob bool) {
 	updatedWorkE := buf.String()
 	blockVersion := updatedWorkE[:8]
 	prevBlock := updatedWorkE[8:72]
-	genTx1 := updatedWorkE[72:288]
+	genTx1 := updatedWorkE[72:360]
 	nBits := updatedWorkE[232:240]
 	nTime := updatedWorkE[272:280]
-	genTx2 := updatedWorkE[352:360]
 
 	heightD, err := hex.DecodeString(updatedWorkE[256:264])
 	if err != nil {
@@ -779,8 +778,8 @@ func (c *Client) updateWork(cleanJob bool) {
 		log.Error(err)
 		return
 	}
-	workNotif := WorkNotification(job.UUID, prevBlock, genTx1, genTx2,
-		blockVersion, nBits, nTime, cleanJob)
+	workNotif := WorkNotification(job.UUID, prevBlock, genTx1, blockVersion,
+		nBits, nTime, cleanJob)
 
 	c.sendMessage(workNotif)
 	log.Tracef("Sent a timestamp-rolled current work at "+

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -440,14 +440,13 @@ func testClientMessageHandling(t *testing.T) {
 
 	blockVersion := workE[:8]
 	prevBlock := workE[8:72]
-	genTx1 := workE[72:288]
+	genTx1 := workE[72:360]
 	nBits := workE[232:240]
 	nTime := workE[272:280]
-	genTx2 := workE[352:360]
 
 	// Send a work notification to the CPU client.
-	r = WorkNotification(job.UUID, prevBlock, genTx1, genTx2,
-		blockVersion, nBits, nTime, true)
+	r = WorkNotification(job.UUID, prevBlock, genTx1, blockVersion, nBits,
+		nTime, true)
 	select {
 	case <-client.ctx.Done():
 		t.Fatalf("client context done: %v", err)

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -543,18 +543,17 @@ func (h *Hub) processWork(headerE string) {
 
 	blockVersion := headerE[:8]
 	prevBlock := headerE[8:72]
-	genTx1 := headerE[72:288]
+	genTx1 := headerE[72:360]
 	nBits := headerE[232:240]
 	nTime := headerE[272:280]
-	genTx2 := headerE[352:360]
 	job := NewJob(headerE, height)
 	err = h.cfg.DB.persistJob(job)
 	if err != nil {
 		log.Error(err)
 		return
 	}
-	workNotif := WorkNotification(job.UUID, prevBlock, genTx1, genTx2,
-		blockVersion, nBits, nTime, true)
+	workNotif := WorkNotification(job.UUID, prevBlock, genTx1, blockVersion,
+		nBits, nTime, true)
 	h.endpoint.clientsMtx.Lock()
 	for _, client := range h.endpoint.clients {
 		client.sendMessage(workNotif)


### PR DESCRIPTION
This modifies the pool to report the entire partial header via the first generation tx field as intended and no longer populates the second generation tx field since it does not apply to Decred.

Some of the old ASICs hacked the stake version in there, but that is really not something that should have ever been done because the stratum "protocol" (which is not actually very well defined) already does not individually provide all of the information the Decred header needs nor does it provide an official way to extend it.

Further, the Decred header explicitly provides additional space which removes the need to create a new coinbase and update the merkle root.

So, in order to address these things, the field that was intended to serve for the coinbase (generate transaction) was repurposed to contain the serialized partial header for data after the previous block hash in the format it is to be hashed.  Therefore, it should be providing the entire remaining partial header to ensure that any future modifications to the end of the header are available to miners without modification.

Given that the old ASICs no longer work with the network, this takes the opportunity to make the change.