### PR TITLE
pool: Reinstate Fetch txBroadcaster/txCreator.

### DIFF
--- a/pool/hub.go
+++ b/pool/hub.go
@@ -245,8 +245,8 @@ func NewHub(hcfg *HubConfig) (*Hub, error) {
 		WalletAccount:         h.cfg.WalletAccount,
 		WalletPass:            h.cfg.WalletPass,
 		GetBlockConfirmations: h.getBlockConfirmations,
-		TxCreator:             h.nodeConn,
-		TxBroadcaster:         h.walletConn,
+		FetchTxCreator:        func() txCreator { return h.nodeConn },
+		FetchTxBroadcaster:    func() txBroadcaster { return h.walletConn },
 		CoinbaseConfTimeout:   h.cfg.CoinbaseConfTimeout,
 		SignalCache:           h.SignalCache,
 	}

--- a/pool/paymentmgr.go
+++ b/pool/paymentmgr.go
@@ -106,12 +106,12 @@ type PaymentMgrConfig struct {
 	// GetBlockConfirmations returns the number of block confirmations for the
 	// provided block hash.
 	GetBlockConfirmations func(context.Context, *chainhash.Hash) (int64, error)
-	// TxCreator is a transaction creator that allows coinbase lookups and
-	// payment transaction creation.
-	TxCreator txCreator
-	// TxBroadcaster is a transaction broadcaster that allows signing and
-	// publishing of transactions.
-	TxBroadcaster txBroadcaster
+	// FetchTxCreator returns a transaction creator that allows coinbase lookups
+	// and payment transaction creation.
+	FetchTxCreator func() txCreator
+	// FetchTxBroadcaster returns a transaction broadcaster that allows signing
+	// and publishing of transactions.
+	FetchTxBroadcaster func() txBroadcaster
 	// CoinbaseConfTimeout is the duration to wait for coinbase confirmations
 	// when generating a payout transaction.
 	CoinbaseConfTimeout time.Duration
@@ -718,7 +718,7 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32, coinbaseI
 		pm.mtx.Unlock()
 	}()
 
-	txB := pm.cfg.TxBroadcaster
+	txB := pm.cfg.FetchTxBroadcaster()
 	if txB == nil {
 		desc := fmt.Sprintf("%s: tx broadcaster cannot be nil", funcName)
 		return errs.PoolError(errs.Disconnected, desc)
@@ -775,7 +775,7 @@ func (pm *PaymentMgr) payDividends(ctx context.Context, height uint32, coinbaseI
 		}
 	}
 
-	txC := pm.cfg.TxCreator
+	txC := pm.cfg.FetchTxCreator()
 	if txC == nil {
 		desc := fmt.Sprintf("%s: tx creator cannot be nil", funcName)
 		return errs.PoolError(errs.Disconnected, desc)


### PR DESCRIPTION
Reverts part of #418 

These funcs were mistakenly removed because they seemed to be unnecessary, but actually they are required due to the extremely tight coupling between PaymentManager and Hub. Removing them is possible, but requires more involved work to untangle the construction of the two components.