### PR TITLE
pool: Remove handlePayments goroutine.

### DIFF
--- a/pool/chainstate.go
+++ b/pool/chainstate.go
@@ -262,7 +262,6 @@ func (cs *ChainState) blockConnected(ctx context.Context, msg []byte) error {
 		go cs.cfg.ProcessPayments(ctx, &paymentMsg{
 			CurrentHeight: header.Height,
 			CoinbaseIndex: coinbaseIndex,
-			Done:          make(chan struct{}),
 		})
 	}
 

--- a/pool/hub.go
+++ b/pool/hub.go
@@ -622,7 +622,7 @@ func (h *Hub) Run(ctx context.Context) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(2)
 	go func() {
 		h.endpoint.run(ctx)
 		wg.Done()
@@ -638,10 +638,6 @@ func (h *Hub) Run(ctx context.Context) {
 			}
 			cancel()
 		}
-		wg.Done()
-	}()
-	go func() {
-		h.paymentMgr.handlePayments(ctx)
 		wg.Done()
 	}()
 

--- a/pool/paymentmgr_test.go
+++ b/pool/paymentmgr_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"math/big"
 	mrand "math/rand"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1505,18 +1504,9 @@ func testPaymentMgrSignals(t *testing.T) {
 	msgA := paymentMsg{
 		CurrentHeight: estMaturity + 1,
 		CoinbaseIndex: 2,
-		Done:          make(chan struct{}),
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		mgr.handlePayments(ctx)
-		wg.Done()
-	}()
-
 	mgr.processPayments(ctx, &msgA)
-	<-msgA.Done
 
 	// Esure the payment lifecycle process cancels the context when an
 	// error is encountered.
@@ -1539,11 +1529,8 @@ func testPaymentMgrSignals(t *testing.T) {
 	msgB := paymentMsg{
 		CurrentHeight: estMaturity + 1,
 		CoinbaseIndex: 2,
-		Done:          make(chan struct{}),
 	}
 	mgr.processPayments(ctx, &msgB)
-	<-msgB.Done
 
 	cancel()
-	wg.Wait()
 }


### PR DESCRIPTION
Previously a long-lived goroutine named handlePayments would buffer calls to processPayments and run them sequentially. This adds unnecessary complexity without any obvious benefit.

In addition, it appears as though the only purpose of the done channel in the paymentMsg was to facilitate testing, which means this change makes it redundant and it can be removed.