### PR TITLE
hub: Clamp max gen time to target block time.

### DIFF
--- a/pool/hub.go
+++ b/pool/hub.go
@@ -228,6 +228,9 @@ func NewHub(hcfg *HubConfig) (*Hub, error) {
 	if h.cfg.SoloPool {
 		maxGenTime = soloMaxGenTime
 	}
+	if maxGenTime > h.cfg.ActiveNet.TargetTimePerBlock {
+		maxGenTime = h.cfg.ActiveNet.TargetTimePerBlock
+	}
 
 	log.Infof("Maximum work submission generation time at "+
 		"pool difficulty is %s.", maxGenTime)


### PR DESCRIPTION
This clamps the max generation time threshold to the target block time for the active network since it doesn't make any sense for it to be longer.  It is also needed for proper simnet support since the defaults are longer than the target block time there.