### PR TITLE
gui: Display miner ip:port on account page.

### DIFF
--- a/internal/gui/assets/templates/account.html
+++ b/internal/gui/assets/templates/account.html
@@ -79,6 +79,7 @@
                     <thead>
                         <tr>
                             <th>Miner</th>
+                            <th>IP</th>
                             <th>Hash Rate</th>
                         </tr>
                     </thead>
@@ -86,6 +87,7 @@
                         {{ range .ConnectedClients }}
                         <tr>
                             <td>{{.Miner}}</td>
+                            <td>{{.IP}}</td>
                             <td>{{.HashRate}}</td>
                         </tr>
                         {{else}}


### PR DESCRIPTION
The miner ip:port are already present in the connected client info so they can be displayed on the account page with only a minor change.

Previously only the name of the miner software and the hashrate were displayed which made it impossible to distinguish which client was which. Having the ip:port of the client isn't much better, but it's definitely better than nothing.

![Screenshot from 2023-11-20 10-03-36](https://github.com/decred/dcrpool/assets/6762864/4040b5a5-7936-4140-b847-91044ee0ff23)
