### PR TITLE
pool: Update for BLAKE3.

### DIFF
--- a/pool/client.go
+++ b/pool/client.go
@@ -526,7 +526,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 		c.sendMessage(resp)
 		return errs.PoolError(errs.LowDifficulty, err.Error())
 	}
-	hash := header.BlockHash()
+	hash := header.PowHashV2()
 	hashTarget := new(big.Rat).SetInt(standalone.HashToBig(&hash))
 	netDiff := new(big.Rat).Quo(powLimit, target)
 	hashDiff := new(big.Rat).Quo(powLimit, hashTarget)
@@ -562,7 +562,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 		c.cfg.SignalCache(ClaimedShare)
 	}
 
-	// Only submit work to the network if the submitted blockhash is
+	// Only submit work to the network if the submitted proof of work hash is
 	// less than the network target difficulty.
 	if hashTarget.Cmp(target) > 0 {
 		// Accept the submitted work but note it is not less than the
@@ -583,7 +583,7 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 		c.sendMessage(resp)
 		return err
 	}
-	submissionB := make([]byte, getworkDataLen)
+	submissionB := make([]byte, getworkDataLenBlake3)
 	copy(submissionB[:wire.MaxBlockHeaderPayload], headerB)
 	submission := hex.EncodeToString(submissionB)
 	accepted, err := c.cfg.SubmitWork(ctx, submission)

--- a/pool/client_test.go
+++ b/pool/client_test.go
@@ -424,17 +424,25 @@ func testClientMessageHandling(t *testing.T) {
 		t.Fatalf("expected a subscribed mining client")
 	}
 
-	const workE = "07000000022b580ca96146e9c85fa1ee2ec02e0e2579af4e3881fc619e" +
-		"c52d64d83e0000bd646e312ff574bc90e08ed91f1d99a85b318cb4464f2a24f9ad2b" +
-		"f3b9881c2bc9c344adde75e89b14b627acce606e6d652915bdb71dcf5351e8ad6128" +
-		"faab9e010000000000000000000000000000003e133920204e000000000000290000" +
-		"00a6030000954cee5d00000000000000000000000000000000000000000000000000" +
-		"0000000000000000000000000000008000000100000000000005a0"
+	const (
+		workE = "07000000022b580ca96146e9c85fa1ee2ec02e0e2579af4e3881fc619e" +
+			"c52d64d83e0000bd646e312ff574bc90e08ed91f1d99a85b318cb4464f2a24" +
+			"f9ad2bf3b9881c2bc9c344adde75e89b14b627acce606e6d652915bdb71dcf" +
+			"5351e8ad6128faab9e010000000000000000000000000000003e133920204e" +
+			"00000000000029000000a6030000954cee5d00000000000000000000000000" +
+			"00000000000000000000000000000000000000000000000013000000000000" +
+			"000000000000000000000000"
+		workENonce       = "04000000"
+		workEExtraNonce1 = "2e00fcd0"
+		workEExtraNonce2 = "c2ebbe69"
+	)
+
 	job := NewJob(workE, 41)
 	err = client.cfg.db.persistJob(job)
 	if err != nil {
 		t.Fatalf("failed to persist job %v", err)
 	}
+	client.extraNonce1 = workEExtraNonce1
 
 	blockVersion := workE[:8]
 	prevBlock := workE[8:72]
@@ -550,7 +558,8 @@ func testClientMessageHandling(t *testing.T) {
 		return false
 	}
 	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000", "954cee5d", "6ddf0200")
+	sub = SubmitWorkRequest(&id, "tcl", job.UUID, workEExtraNonce2, nTime,
+		workEExtraNonce2)
 	err = sE.Encode(sub)
 	if err != nil {
 		t.Fatalf("[Encode] unexpected error: %v", err)
@@ -581,22 +590,31 @@ func testClientMessageHandling(t *testing.T) {
 		return true
 	}
 
-	// Ensure a CPU client receives an error response when
-	// submitting work referencing a non-existent job.
-	const workE2 = "07000000e2bb3110848ec197118e8df2a3bc85dcaf5a787008a9c7072" +
-		"109dfb25e0a000047fe98e377430404709f8045ebf14b3a1903237c2adb49ed55724" +
-		"12eb2e0ca3c8ad3ffc23e946e1cce2dca67e2f711a78f41003358630b79231f0af33" +
-		"11bd73c010000000000000000000a000000000064ad2620204e0000000000002e000" +
-		"0003b0f000005ec705e0000000000000000000000000000000000000000000000000" +
-		"00000000000000000000000000000008000000100000000000005a0"
+	// Ensure a CPU client receives an error response when submitting work
+	// referencing a non-existent job.
+	const (
+		workE2 = "07000000e2bb3110848ec197118e8df2a3bc85dcaf5a787008a9c707210" +
+			"9dfb25e0a000047fe98e377430404709f8045ebf14b3a1903237c2adb49ed557" +
+			"2412eb2e0ca3c8ad3ffc23e946e1cce2dca67e2f711a78f41003358630b79231" +
+			"f0af3311bd73c010000000000000000000a000000000064ad2620204e0000000" +
+			"000002e0000003b0f000005ec705e00000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"00000"
+		workE2Nonce       = "13000000"
+		workE2ExtraNonce1 = "b072e5dc"
+		workE2ExtraNonce2 = "a9467db0"
+	)
 	job = NewJob(workE2, 46)
 	err = client.cfg.db.persistJob(job)
 	if err != nil {
 		t.Fatalf("failed to persist job %v", err)
 	}
-	client.extraNonce1 = "b072e5dc"
+	client.extraNonce1 = workE2ExtraNonce1
+	nTime = workE2[172:180]
+
 	id++
-	sub = SubmitWorkRequest(&id, "tcl", "notajob", "00000000", "05ec705e", "116f0200")
+	sub = SubmitWorkRequest(&id, "tcl", "notajob", workE2ExtraNonce2,
+		nTime, workE2Nonce)
 	err = sE.Encode(sub)
 	if err != nil {
 		t.Fatalf("[Encode] unexpected error: %v", err)
@@ -640,7 +658,8 @@ func testClientMessageHandling(t *testing.T) {
 		return false, fmt.Errorf("unable to submit work")
 	}
 	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000", "05ec705e", "116f0200")
+	sub = SubmitWorkRequest(&id, "tcl", job.UUID, workE2ExtraNonce2,
+		nTime, workE2Nonce)
 	err = sE.Encode(sub)
 	if err != nil {
 		t.Fatalf("[Encode] unexpected error: %v", err)
@@ -676,7 +695,8 @@ func testClientMessageHandling(t *testing.T) {
 	// Ensure a CPU client receives a non-error response when
 	// submitting valid work.
 	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000", "05ec705e", "116f0200")
+	sub = SubmitWorkRequest(&id, "tcl", job.UUID, workE2ExtraNonce2,
+		nTime, workE2Nonce)
 	err = sE.Encode(sub)
 	if err != nil {
 		t.Fatalf("[Encode] unexpected error: %v", err)
@@ -707,7 +727,8 @@ func testClientMessageHandling(t *testing.T) {
 	// Ensure a CPU client receives an error response when
 	// submitting duplicate work.
 	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000", "05ec705e", "116f0200")
+	sub = SubmitWorkRequest(&id, "tcl", job.UUID, workE2ExtraNonce2,
+		nTime, workE2Nonce)
 	err = sE.Encode(sub)
 	if err != nil {
 		t.Fatalf("[Encode] unexpected error: %v", err)
@@ -742,7 +763,8 @@ func testClientMessageHandling(t *testing.T) {
 	// submitting work intended for a different network.
 	client.cfg.ActiveNet = chaincfg.MainNetParams()
 	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000", "05ec705e", "116f0200")
+	sub = SubmitWorkRequest(&id, "tcl", job.UUID, workE2ExtraNonce2,
+		nTime, workE2Nonce)
 	err = sE.Encode(sub)
 	if err != nil {
 		t.Fatalf("[Encode] unexpected error: %v", err)
@@ -774,7 +796,8 @@ func testClientMessageHandling(t *testing.T) {
 	// Ensure a CPU client receives an error response when
 	// submitting work that is rejected by the network.
 	id++
-	sub = SubmitWorkRequest(&id, "tcl", job.UUID, "00000000", "05ec705e", "116f0200")
+	sub = SubmitWorkRequest(&id, "tcl", job.UUID, workE2ExtraNonce2,
+		nTime, workE2Nonce)
 	err = sE.Encode(sub)
 	if err != nil {
 		t.Fatalf("[Encode] unexpected error: %v", err)

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -43,19 +43,16 @@ const (
 	// blocks from the chain tip.
 	MaxReorgLimit = 6
 
-	// getworkDataLen is the length of the data field of the getwork RPC.
-	// It consists of the serialized block header plus the internal blake256
-	// padding.  The internal blake256 padding consists of a single 1 bit
-	// followed by zeros and a final 1 bit in order to pad the message out
-	// to 56 bytes followed by length of the message in bits encoded as a
-	// big-endian uint64 (8 bytes).  Thus, the resulting length is a
-	// multiple of the blake256 block size (64 bytes).  Given the padding
-	// requires at least a 1 bit and 64 bits for the padding, the following
-	// converts the block header length and hash block size to bits in order
-	// to ensure the correct number of hash blocks are calculated and then
-	// multiplies the result by the block hash block size in bytes.
-	getworkDataLen = (1 + ((wire.MaxBlockHeaderPayload*8 + 65) /
-		(chainhash.HashBlockSize * 8))) * chainhash.HashBlockSize
+	// blake3BlkSize is the internal block size of the blake3 hashing algorithm.
+	blake3BlkSize = 64
+
+	// getworkDataLenBlake3 is the length of the data field of the getwork RPC
+	// when providing work for blake3.  It consists of the serialized block
+	// header plus the internal blake3 padding.  The internal blake3 padding
+	// consists of enough zeros to pad the message out to a multiple of the
+	// blake3 block size (64 bytes).
+	getworkDataLenBlake3 = ((wire.MaxBlockHeaderPayload + (blake3BlkSize - 1)) /
+		blake3BlkSize) * blake3BlkSize
 
 	// NewParent is the reason given when a work notification is generated
 	// because there is a new chain tip.


### PR DESCRIPTION
This modifies the pool to work with BLAKE3 as now required by the Decred network.

In particular:

- All submissions are now checked against BLAKE3
- The padding semantics for the underlying `getwork` communications now match the padding of BLAKE3 as required
- The work submissions in the tests are now updated for BLAKE3 padding semantics, solved using BLAKE3, and updated with the solutions accordingly