### PR TITLE
build: Remove unnecessary toolchain from go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/decred/dcrpool
 
 go 1.21
 
-toolchain go1.22.3
-
 require (
 	decred.org/dcrwallet/v4 v4.1.0
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.2.1


### PR DESCRIPTION
Only Go 1.21 is actually required.  The addition of the toolchain line makes it require Go 1.22.3 which is not at all necessary and 
should not be there.