### PR TITLE
Use blockHash for AcceptedWorkID, not powHash.

### DIFF
--- a/cmd/miner/cpuminer.go
+++ b/cmd/miner/cpuminer.go
@@ -146,10 +146,10 @@ func (m *CPUMiner) solveBlock(ctx context.Context, headerB []byte, target *big.R
 					return false
 				}
 
-				// A valid submission is generated when the block hash is less
-				// than the pool target of the client.
-				hash := header.PowHashV2()
-				hashNum.SetInt(standalone.HashToBig(&hash))
+				// A valid submission is generated when the block proof of work
+				// hash is less than the pool target of the client.
+				powHash := header.PowHashV2()
+				hashNum.SetInt(standalone.HashToBig(&powHash))
 				hashesCompleted++
 
 				if hashNum.Cmp(target) < 0 {
@@ -173,7 +173,7 @@ func (m *CPUMiner) solveBlock(ctx context.Context, headerB []byte, target *big.R
 
 					m.updateHashes <- hashesCompleted
 					log.Infof("Found hash at height %d with work below target!"+
-						" (pow hash %v)", header.Height, hash)
+						" (pow hash %v)", header.Height, powHash)
 					return true
 				}
 

--- a/pool/client.go
+++ b/pool/client.go
@@ -612,9 +612,9 @@ func (c *Client) handleSubmitWorkRequest(ctx context.Context, req *Request, allo
 		return errs.PoolError(errs.WorkRejected, desc)
 	}
 
-	// Create accepted work if the work submission is accepted
-	// by the mining node.
-	work := NewAcceptedWork(powHash.String(), header.PrevBlock.String(),
+	// Create accepted work if the work submission is accepted by the mining
+	// node.
+	work := NewAcceptedWork(header.BlockHash().String(), header.PrevBlock.String(),
 		header.Height, c.FetchAccountID(), miner)
 	err = c.cfg.db.persistAcceptedWork(work)
 	if err != nil {


### PR DESCRIPTION
blockHash is used to construct the AcceptedWorkID when retrieving AcceptedWork from the database, not the powHash.

Because of this bug, dcrpool was failing to register when a block mined by the pool had been confirmed, thus it was never sending the coinbase from that block to the mining participants.