### PR TITLE
multi: Rework client user agent id logic.

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2015-2023 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package semver parses semantic versioning 2.0.0 version strings.
+package semver
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// semanticAlphabet defines the allowed characters for the pre-release and
+	// build metadata portions of a semantic version string.
+	semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
+)
+
+// semverRE is a regular expression used to parse a semantic version string into
+// its constituent parts.
+var semverRE = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*` +
+	`[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+// parseUint32 converts the passed string to an unsigned integer or returns an
+// error if it is invalid.
+func parseUint32(s string, fieldName string) (uint32, error) {
+	val, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("malformed semver %s: %w", fieldName, err)
+	}
+	return uint32(val), err
+}
+
+// checkSemString returns an error if the passed string contains characters that
+// are not in the provided alphabet.
+func checkSemString(s, alphabet, fieldName string) error {
+	for _, r := range s {
+		if !strings.ContainsRune(alphabet, r) {
+			return fmt.Errorf("malformed semver %s: %q invalid", fieldName, r)
+		}
+	}
+	return nil
+}
+
+// ParsedSemVer houses the individual components of a parsed semantic versioning
+// 2.0.0 version string.
+type ParsedSemVer struct {
+	Major         uint32
+	Minor         uint32
+	Patch         uint32
+	PreRelease    string
+	BuildMetadata string
+}
+
+// Parse attempts to parse the various semver components from the provided
+// version string.
+func Parse(s string) (*ParsedSemVer, error) {
+	// Parse the various semver component from the version string via a regular
+	// expression.
+	m := semverRE.FindStringSubmatch(s)
+	if m == nil {
+		err := fmt.Errorf("malformed version string %q: does not conform to "+
+			"semver specification", s)
+		return nil, err
+	}
+
+	major, err := parseUint32(m[1], "major")
+	if err != nil {
+		return nil, err
+	}
+
+	minor, err := parseUint32(m[2], "minor")
+	if err != nil {
+		return nil, err
+	}
+
+	patch, err := parseUint32(m[3], "patch")
+	if err != nil {
+		return nil, err
+	}
+
+	preRel := m[4]
+	err = checkSemString(preRel, semanticAlphabet, "pre-release")
+	if err != nil {
+		return nil, err
+	}
+
+	build := m[5]
+	err = checkSemString(build, semanticAlphabet, "buildmetadata")
+	if err != nil {
+		return nil, err
+	}
+
+	return &ParsedSemVer{
+		Major:         major,
+		Minor:         minor,
+		Patch:         patch,
+		PreRelease:    preRel,
+		BuildMetadata: build,
+	}, nil
+}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,0 +1,359 @@
+// Copyright (c) 2023 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package semver
+
+import "testing"
+
+// TestParse ensures the semantic versioning 2.0.0 parsing logic works as
+// intended.
+func TestParse(t *testing.T) {
+	tests := []struct {
+		version           string // version string to parse
+		wantErr           bool   // whether or not an error is expected
+		wantMajor         uint32 // expected major version
+		wantMinor         uint32 // expected minor version
+		wantPatch         uint32 // expected patch version
+		wantPreRelease    string // expected pre-release string
+		wantBuildMetadata string // expected build metadata string
+	}{{
+		version:   "0.0.4",
+		wantMajor: 0,
+		wantMinor: 0,
+		wantPatch: 4,
+	}, {
+		version:   "1.2.3",
+		wantMajor: 1,
+		wantMinor: 2,
+		wantPatch: 3,
+	}, {
+		version:   "10.20.30",
+		wantMajor: 10,
+		wantMinor: 20,
+		wantPatch: 30,
+	}, {
+		version:           "1.1.2-prerelease+meta",
+		wantMajor:         1,
+		wantMinor:         1,
+		wantPatch:         2,
+		wantPreRelease:    "prerelease",
+		wantBuildMetadata: "meta",
+	}, {
+		version:           "1.1.2+meta",
+		wantMajor:         1,
+		wantMinor:         1,
+		wantPatch:         2,
+		wantBuildMetadata: "meta",
+	}, {
+		version:           "1.1.2+meta-valid",
+		wantMajor:         1,
+		wantMinor:         1,
+		wantPatch:         2,
+		wantBuildMetadata: "meta-valid",
+	}, {
+		version:        "1.0.0-alpha",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "alpha",
+	}, {
+		version:        "1.0.0-beta",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "beta",
+	}, {
+		version:        "1.0.0-alpha.beta",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "alpha.beta",
+	}, {
+		version:        "1.0.0-alpha.beta.1",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "alpha.beta.1",
+	}, {
+		version:        "1.0.0-alpha.1",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "alpha.1",
+	}, {
+		version:        "1.0.0-alpha0.valid",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "alpha0.valid",
+	}, {
+		version:        "1.0.0-alpha.0valid",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "alpha.0valid",
+	}, {
+		version:           "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",
+		wantMajor:         1,
+		wantMinor:         0,
+		wantPatch:         0,
+		wantPreRelease:    "alpha-a.b-c-somethinglong",
+		wantBuildMetadata: "build.1-aef.1-its-okay",
+	}, {
+		version:           "1.0.0-rc.1+build.1",
+		wantMajor:         1,
+		wantMinor:         0,
+		wantPatch:         0,
+		wantPreRelease:    "rc.1",
+		wantBuildMetadata: "build.1",
+	}, {
+		version:           "2.0.0-rc.1+build.123",
+		wantMajor:         2,
+		wantMinor:         0,
+		wantPatch:         0,
+		wantPreRelease:    "rc.1",
+		wantBuildMetadata: "build.123",
+	}, {
+		version:        "1.2.3-beta",
+		wantMajor:      1,
+		wantMinor:      2,
+		wantPatch:      3,
+		wantPreRelease: "beta",
+	}, {
+		version:        "10.2.3-DEV-SNAPSHOT",
+		wantMajor:      10,
+		wantMinor:      2,
+		wantPatch:      3,
+		wantPreRelease: "DEV-SNAPSHOT",
+	}, {
+		version:        "1.2.3-SNAPSHOT-123",
+		wantMajor:      1,
+		wantMinor:      2,
+		wantPatch:      3,
+		wantPreRelease: "SNAPSHOT-123",
+	}, {
+		version:   "1.0.0",
+		wantMajor: 1,
+		wantMinor: 0,
+		wantPatch: 0,
+	}, {
+		version:   "2.0.0",
+		wantMajor: 2,
+		wantMinor: 0,
+		wantPatch: 0,
+	}, {
+		version:   "1.1.7",
+		wantMajor: 1,
+		wantMinor: 1,
+		wantPatch: 7,
+	}, {
+		version:           "2.0.0+build.1848",
+		wantMajor:         2,
+		wantMinor:         0,
+		wantPatch:         0,
+		wantBuildMetadata: "build.1848",
+	}, {
+		version:        "2.0.1-alpha.1227",
+		wantMajor:      2,
+		wantMinor:      0,
+		wantPatch:      1,
+		wantPreRelease: "alpha.1227",
+	}, {
+		version:           "1.0.0-alpha+beta",
+		wantMajor:         1,
+		wantMinor:         0,
+		wantPatch:         0,
+		wantPreRelease:    "alpha",
+		wantBuildMetadata: "beta",
+	}, {
+		version:           "1.2.3----RC-SNAPSHOT.12.9.1--.12+788",
+		wantMajor:         1,
+		wantMinor:         2,
+		wantPatch:         3,
+		wantPreRelease:    "---RC-SNAPSHOT.12.9.1--.12",
+		wantBuildMetadata: "788",
+	}, {
+		version:           "1.2.3----R-S.12.9.1--.12+meta",
+		wantMajor:         1,
+		wantMinor:         2,
+		wantPatch:         3,
+		wantPreRelease:    "---R-S.12.9.1--.12",
+		wantBuildMetadata: "meta",
+	}, {
+		version:        "1.2.3----RC-SNAPSHOT.12.9.1--.12",
+		wantMajor:      1,
+		wantMinor:      2,
+		wantPatch:      3,
+		wantPreRelease: "---RC-SNAPSHOT.12.9.1--.12",
+	}, {
+		version:           "1.0.0+0.build.1-rc.10000aaa-kk-0.1",
+		wantMajor:         1,
+		wantMinor:         0,
+		wantPatch:         0,
+		wantBuildMetadata: "0.build.1-rc.10000aaa-kk-0.1",
+	}, {
+		version:        "1.0.0-0A.is.legal",
+		wantMajor:      1,
+		wantMinor:      0,
+		wantPatch:      0,
+		wantPreRelease: "0A.is.legal",
+	}, {
+		version: "1",
+		wantErr: true,
+	}, {
+		version: "1.2",
+		wantErr: true,
+	}, {
+		version: "1.2.3-0123",
+		wantErr: true,
+	}, {
+		version: "1.2.3-0123.0123",
+		wantErr: true,
+	}, {
+		version: "1.1.2+.123",
+		wantErr: true,
+	}, {
+		version: "+invalid",
+		wantErr: true,
+	}, {
+		version: "-invalid",
+		wantErr: true,
+	}, {
+		version: "-invalid+invalid",
+		wantErr: true,
+	}, {
+		version: "-invalid.01",
+		wantErr: true,
+	}, {
+		version: "alpha",
+		wantErr: true,
+	}, {
+		version: "alpha.beta",
+		wantErr: true,
+	}, {
+		version: "alpha.beta.1",
+		wantErr: true,
+	}, {
+		version: "alpha.1",
+		wantErr: true,
+	}, {
+		version: "alpha+beta",
+		wantErr: true,
+	}, {
+		version: "alpha_beta",
+		wantErr: true,
+	}, {
+		version: "alpha.",
+		wantErr: true,
+	}, {
+		version: "alpha..",
+		wantErr: true,
+	}, {
+		version: "beta",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha_beta",
+		wantErr: true,
+	}, {
+		version: "-alpha.",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha..",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha..1",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha...1",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha....1",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha.....1",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha......1",
+		wantErr: true,
+	}, {
+		version: "1.0.0-alpha.......1",
+		wantErr: true,
+	}, {
+		version: "01.1.1",
+		wantErr: true,
+	}, {
+		version: "1.01.1",
+		wantErr: true,
+	}, {
+		version: "1.1.01",
+		wantErr: true,
+	}, {
+		version: "1.2",
+		wantErr: true,
+	}, {
+		version: "1.2.3.DEV",
+		wantErr: true,
+	}, {
+		version: "1.2-SNAPSHOT",
+		wantErr: true,
+	}, {
+		version: "1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788",
+		wantErr: true,
+	}, {
+		version: "1.2-RC-SNAPSHOT",
+		wantErr: true,
+	}, {
+		version: "-1.0.3-gamma+b7718",
+		wantErr: true,
+	}, {
+		version: "+justmeta",
+		wantErr: true,
+	}, {
+		version: "9.8.7+meta+meta",
+		wantErr: true,
+	}, {
+		version: "9.8.7-whatever+meta+meta",
+		wantErr: true,
+	}}
+
+	for _, test := range tests {
+		// Parse the test version string and ensure the error result is as
+		// expected.
+		parsed, err := Parse(test.version)
+		if test.wantErr != (err != nil) {
+			t.Errorf("%q: unexpected error result -- got %v", test.version, err)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+
+		// Ensure all parsed values matches their expected values.
+		if parsed.Major != test.wantMajor {
+			t.Errorf("%q: unexpected major -- got %d, want %d", test.version,
+				parsed.Major, test.wantMajor)
+			continue
+		}
+		if parsed.Minor != test.wantMinor {
+			t.Errorf("%q: unexpected minor -- got %d, want %d", test.version,
+				parsed.Minor, test.wantMinor)
+			continue
+		}
+		if parsed.Patch != test.wantPatch {
+			t.Errorf("%q: unexpected patch -- got %d, want %d", test.version,
+				parsed.Patch, test.wantPatch)
+			continue
+		}
+		if parsed.PreRelease != test.wantPreRelease {
+			t.Errorf("%q: unexpected prerelease -- got %s, want %s",
+				test.version, parsed.PreRelease, test.wantPreRelease)
+			continue
+		}
+		if parsed.BuildMetadata != test.wantBuildMetadata {
+			t.Errorf("%q: unexpected build metadata -- got %s, want %s",
+				test.version, parsed.BuildMetadata, test.wantBuildMetadata)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
This reworks the client user agent identification logic to improve its efficiency and flexibility as well as to easily support old minor versions.

It does this by changing the matching logic to first parse the user agent into its individual components and then attempting to match against that parsed information using matching functions as opposed to encoding the more specific matching logic directly into a regular expression.

The user agent parsing first attempts to split it into a client name and version part and when that is successful further attempts to parse the version part into the individual semantic version components using a regular expression with capture groups.

The matching functions are closures that accept the parsed user agent details and may impose arbitrary criteria.

For convenience a default matching function is added that requires the user agent to have a provided client name and major version as well as a minor version that is less than or equal to specified value.

The user agent matching tests are updated accordingly.

Finally, `decred-gominer` is updated to support up to version 2.1.x so the pool will work with both version 2.0.0 as well as the master branch that will be moving to version 2.1.0-pre for ongoing development.