### PR TITLE
pool: Use fmt.Stringer.

### DIFF
--- a/pool/chainstate_test.go
+++ b/pool/chainstate_test.go
@@ -165,7 +165,7 @@ func testChainState(t *testing.T) {
 	cs.cfg.GetBlock = func(ctx context.Context, hash *chainhash.Hash) (*wire.MsgBlock, error) {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCBlockNotFound,
-			Message: fmt.Sprintf("no block found with hash: %v", hash.String()),
+			Message: fmt.Sprintf("no block found with hash: %v", hash),
 		}
 	}
 	height := uint32(10)

--- a/pool/client.go
+++ b/pool/client.go
@@ -603,8 +603,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 		resp := SubmitWorkResponse(*req.ID, false, nil)
 		c.sendMessage(resp)
 
-		desc := fmt.Sprintf("%s: work %s rejected by the network",
-			id, hash.String())
+		desc := fmt.Sprintf("%s: work %s rejected by the network", id, hash)
 		if err != nil {
 			// send the current work if the error is a block difficulty mismatch.
 			if strings.Contains(err.Error(), "block difficulty of") {
@@ -612,7 +611,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 			}
 
 			desc = fmt.Sprintf("%s: work %s rejected by the network (%v)",
-				id, hash.String(), err)
+				id, hash, err)
 		}
 
 		return errs.PoolError(errs.WorkRejected, desc)
@@ -637,7 +636,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 		c.sendMessage(resp)
 		return err
 	}
-	log.Tracef("Work %s accepted by the network", hash.String())
+	log.Tracef("Work %s accepted by the network", hash)
 	resp := SubmitWorkResponse(*req.ID, true, nil)
 	c.sendMessage(resp)
 	return nil


### PR DESCRIPTION
There is no reason to explicitly call .String in format statements since they automatically invoke it because it implements fmt.Stringer.